### PR TITLE
Stop on first type error

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -407,13 +407,11 @@ describe("Titan type checker", function()
         local prog, errors = run_checker([[
             record Point
                 x: float
-                y: float
             end
             local p: Point = { }
         ]])
         assert.falsy(prog)
         assert.matches("required field x is missing", errors)
-        assert.matches("required field y is missing", errors)
     end)
 
     it("forbids type hints that are not array or records", function()
@@ -579,7 +577,7 @@ describe("Titan type checker", function()
         local code = [[
             function fn(x: integer): integer
                 local i: integer = 15
-                while i do
+                while i > 0 do
                     local s: string = i
                 end
                 return x
@@ -1263,14 +1261,17 @@ describe("Titan type checker", function()
 
     it("catches assignment to function", function ()
         local code = [[
-            function foo(): integer
-                foo = 2
+            function f()
+            end
+
+            function g()
+                f = g
             end
         ]]
         local prog, errs = run_checker(code)
         assert.falsy(prog)
         assert.match(
-            "attempting to assign to toplevel constant function foo",
+            "attempting to assign to toplevel constant function f",
             errs, nil, true)
     end)
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1194,6 +1194,38 @@ describe("Titan type checker", function()
         end
     end
 
+    for _, op in ipairs({"+", "-", "*", "//", "/", "^"}) do
+        for _, t in ipairs({"{integer}", "boolean", "string"}) do
+            it("cannot use arithmetic operator " .. op .. " when left hand side is not a  number", function()
+                local code = [[
+                    function fn(a: ]] .. t .. [[, b: float): float
+                        return a ]] .. op .. [[ b
+                    end
+                ]]
+                local prog, errs = run_checker(code)
+                assert.falsy(prog)
+                assert.match("left hand side of arithmetic expression is a", errs)
+            end)
+        end
+    end
+
+    for _, op in ipairs({"+", "-", "*", "//", "/", "^"}) do
+        for _, t in ipairs({"{integer}", "boolean", "string"}) do
+            it("cannot use arithmetic operator " .. op .. " when right hand side is not integer", function()
+                local code = [[
+                    function fn(a: float, b: ]] .. t .. [[): float
+                        return a ]] .. op .. [[ b
+                    end
+                ]]
+                local prog, errs = run_checker(code)
+                assert.falsy(prog)
+                assert.match("right hand side of arithmetic expression is a", errs)
+            end)
+        end
+    end
+
+
+
     for _, t in ipairs({"boolean", "float", "integer", "nil", "string"}) do
         it("cannot explicitly cast from " .. t .. " to {integer}", function()
             local code = [[

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -148,7 +148,7 @@ end
 --
 
 typecheck = function(prog)
-    local ok, err = pcall(check_program, prog)
+    local ok, err = xpcall(check_program, debug.traceback, prog)
     if ok then
         return prog, {} -- TODO:  no {}
     else

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -683,12 +683,12 @@ check_exp = function(exp, errors, typehint)
                 exp.rhs = coerce_numeric_exp_to_float(exp.rhs)
                 exp._type = types.T.Float()
             else
-                if not is_numeric_type(exp.lhs._type._tag) then
+                if not is_numeric_type(exp.lhs._type) then
                     type_error(errors, exp.loc,
                         "left hand side of arithmetic expression is a %s instead of a number",
                         types.tostring(exp.lhs._type))
                 end
-                if not is_numeric_type(exp.rhs._type._tag) then
+                if not is_numeric_type(exp.rhs._type) then
                     type_error(errors, exp.loc,
                         "right hand side of arithmetic expression is a %s instead of a number",
                         types.tostring(exp.rhs._type))

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -180,7 +180,7 @@ check_type = function(typ, errors)
     elseif tag == ast.Type.Name then
         local decl = typ._decl
         if decl._tag == ast.Toplevel.Record then
-            return decl._type
+            return assert(decl._type)
         else
             type_error(errors, typ.loc, "'%s' isn't a type", typ.name)
             return types.T.Invalid()

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -494,7 +494,7 @@ end
 
 -- @param typehint Expected type; Used to infer polymorphic/record constructors.
 check_exp = function(exp, typehint)
-    assert(typehint  ~= nil)
+    assert(typehint ~= nil)
 
     local tag = exp._tag
     if     tag == ast.Exp.Nil then

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -6,6 +6,8 @@ local location = require "titan-compiler.location"
 local scope_analysis = require "titan-compiler.scope_analysis"
 local types = require "titan-compiler.types"
 
+local typecheck
+
 local check_program
 local check_type
 local check_toplevel
@@ -34,46 +36,51 @@ local check_exp
 function checker.check(filename, input)
     local prog, errors = scope_analysis.bind_names(filename, input)
     if not prog then return false, errors end
-    check_program(prog, errors)
-    return (#errors == 0 and prog), errors
+    return typecheck(prog)
 end
 
 --
 -- local functions
 --
 
-local function type_error(errors, loc, fmt, ...)
+local TypeError = {}
+TypeError.__index = TypeError
+
+function TypeError.new(msg)
+    return setmetatable({ msg = msg }, TypeError)
+end
+
+local function type_error(loc, fmt, ...)
     local errmsg = location.format_error(loc, "type error: "..fmt, ...)
-    table.insert(errors, errmsg)
+    error(TypeError.new(errmsg))
 end
 
 -- Checks if two types are the same, and logs an error message otherwise
 --   term: string describing what is being compared
 --   expected: type that is expected
 --   found: type that was actually present
---   errors: list of compile-time errors
 --   loc: location of the term that is being compared
-local function checkmatch(term, expected, found, errors, loc)
+local function checkmatch(term, expected, found, loc)
     if not types.equals(expected, found) then
         local fmt = "types in %s do not match, expected %s but found %s"
         local msg = string.format(fmt, term, types.tostring(expected), types.tostring(found))
-        type_error(errors, loc, msg)
+        type_error(loc, msg)
     end
 end
 
-local function check_arity(term, expected, found, errors, loc)
+local function check_arity(term, expected, found, loc)
     if expected ~= found then
         local fmt = "%s: expected %d value(s) but found %d"
         local msg = string.format(fmt, term, expected, found)
-        type_error(errors, loc, msg)
+        type_error(loc, msg)
     end
 end
 
-local function check_is_array(term, found, errors, loc)
+local function check_is_array(term, found, loc)
     if found._tag ~= types.T.Array then
         local fmt = "%s: expected array but found %s"
         local msg = string.format(fmt, term, types.tostring(found))
-        type_error(errors, loc, msg)
+        type_error(loc, msg)
     end
 end
 
@@ -140,7 +147,20 @@ end
 -- check
 --
 
-check_program = function(prog, errors)
+typecheck = function(prog)
+    local ok, err = pcall(check_program, prog)
+    if ok then
+        return prog, {} -- TODO:  no {}
+    else
+        if getmetatable(err) == TypeError then
+            return false, { err.msg } -- TODO  no {}
+        else
+            error(err)
+        end
+    end
+end
+
+check_program = function(prog)
     -- Ugh!
     -- Here we mutate fields in "constant" variables from another module, which
     -- definitely smells bad. There are many ways we vould fix this but I don't
@@ -156,11 +176,11 @@ check_program = function(prog, errors)
     end
 
     for _, tlnode in ipairs(prog) do
-        check_toplevel(tlnode, errors)
+        check_toplevel(tlnode)
     end
 end
 
-check_type = function(typ, errors)
+check_type = function(typ)
     local tag = typ._tag
     if     tag == ast.Type.Nil then
         return types.T.Nil()
@@ -182,14 +202,13 @@ check_type = function(typ, errors)
         if decl._tag == ast.Toplevel.Record then
             return assert(decl._type)
         else
-            type_error(errors, typ.loc, "'%s' isn't a type", typ.name)
-            return types.T.Invalid()
+            type_error(typ.loc, "'%s' isn't a type", typ.name)
         end
 
     elseif tag == ast.Type.Array then
-        local subtype = check_type(typ.subtype, errors)
+        local subtype = check_type(typ.subtype)
         if subtype._tag == types.T.Nil then
-            type_error(errors, typ.loc, "array of nil is not allowed")
+            type_error(typ.loc, "array of nil is not allowed")
         end
         return types.T.Array(subtype)
 
@@ -199,11 +218,11 @@ check_type = function(typ, errors)
         end
         local ptypes = {}
         for _, ptype in ipairs(typ.argtypes) do
-            table.insert(ptypes, check_type(ptype, errors))
+            table.insert(ptypes, check_type(ptype))
         end
         local rettypes = {}
         for _, rettype in ipairs(typ.rettypes) do
-            table.insert(rettypes, check_type(rettype, errors))
+            table.insert(rettypes, check_type(rettype))
         end
         return types.T.Function(ptypes, rettypes)
 
@@ -212,19 +231,19 @@ check_type = function(typ, errors)
     end
 end
 
-check_toplevel = function(tl_node, errors)
+check_toplevel = function(tl_node)
     local tag = tl_node._tag
     if     tag == ast.Toplevel.Import then
-        type_error(errors, tl_node.loc, "modules are not implemented yet")
+        type_error(tl_node.loc, "modules are not implemented yet")
 
     elseif tag == ast.Toplevel.Var then
         if tl_node.decl.type then
-            tl_node._type = check_type(tl_node.decl.type, errors)
-            check_exp(tl_node.value, errors, tl_node._type)
+            tl_node._type = check_type(tl_node.decl.type)
+            check_exp(tl_node.value, tl_node._type)
             checkmatch("declaration of module variable " .. tl_node.decl.name,
-                       tl_node._type, tl_node.value._type, errors, tl_node.loc)
+                       tl_node._type, tl_node.value._type, tl_node.loc)
         else
-            check_exp(tl_node.value, errors, false)
+            check_exp(tl_node.value, false)
             tl_node._type = tl_node.value._type
         end
 
@@ -235,29 +254,29 @@ check_toplevel = function(tl_node, errors)
 
         local ptypes = {}
         for _, param in ipairs(tl_node.params) do
-            param._type = check_type(param.type, errors)
+            param._type = check_type(param.type)
             table.insert(ptypes, param._type)
         end
 
         local rettypes = {}
         for _, rt in ipairs(tl_node.rettypes) do
-            table.insert(rettypes, check_type(rt, errors))
+            table.insert(rettypes, check_type(rt))
         end
         tl_node._type = types.T.Function(ptypes, rettypes)
 
-        check_stat(tl_node.block, errors, rettypes)
+        check_stat(tl_node.block, rettypes)
 
         if #tl_node._type.rettypes > 0 and
            not stat_always_returns(tl_node.block)
         then
-            type_error(errors, tl_node.loc,
+            type_error(tl_node.loc,
                 "control reaches end of function with non-empty return type")
         end
 
     elseif tag == ast.Toplevel.Record then
         tl_node._field_types = {}
         for _, field_decl in ipairs(tl_node.field_decls) do
-            local typ = check_type(field_decl.type, errors)
+            local typ = check_type(field_decl.type)
             tl_node._field_types[field_decl.name] = typ
         end
         tl_node._type = types.T.Record(tl_node)
@@ -267,55 +286,55 @@ check_toplevel = function(tl_node, errors)
     end
 end
 
-check_decl = function(decl, errors)
-    decl._type = decl._type or check_type(decl.type, errors)
+check_decl = function(decl)
+    decl._type = decl._type or check_type(decl.type)
 end
 
 -- @param rettypes Declared function return types (for return statements)
-check_stat = function(stat, errors, rettypes)
+check_stat = function(stat, rettypes)
     local tag = stat._tag
     if     tag == ast.Stat.Decl then
         if stat.decl.type then
-            check_decl(stat.decl, errors)
-            check_exp(stat.exp, errors, stat.decl._type)
+            check_decl(stat.decl)
+            check_exp(stat.exp, stat.decl._type)
         else
-            check_exp(stat.exp, errors, false)
+            check_exp(stat.exp, false)
             stat.decl._type = stat.exp._type
-            check_decl(stat.decl, errors)
+            check_decl(stat.decl)
         end
         checkmatch("declaration of local variable " .. stat.decl.name,
-            stat.decl._type, stat.exp._type, errors, stat.decl.loc)
+            stat.decl._type, stat.exp._type, stat.decl.loc)
 
     elseif tag == ast.Stat.Block then
         for _, inner_stat in ipairs(stat.stats) do
-            check_stat(inner_stat, errors, rettypes)
+            check_stat(inner_stat, rettypes)
         end
 
     elseif tag == ast.Stat.While then
-        check_exp(stat.condition, errors, false)
+        check_exp(stat.condition, false)
         checkmatch("while statement condition",
-            types.T.Boolean(), stat.condition._type, errors, stat.condition.loc)
-        check_stat(stat.block, errors, rettypes)
+            types.T.Boolean(), stat.condition._type, stat.condition.loc)
+        check_stat(stat.block, rettypes)
 
     elseif tag == ast.Stat.Repeat then
         for _, inner_stat in ipairs(stat.block.stats) do
-            check_stat(inner_stat, errors, rettypes)
+            check_stat(inner_stat, rettypes)
         end
-        check_exp(stat.condition, errors, false)
+        check_exp(stat.condition, false)
         checkmatch("repeat statement condition",
-            types.T.Boolean(), stat.condition._type, errors, stat.condition.loc)
+            types.T.Boolean(), stat.condition._type, stat.condition.loc)
 
     elseif tag == ast.Stat.For then
         if stat.decl.type then
-            check_decl(stat.decl, errors)
+            check_decl(stat.decl)
         else
             stat.decl._type =  false
         end
 
-        check_exp(stat.start, errors, stat.decl._type)
-        check_exp(stat.finish, errors, stat.decl._type)
+        check_exp(stat.start, stat.decl._type)
+        check_exp(stat.finish, stat.decl._type)
         if stat.inc then
-            check_exp(stat.inc, errors, stat.decl._type)
+            check_exp(stat.inc, stat.decl._type)
         end
         if not stat.decl.type then
             stat.decl._type = stat.start._type
@@ -336,61 +355,61 @@ check_stat = function(stat, errors, rettypes)
             end
         else
             loop_type_is_valid = false
-            type_error(errors, stat.decl.loc,
+            type_error(stat.decl.loc,
                 "type of for control variable %s must be integer or float",
                 stat.decl.name)
         end
 
         if loop_type_is_valid then
             checkmatch("'for' start expression",
-                stat.decl._type, stat.start._type, errors, stat.start.loc)
+                stat.decl._type, stat.start._type, stat.start.loc)
             checkmatch("'for' finish expression",
-                stat.decl._type, stat.finish._type, errors, stat.finish.loc)
+                stat.decl._type, stat.finish._type, stat.finish.loc)
             checkmatch("'for' step expression",
-                stat.decl._type, stat.inc._type, errors, stat.inc.loc)
+                stat.decl._type, stat.inc._type, stat.inc.loc)
         end
 
-        check_stat(stat.block, errors, rettypes)
+        check_stat(stat.block, rettypes)
 
     elseif tag == ast.Stat.Assign then
-        check_var(stat.var, errors)
-        check_exp(stat.exp, errors, stat.var._type)
-        checkmatch("assignment", stat.var._type, stat.exp._type, errors, stat.var.loc)
+        check_var(stat.var)
+        check_exp(stat.exp, stat.var._type)
+        checkmatch("assignment", stat.var._type, stat.exp._type, stat.var.loc)
         if stat.var._tag == ast.Var.Name and
             stat.var._decl._tag == ast.Toplevel.Func
         then
-            type_error(errors, stat.loc,
+            type_error(stat.loc,
                 "attempting to assign to toplevel constant function %s",
                 stat.var.name)
         end
 
     elseif tag == ast.Stat.Call then
-        check_exp(stat.callexp, errors, false)
+        check_exp(stat.callexp, false)
 
     elseif tag == ast.Stat.Return then
         assert(#rettypes <= 1)
         if #stat.exps ~= #rettypes then
-            type_error(errors, stat.loc,
+            type_error(stat.loc,
                 "returning %d value(s) but function expects %s",
                 #stat.exps, #rettypes)
         else
             for i = 1, #stat.exps do
                 local exp = stat.exps[i]
                 local rettype = rettypes[i]
-                check_exp(exp, errors, rettype)
-                checkmatch("return statement", rettype, exp._type, errors, exp.loc)
+                check_exp(exp, rettype)
+                checkmatch("return statement", rettype, exp._type, exp.loc)
             end
         end
 
     elseif tag == ast.Stat.If then
         for _, thn in ipairs(stat.thens) do
-            check_exp(thn.condition, errors, false)
+            check_exp(thn.condition, false)
             checkmatch("if statement condition",
-                types.T.Boolean(), thn.condition._type, errors, thn.loc)
-            check_stat(thn.block, errors, rettypes)
+                types.T.Boolean(), thn.condition._type, thn.loc)
+            check_stat(thn.block, rettypes)
         end
         if stat.elsestat then
-            check_stat(stat.elsestat, errors, rettypes)
+            check_stat(stat.elsestat, rettypes)
         end
 
     else
@@ -398,7 +417,7 @@ check_stat = function(stat, errors, rettypes)
     end
 end
 
-check_var = function(var, errors)
+check_var = function(var)
     local tag = var._tag
     if     tag == ast.Var.Name then
         local decl = var._decl
@@ -409,75 +428,71 @@ check_var = function(var, errors)
         then
             var._type = var._decl._type
         else
-            type_error(errors, var.loc, "'%s' isn't a value", var.name)
-            var._type = types.T.Invalid()
+            type_error(var.loc, "'%s' isn't a value", var.name)
         end
 
     elseif tag == ast.Var.Dot then
-        check_exp(var.exp, errors, false)
+        check_exp(var.exp, false)
         local exptype = var.exp._type
         if exptype._tag == types.T.Record then
             local field_type = exptype.type_decl._field_types[var.name]
             if field_type then
                 var._type = field_type
             else
-                type_error(errors, var.loc,
+                type_error(var.loc,
                     "field '%s' not found in record '%s'",
                     var.name, exptype.type_decl.name)
-                var._type = types.T.Invalid()
             end
         else
-            type_error(errors, var.loc,
+            type_error(var.loc,
                 "trying to access a member of value of type '%s'",
                 types.tostring(exptype))
-            var._type = types.T.Invalid()
         end
 
     elseif tag == ast.Var.Bracket then
-        check_exp(var.exp1, errors, false)
+        check_exp(var.exp1, false)
         if var.exp1._type._tag ~= types.T.Array then
-            type_error(errors, var.exp1.loc,
+            type_error(var.exp1.loc,
                 "array expression in indexing is not an array but %s",
                 types.tostring(var.exp1._type))
-            var._type = types.T.Invalid()
         else
             var._type = var.exp1._type.elem
         end
-        check_exp(var.exp2, errors, false)
-        checkmatch("array indexing", types.T.Integer(), var.exp2._type, errors, var.exp2.loc)
+        check_exp(var.exp2, false)
+        checkmatch("array indexing", types.T.Integer(), var.exp2._type, var.exp2.loc)
 
     else
         error("impossible")
     end
 end
 
-local function check_exp_callfunc_builtin(exp, errors, _typehint)
+local function check_exp_callfunc_builtin(exp, _typehint)
     assert(_typehint ~= nil)
 
     local fexp = exp.exp
     local args = exp.args
     local builtin_name = fexp._type.builtin_decl.name
     if builtin_name == "io.write" then
-        check_arity("io.write arguments", 1, #args, errors, exp.loc)
-        check_exp(args[1], errors, false)
+        check_arity("io.write arguments", 1, #args, exp.loc)
+        check_exp(args[1], false)
         checkmatch("io.write argument",
-            types.T.String(), args[1]._type, errors, args[1].loc)
+            types.T.String(), args[1]._type, args[1].loc)
         exp._type = types.T.Void()
     elseif builtin_name == "table.insert" then
-        check_arity("table.insert arguments", 2, #args, errors, exp.loc)
-        check_exp(args[1], errors, false)
+        check_arity("table.insert arguments", 2, #args, exp.loc)
+        check_exp(args[1], false)
         check_is_array("table.insert first argument",
-            args[1]._type, errors, args[1].loc)
+            args[1]._type, args[1].loc)
         local elem_type = args[1]._type.elem
-        check_exp(args[2], errors, elem_type)
+        check_exp(args[2], elem_type)
         checkmatch("table.insert second argument",
-            elem_type, args[2]._type, errors, args[2].loc)
+            elem_type, args[2]._type, args[2].loc)
         exp._type = types.T.Void()
     elseif builtin_name == "table.remove" then
-        check_arity("table.insert arguments", 1, #args, errors, exp.loc)
-        check_exp(args[1], errors, false)
+        check_arity("table.insert arguments", 1, #args, exp.loc)
+        check_exp(args[1], false)
         check_is_array("table.insert first argument",
-            args[1]._type, errors, args[1].loc)
+            args[1]._type, args[1].loc)
         exp._type = types.T.Void()
     else
         error("impossible")
@@ -485,7 +500,7 @@ local function check_exp_callfunc_builtin(exp, errors, _typehint)
 end
 
 -- @param typehint Expected type; Used to infer polymorphic/record constructors.
-check_exp = function(exp, errors, typehint)
+check_exp = function(exp, typehint)
     assert(typehint  ~= nil)
 
     local tag = exp._tag
@@ -509,90 +524,90 @@ check_exp = function(exp, errors, typehint)
         -- In theory, we could try to infer the type without a type hint for
         -- non-empty arrays whose contents are inferrable, but I am not sure
         -- we should treat that case differently from the others...
-        if typehint then
-            if typehint._tag == types.T.Array then
-                for _, field in ipairs(exp.fields) do
-                    if field.name then
-                        type_error(errors, field.loc,
-                            "named field %s in array initializer",
-                            field.name)
-                    else
-                        local field_type = typehint.elem
-                        check_exp(field.exp, errors, field_type)
-                        checkmatch("array initializer",
-                            field_type, field.exp._type, errors, field.loc)
-                    end
-                end
-
-            elseif typehint._tag == types.T.Record then
-                local initialized_fields = {}
-                for _, field in ipairs(exp.fields) do
-                    if field.name then
-                        if initialized_fields[field.name] then
-                            type_error(errors, field.loc,
-                                "duplicate field %s in record initializer",
-                                field.name)
-                        end
-                        initialized_fields[field.name] = true
-
-                        local field_type = typehint.type_decl._field_types[field.name]
-                        if field_type then
-                            check_exp(field.exp, errors, field_type)
-                            checkmatch("record initializer",
-                                field_type, field.exp._type, errors, field.loc)
-                        else
-                            type_error(errors, field.loc,
-                                "invalid field %s in record initializer for %s",
-                                field.name, typehint.type_decl.name)
-                        end
-                    else
-                        type_error(errors, field.loc,
-                            "record initializer has array part")
-                    end
-                end
-
-                for field_name, _ in pairs(typehint.type_decl._field_types) do
-                    if not initialized_fields[field_name] then
-                        type_error(errors, exp.loc,
-                            "required field %s is missing from initializer",
-                            field_name)
-                    end
-                end
-            else
-                type_error(errors, exp.loc,
-                    "type hint for array or record initializer is not an array or record type")
-            end
-        else
-            type_error(errors, exp.loc,
+        --
+        if not typehint then
+            type_error(exp.loc,
                 "missing type hint for array or record initializer")
         end
 
-        exp._type = typehint or types.T.Invalid()
+        if typehint._tag == types.T.Array then
+            for _, field in ipairs(exp.fields) do
+                if field.name then
+                    type_error(field.loc,
+                        "named field %s in array initializer",
+                        field.name)
+                else
+                    local field_type = typehint.elem
+                    check_exp(field.exp, field_type)
+                    checkmatch("array initializer",
+                        field_type, field.exp._type, field.loc)
+                end
+            end
+
+        elseif typehint._tag == types.T.Record then
+            local initialized_fields = {}
+            for _, field in ipairs(exp.fields) do
+                if field.name then
+                    if initialized_fields[field.name] then
+                        type_error(field.loc,
+                            "duplicate field %s in record initializer",
+                            field.name)
+                    end
+                    initialized_fields[field.name] = true
+
+                    local field_type = typehint.type_decl._field_types[field.name]
+                    if field_type then
+                        check_exp(field.exp, field_type)
+                        checkmatch("record initializer",
+                            field_type, field.exp._type, field.loc)
+                    else
+                        type_error(field.loc,
+                            "invalid field %s in record initializer for %s",
+                            field.name, typehint.type_decl.name)
+                    end
+                else
+                    type_error(field.loc,
+                        "record initializer has array part")
+                end
+            end
+
+            for field_name, _ in pairs(typehint.type_decl._field_types) do
+                if not initialized_fields[field_name] then
+                    type_error(exp.loc,
+                        "required field %s is missing from initializer",
+                        field_name)
+                end
+            end
+        else
+            type_error(exp.loc,
+                "type hint for array or record initializer is not an array or record type")
+        end
+        exp._type = typehint
 
     elseif tag == ast.Exp.Var then
-        check_var(exp.var, errors)
+        check_var(exp.var)
         exp._type = exp.var._type
 
     elseif tag == ast.Exp.Unop then
-        check_exp(exp.exp, errors, false)
+        check_exp(exp.exp, false)
         local op = exp.op
         if op == "#" then
             if exp.exp._type._tag ~= types.T.Array and exp.exp._type._tag ~= types.T.String then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "trying to take the length of a %s instead of an array or string",
                     types.tostring(exp.exp._type))
             end
             exp._type = types.T.Integer()
         elseif op == "-" then
             if exp.exp._type._tag ~= types.T.Integer and exp.exp._type._tag ~= types.T.Float then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "trying to negate a %s instead of a number",
                     types.tostring(exp.exp._type))
             end
             exp._type = exp.exp._type
         elseif op == "~" then
             if exp.exp._type._tag ~= types.T.Integer then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "trying to bitwise negate a %s instead of an integer",
                     types.tostring(exp.exp._type))
             end
@@ -600,7 +615,7 @@ check_exp = function(exp, errors, typehint)
         elseif op == "not" then
             if exp.exp._type._tag ~= types.T.Boolean then
                 -- Titan is being intentionaly restrictive here
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "trying to boolean negate a %s instead of a boolean",
                     types.tostring(exp.exp._type))
             end
@@ -611,27 +626,27 @@ check_exp = function(exp, errors, typehint)
 
     elseif tag == ast.Exp.Concat then
         for _, inner_exp in ipairs(exp.exps) do
-            check_exp(inner_exp, errors, false)
+            check_exp(inner_exp, false)
             local texp = inner_exp._type
             if texp._tag ~= types.T.String then
-                type_error(errors, inner_exp.loc,
+                type_error(inner_exp.loc,
                     "cannot concatenate with %s value", types.tostring(texp))
             end
         end
         exp._type = types.T.String()
 
     elseif tag == ast.Exp.Binop then
-        check_exp(exp.lhs, errors, false)
-        check_exp(exp.rhs, errors, false)
+        check_exp(exp.lhs, false)
+        check_exp(exp.rhs, false)
         local op = exp.op
         if op == "==" or op == "~=" then
             if (exp.lhs._type._tag == types.T.Integer and exp.rhs._type._tag == types.T.Float) or
                (exp.lhs._type._tag == types.T.Float   and exp.rhs._type._tag == types.T.Integer) then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "comparisons between float and integers are not yet implemented")
                 -- note: use Lua's implementation of comparison, don't just cast to float
             elseif not types.equals(exp.lhs._type, exp.rhs._type) then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "cannot compare %s and %s with %s",
                     types.tostring(exp.lhs._type), types.tostring(exp.rhs._type), op)
             end
@@ -643,79 +658,73 @@ check_exp = function(exp, errors, typehint)
                -- OK
             elseif (exp.lhs._type._tag == types.T.Integer and exp.rhs._type._tag == types.T.Float) or
                    (exp.lhs._type._tag == types.T.Float   and exp.rhs._type._tag == types.T.Integer) then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "comparisons between float and integers are not yet implemented")
                 -- note: use Lua's implementation of comparison, don't just cast to float
             else
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "cannot compare %s and %s with %s",
                     types.tostring(exp.lhs._type), types.tostring(exp.rhs._type), op)
             end
             exp._type = types.T.Boolean()
 
         elseif op == "+" or op == "-" or op == "*" or op == "%" or op == "//" then
-            if is_numeric_type(exp.lhs._type) and is_numeric_type(exp.rhs._type) then
-                if exp.lhs._type._tag == types.T.Integer and
-                   exp.rhs._type._tag == types.T.Integer then
-                    exp._type = types.T.Integer()
-                else
-                    exp.lhs = coerce_numeric_exp_to_float(exp.lhs)
-                    exp.rhs = coerce_numeric_exp_to_float(exp.rhs)
-                    exp._type = types.T.Float()
-                end
-            else
-                if not is_numeric_type(exp.lhs._type) then
-                    type_error(errors, exp.loc,
-                        "left hand side of arithmetic expression is a %s instead of a number",
-                        types.tostring(exp.lhs._type))
-                end
-                if not is_numeric_type(exp.rhs._type) then
-                    type_error(errors, exp.loc,
-                        "right hand side of arithmetic expression is a %s instead of a number",
-                        types.tostring(exp.rhs._type))
-                end
-                exp._type = types.T.Invalid()
+            if not is_numeric_type(exp.lhs._type) then
+                type_error(exp.loc,
+                    "left hand side of arithmetic expression is a %s instead of a number",
+                    types.tostring(exp.lhs._type))
+            end
+            if not is_numeric_type(exp.rhs._type) then
+                type_error(exp.loc,
+                    "right hand side of arithmetic expression is a %s instead of a number",
+                    types.tostring(exp.rhs._type))
             end
 
-        elseif op == "/" or op == "^" then
-            if is_numeric_type(exp.lhs._type) and is_numeric_type(exp.rhs._type) then
+            if exp.lhs._type._tag == types.T.Integer and
+               exp.rhs._type._tag == types.T.Integer then
+                exp._type = types.T.Integer()
+            else
                 exp.lhs = coerce_numeric_exp_to_float(exp.lhs)
                 exp.rhs = coerce_numeric_exp_to_float(exp.rhs)
                 exp._type = types.T.Float()
-            else
-                if not is_numeric_type(exp.lhs._type) then
-                    type_error(errors, exp.loc,
-                        "left hand side of arithmetic expression is a %s instead of a number",
-                        types.tostring(exp.lhs._type))
-                end
-                if not is_numeric_type(exp.rhs._type) then
-                    type_error(errors, exp.loc,
-                        "right hand side of arithmetic expression is a %s instead of a number",
-                        types.tostring(exp.rhs._type))
-                end
-                exp._type = types.T.Float()
             end
+
+        elseif op == "/" or op == "^" then
+            if not is_numeric_type(exp.lhs._type) then
+                type_error(exp.loc,
+                    "left hand side of arithmetic expression is a %s instead of a number",
+                    types.tostring(exp.lhs._type))
+            end
+            if not is_numeric_type(exp.rhs._type) then
+                type_error(exp.loc,
+                    "right hand side of arithmetic expression is a %s instead of a number",
+                    types.tostring(exp.rhs._type))
+            end
+
+            exp.lhs = coerce_numeric_exp_to_float(exp.lhs)
+            exp.rhs = coerce_numeric_exp_to_float(exp.rhs)
+            exp._type = types.T.Float()
 
         elseif op == "and" or op == "or" then
             if exp.lhs._type._tag ~= types.T.Boolean then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "left hand side of logical expression is a %s instead of a boolean",
                     types.tostring(exp.lhs._type))
             end
             if exp.rhs._type._tag ~= types.T.Boolean then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "right hand side of logical expression is a %s instead of a boolean",
                     types.tostring(exp.rhs._type))
             end
             exp._type = types.T.Boolean()
         elseif op == "|" or op == "&" or op == "~" or op == "<<" or op == ">>" then
             if exp.lhs._type._tag ~= types.T.Integer then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "left hand side of arithmetic expression is a %s instead of an integer",
                     types.tostring(exp.lhs._type))
             end
             if exp.rhs._type._tag ~= types.T.Integer then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "right hand side of arithmetic expression is a %s instead of an integer",
                     types.tostring(exp.rhs._type))
             end
@@ -728,22 +737,22 @@ check_exp = function(exp, errors, typehint)
         local fexp = exp.exp
         local args = exp.args
 
-        check_exp(fexp, errors, false)
+        check_exp(fexp, false)
         local ftype = fexp._type
 
         if ftype._tag == types.T.Function then
             if #ftype.params ~= #args then
-                type_error(errors, exp.loc,
+                type_error(exp.loc,
                     "function expects %d argument(s) but received %d",
                     #ftype.params, #args)
             end
             for i = 1, math.min(#ftype.params, #args) do
                 local ptype = ftype.params[i]
                 local arg = args[i]
-                check_exp(arg, errors, ptype)
+                check_exp(arg, ptype)
                 checkmatch(
                     "argument " .. i .. " of call to function",
-                    ptype, arg._type, errors, fexp.loc)
+                    ptype, arg._type, fexp.loc)
             end
             assert(#ftype.rettypes <= 1)
             if #ftype.rettypes >= 1 then
@@ -752,22 +761,21 @@ check_exp = function(exp, errors, typehint)
                 exp._type = types.T.Void()
             end
         elseif ftype._tag == types.T.Builtin then
-            check_exp_callfunc_builtin(exp, errors, false)
+            check_exp_callfunc_builtin(exp, false)
         else
-            type_error(errors, exp.loc,
+            type_error(exp.loc,
                 "attempting to call a %s value",
                 types.tostring(exp.exp._type))
-            exp._type = types.T.Invalid()
         end
 
     elseif tag == ast.Exp.CallMethod then
         error("not implemented")
 
     elseif tag == ast.Exp.Cast then
-        local target = check_type(exp.target, errors)
-        check_exp(exp.exp, errors, target)
+        local target = check_type(exp.target)
+        check_exp(exp.exp, target)
         if not types.coerceable(exp.exp._type, target) then
-            type_error(errors, exp.loc,
+            type_error(exp.loc,
                 "cannot cast '%s' to '%s'",
                 types.tostring(exp.exp._type), types.tostring(target))
         end

--- a/titan-compiler/types.lua
+++ b/titan-compiler/types.lua
@@ -7,8 +7,7 @@ local function declare_type(typename, cons)
 end
 
 declare_type("T", {
-    Invalid  = {},
-    Void     = {}, -- Special kind of "invalid", for functions with 0 returns
+    Void     = {}, -- For functions with 0 returns
     Nil      = {},
     Boolean  = {},
     Integer  = {},
@@ -87,7 +86,6 @@ function types.tostring(t)
     elseif tag == types.T.String      then return "string"
     elseif tag == types.T.Nil         then return "nil"
     elseif tag == types.T.Float       then return "float"
-    elseif tag == types.T.Invalid     then return "invalid type"
     elseif tag == types.T.Void        then return "void"
     elseif tag == types.T.Function then
         return "function" -- TODO implement


### PR DESCRIPTION
Simplify the type checker by stopping after the first type error.