### PR TITLE
Update LICENSE file with new authors list

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 The Titan Project Developers
+Copyright (c) 2018, The Titan Project Developers, The Pallene Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The authors list for Pallene now includes both the original Titan
Project developers plus everyone else who later contributed to the
Pallene branch of the project.

This is one of the last missing items for #22.