### PR TITLE
Desugar if-elseif into if-then-else

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -348,36 +348,32 @@ describe("Titan parser", function()
     describe("can parse if statements", function()
         assert_statements_ast("if 10 then end", {
             { _tag = ast.Stat.If,
-                thens = {
-                    { _tag = ast.Then.Then, condition = { value = 10 } },
-                },
-              elsestat = false }
+                condition = { value = 10 },
+                then_ = { _tag = ast.Stat.Block },
+                else_ = { _tag = ast.Stat.Block }, }
         })
 
         assert_statements_ast("if 20 then else end", {
             { _tag = ast.Stat.If,
-                thens = {
-                    { _tag = ast.Then.Then, condition = { value = 20 } },
-                },
-                elsestat = { _tag = ast.Stat.Block } }
+                condition = { value = 20 },
+                then_ = { _tag = ast.Stat.Block },
+                else_ = { _tag = ast.Stat.Block }, }
         })
 
         assert_statements_ast("if 30 then elseif 40 then end", {
             { _tag = ast.Stat.If,
-                thens = {
-                    { _tag = ast.Then.Then, condition = { value = 30 } },
-                    { _tag = ast.Then.Then, condition = { value = 40 } },
-                },
-                elsestat = false }
+                condition = { value = 30 },
+                then_ = { _tag = ast.Stat.Block },
+                else_ = { _tag = ast.Stat.If,
+                    condition = { value = 40 }, }, }
         })
 
         assert_statements_ast("if 50 then elseif 60 then else end", {
             { _tag = ast.Stat.If,
-              thens = {
-                    { _tag = ast.Then.Then, condition = { value = 50 } },
-                    { _tag = ast.Then.Then, condition = { value = 60 } },
-                },
-                elsestat = { _tag = ast.Stat.Block } }
+                condition = { value = 50 },
+                then_ = { _tag = ast.Stat.Block },
+                else_ = { _tag = ast.Stat.If,
+                    condition = { value = 60 }, }, }
         })
     end)
 

--- a/spec/scope_analysis_spec.lua
+++ b/spec/scope_analysis_spec.lua
@@ -61,7 +61,7 @@ describe("Scope analysis: ", function()
         assert.truthy(prog)
         assert.are.equal(
             prog[1], -- fac
-            prog[1].block.stats[1].elsestat.stats[1].exps[1].rhs.exp.var._decl)
+            prog[1].block.stats[1].else_.stats[1].exps[1].rhs.exp.var._decl)
     end)
 
     it("builtins work", function()
@@ -233,7 +233,7 @@ describe("Scope analysis: ", function()
         assert.truthy(prog)
         assert.are.equal(
             prog[1], -- fat
-            prog[1].block.stats[1].elsestat.stats[1].exps[1].rhs.exp.var._decl)
+            prog[1].block.stats[1].else_.stats[1].exps[1].rhs.exp.var._decl)
     end)
 
     it("forbids mutually recursive definitions", function()

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -34,16 +34,12 @@ declare_type("Stat", {
     Block  = {"loc", "stats"},
     While  = {"loc", "condition", "block"},
     Repeat = {"loc", "block", "condition"},
-    If     = {"loc", "thens", "elsestat"},
+    If     = {"loc", "condition", "then_", "else_"},
     For    = {"loc", "decl", "start", "finish", "inc", "block"},
     Assign = {"loc", "var", "exp"},
     Decl   = {"loc", "decl", "exp"},
     Call   = {"loc", "callexp"},
     Return = {"loc", "exps"},
-})
-
-declare_type("Then", {
-    Then = {"loc", "condition", "block"},
 })
 
 declare_type("Var", {

--- a/titan-compiler/ast_iterator.lua
+++ b/titan-compiler/ast_iterator.lua
@@ -105,12 +105,9 @@ function ast_iterator:Stat(stat, ...)
         stat.condition = self:Exp(stat.condition, ...) or stat.condition
 
     elseif tag == ast.Stat.If then
-        for i = 1, #stat.thens do
-            stat.thens[i] = self:Then(stat.thens[i], ...) or stat.thens[i]
-        end
-        if stat.elsestat then
-            stat.elsestat = self:Stat(stat.elsestat, ...) or stat.elsestat
-        end
+        stat.condition = self:Exp(stat.condition, ...) or stat.condition
+        stat.then_ = self:Stat(stat.then_, ...) or stat.then_
+        stat.else_ = self:Stat(stat.else_, ...) or stat.else_
 
     elseif tag == ast.Stat.For then
         stat.decl = self:Decl(stat.decl, ...) or stat.decl
@@ -137,16 +134,6 @@ function ast_iterator:Stat(stat, ...)
             stat.exps[i] = self:Exp(stat.exps[i], ...) or stat.exps[i]
         end
 
-    else
-        error("impossible")
-    end
-end
-
-function ast_iterator:Then(then_, ...)
-    local tag = then_._tag
-    if tag == ast.Then.Then then
-        then_.condition = self:Exp(then_.condition, ...) or then_.condition
-        then_.block = self:Stat(then_.block, ...) or then_.block
     else
         error("impossible")
     end

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -1346,34 +1346,21 @@ generate_stat = function(stat, ctx)
 
     elseif tag == ast.Stat.If then
         ctx:begin_scope()
-
-        local cstats
-        if stat.elsestat then
-            cstats = generate_stat(stat.elsestat, ctx)
-        else
-            cstats = nil
-        end
-
-        for i = #stat.thens, 1, -1 do
-            local then_ = stat.thens[i]
-            local cond_cstats, cond_cvalue = generate_exp(then_.condition, ctx)
-            local block_cstats = generate_stat(then_.block, ctx)
-            local else_ = (cstats and "else " .. cstats or "")
-
-            cstats = util.render(
-                [[{
-                    ${STATS}
-                    if (${COND}) ${BLOCK} ${ELSE}
-                }]], {
-                STATS = cond_cstats,
-                COND = cond_cvalue,
-                BLOCK = block_cstats,
-                ELSE = else_
-            })
-        end
-
+        local cond_cstats, cond_cvalue = generate_exp(stat.condition, ctx)
+        local then_cstats = generate_stat(stat.then_, ctx)
+        local else_cstats = generate_stat(stat.else_, ctx)
         ctx:end_scope()
 
+        local cstats = util.render(
+            [[{
+                ${COND_STATS}
+                if (${COND}) ${THEN} else ${ELSE}
+            }]], {
+            COND_STATS = cond_cstats,
+            COND = cond_cvalue,
+            THEN = then_cstats,
+            ELSE = else_cstats,
+        })
         return cstats
 
     elseif tag == ast.Stat.For then

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -85,11 +85,7 @@ function defs.name_exp(pos, name)
 end
 
 function defs.ifstat(pos, exp, block, elseifs, elseopt)
-    local else_ = elseopt
-
-    if not else_ then
-        else_ = ast.Stat.Block(pos, {})
-    end
+    local else_ = elseopt or ast.Stat.Block(pos, {})
 
     for i = #elseifs, 1, -1 do
         local e = elseifs[i]


### PR DESCRIPTION
This commit gets rid of the awkward representation we have of if statments right
now, with the "Thens" array and optional else statement.

I believe the current representation started out as a side effect of the parser
algorithm and then we kept it made the generated code prettier:

```
/* old generated code */
if (c1) {
   ...
} else if (c2) {
   ...
}
```

instead of

```
/* obvious generated code*/
if (c1) {
} else {
    if (c2) {
    } else {
    }
}
```

However, this motivation doesn't apply any more now that we are switching our
generated code to a "flat" list of basic blocks.