### PR TITLE
Remove some quotes in checker error messages

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -628,7 +628,7 @@ describe("Titan type checker", function()
         ]]
         local prog, errs = run_checker(code)
         assert.falsy(prog)
-        assert.match("'for' start expression", errs)
+        assert.match("numeric for loop initializer", errs)
     end)
 
 
@@ -643,7 +643,7 @@ describe("Titan type checker", function()
         ]]
         local prog, errs = run_checker(code)
         assert.falsy(prog)
-        assert.match("'for' finish expression", errs)
+        assert.match("numeric for loop limit", errs)
     end)
 
     it("catches 'for' errors in the step expression", function()
@@ -657,7 +657,7 @@ describe("Titan type checker", function()
         ]]
         local prog, errs = run_checker(code)
         assert.falsy(prog)
-        assert.match("'for' step expression", errs)
+        assert.match("numeric for loop step", errs)
     end)
 
     it("detects wrong number of return values", function()

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -370,15 +370,15 @@ check_stat = function(stat, rettypes)
 
         checkmatch(stat.start.loc,
             stat.decl._type, stat.start._type,
-            "'for' start expression")
+            "numeric for loop initializer")
 
         checkmatch(stat.finish.loc,
             stat.decl._type, stat.finish._type,
-            "'for' finish expression")
+            "numeric for loop limit")
 
         checkmatch(stat.inc.loc,
             stat.decl._type, stat.inc._type,
-            "'for' step expression")
+            "numeric for loop step")
 
         check_stat(stat.block, rettypes)
 


### PR DESCRIPTION
I think rewriting the `'for'` bits was better than putting single quotes around everything