### PR TITLE
Tell Luacheck about Busted

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -25,3 +25,5 @@ ignore = {
     "542", -- Empty if branch.
     "6..", -- Whitespace warnings
 }
+
+files["spec"] = { std = "+busted" }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,11 +6,10 @@
 --    - luarocks install luacheck
 --    - luacheck ./titan-compiler
 --
--- Luacheck can also be integrated with vim, through Syntastic[2]:
---    - let g:syntastic_lua_checkers = ['luac', 'luacheck']
+-- For vim integration, I recommend ALE[2]. It supports luacheck out of the box
 --
 -- [1] https://luacheck.readthedocs.io/en/stable/config.html
--- [2] https://github.com/vim-syntastic/syntastic
+-- [2] https://github.com/w0rp/ale
 
 ignore = {
     "212/_.*",  -- Unused argument, when name starts with "_"


### PR DESCRIPTION
This change to .luacheckrc tells Luacheck to add luassert and busted functions
to the global scope in the spec file.

This gets rid of the majority of the warnings for our spec files.