### PR TITLE
Simplify ast_iterator interface

### DIFF
--- a/pallene/ast_iterator.lua
+++ b/pallene/ast_iterator.lua
@@ -18,7 +18,7 @@ end
 
 function ast_iterator:Program(prog_ast, ...)
     for i = 1, #prog_ast do
-        prog_ast[i] = self:Toplevel(prog_ast[i], ...) or prog_ast[i]
+        self:Toplevel(prog_ast[i], ...)
     end
 end
 
@@ -32,14 +32,14 @@ function ast_iterator:Type(typ, ...)
     elseif tag == ast.Type.Value then -- nothing to do
     elseif tag == ast.Type.Name then -- nothing to do
     elseif tag == ast.Type.Array then
-        typ.subtype = self:Type(typ.subtype, ...) or typ.subtype
+        self:Type(typ.subtype, ...)
 
     elseif tag == ast.Type.Function then
         for i = 1, #typ.argtypes do
-            typ.argtypes[i] = self:Type(typ.argtypes[i], ...) or typ.argtypes[i]
+            self:Type(typ.argtypes[i], ...)
         end
         for i = 1, #typ.rettypes do
-            typ.rettypes[i] = self:Type(typ.rettypes[i], ...) or typ.rettypes[i]
+            self:Type(typ.rettypes[i], ...)
         end
 
     else
@@ -51,20 +51,20 @@ function ast_iterator:Toplevel(tlnode, ...)
     local tag = tlnode._tag
     if     tag == ast.Toplevel.Func then
         for i = 1, #tlnode.params do
-            tlnode.params[i] = self:Decl(tlnode.params[i], ...) or tlnode.params[i]
+            self:Decl(tlnode.params[i], ...)
         end
         for i = 1, #tlnode.rettypes do
-            tlnode.rettypes[i] = self:Type(tlnode.rettypes[i], ...) or tlnode.rettypes[i]
+            self:Type(tlnode.rettypes[i], ...)
         end
-        tlnode.block = self:Stat(tlnode.block, ...) or tlnode.block
+        self:Stat(tlnode.block, ...)
 
     elseif tag == ast.Toplevel.Var then
-        tlnode.decl = self:Decl(tlnode.decl, ...) or tlnode.decl
-        tlnode.value = self:Exp(tlnode.value, ...) or tlnode.value
+        self:Decl(tlnode.decl, ...)
+        self:Exp(tlnode.value, ...)
 
     elseif tag == ast.Toplevel.Record then
         for i = 1, #tlnode.field_decls do
-            tlnode.field_decls[i] = self:Decl(tlnode.field_decls[i], ...) or tlnode.field_decls[i]
+            self:Decl(tlnode.field_decls[i], ...)
         end
 
     elseif tag == ast.Toplevel.Import then
@@ -82,7 +82,7 @@ function ast_iterator:Decl(decl, ...)
     local tag = decl._tag
     if tag == ast.Decl.Decl then
         if decl.type then
-            decl.type = self:Type(decl.type, ...) or decl.type
+            self:Type(decl.type, ...)
         end
     else
         error("impossible")
@@ -93,45 +93,45 @@ function ast_iterator:Stat(stat, ...)
     local tag = stat._tag
     if     tag == ast.Stat.Block then
         for i = 1, #stat.stats do
-            stat.stats[i] = self:Stat(stat.stats[i], ...) or stat.stats[i]
+            self:Stat(stat.stats[i], ...)
         end
 
     elseif tag == ast.Stat.While then
-        stat.condition = self:Exp(stat.condition, ...) or stat.condition
-        stat.block = self:Stat(stat.block, ...) or stat.block
+        self:Exp(stat.condition, ...)
+        self:Stat(stat.block, ...)
 
     elseif tag == ast.Stat.Repeat then
-        stat.block = self:Stat(stat.block, ...) or stat.block
-        stat.condition = self:Exp(stat.condition, ...) or stat.condition
+        self:Stat(stat.block, ...)
+        self:Exp(stat.condition, ...)
 
     elseif tag == ast.Stat.If then
-        stat.condition = self:Exp(stat.condition, ...) or stat.condition
-        stat.then_ = self:Stat(stat.then_, ...) or stat.then_
-        stat.else_ = self:Stat(stat.else_, ...) or stat.else_
+        self:Exp(stat.condition, ...)
+        self:Stat(stat.then_, ...)
+        self:Stat(stat.else_, ...)
 
     elseif tag == ast.Stat.For then
-        stat.decl = self:Decl(stat.decl, ...) or stat.decl
-        stat.start = self:Exp(stat.start, ...) or stat.start
-        stat.limit = self:Exp(stat.limit, ...) or stat.limit
+        self:Decl(stat.decl, ...)
+        self:Exp(stat.start, ...)
+        self:Exp(stat.limit, ...)
         if stat.step then
-            stat.step = self:Exp(stat.step, ...) or stat.step
+            self:Exp(stat.step, ...)
         end
-        stat.block = self:Stat(stat.block, ...) or stat.block
+        self:Stat(stat.block, ...)
 
     elseif tag == ast.Stat.Assign then
-        stat.var = self:Var(stat.var, ...) or stat.var
-        stat.exp = self:Exp(stat.exp, ...) or stat.exp
+        self:Var(stat.var, ...)
+        self:Exp(stat.exp, ...)
 
     elseif tag == ast.Stat.Decl then
-        stat.decl = self:Decl(stat.decl, ...) or stat.decl
-        stat.exp = self:Exp(stat.exp, ...) or stat.exp
+        self:Decl(stat.decl, ...)
+        self:Exp(stat.exp, ...)
 
     elseif tag == ast.Stat.Call then
-        stat.callexp = self:Exp(stat.callexp, ...) or stat.callexp
+        self:Exp(stat.callexp, ...)
 
     elseif tag == ast.Stat.Return then
         for i = 1, #stat.exps do
-            stat.exps[i] = self:Exp(stat.exps[i], ...) or stat.exps[i]
+            self:Exp(stat.exps[i], ...)
         end
 
     else
@@ -145,11 +145,11 @@ function ast_iterator:Var(var, ...)
         -- Nothing to do
 
     elseif tag == ast.Var.Bracket then
-        var.exp1 = self:Exp(var.exp1, ...) or var.exp1
-        var.exp2 = self:Exp(var.exp2, ...) or var.exp2
+        self:Exp(var.exp1, ...)
+        self:Exp(var.exp2, ...)
 
     elseif tag == ast.Var.Dot then
-        var.exp = self:Exp(var.exp, ...) or var.exp
+        self:Exp(var.exp, ...)
 
     else
         error("impossible")
@@ -165,41 +165,40 @@ function ast_iterator:Exp(exp, ...)
     elseif tag == ast.Exp.String then -- Nothing to do
     elseif tag == ast.Exp.Initlist then
         for i = 1, #exp.fields do
-            exp.fields[i] = self:Field(exp.fields[i], ...) or exp.fields[i]
+            self:Field(exp.fields[i], ...)
         end
 
     elseif tag == ast.Exp.CallFunc then
-        exp.exp = self:Exp(exp.exp, ...) or exp.exp
+        self:Exp(exp.exp, ...)
         for i = 1, #exp.args do
-            exp.args[i] = self:Exp(exp.args[i], ...) or exp.args[i]
+            self:Exp(exp.args[i], ...)
         end
 
     elseif tag == ast.Exp.CallMethod then
-        exp.exp = self:Exp(exp.exp, ...) or exp.exp
+        self:Exp(exp.exp, ...)
         for i = 1, #exp.args do
-            exp.args[i] = self:Exp(exp.args[i], ...) or exp.args[i]
+            self:Exp(exp.args[i], ...)
         end
 
-
     elseif tag == ast.Exp.Var then
-        exp.var = self:Var(exp.var, ...) or exp.var
+        self:Var(exp.var, ...)
 
     elseif tag == ast.Exp.Unop then
-        exp.exp = self:Exp(exp.exp, ...) or exp.exp
+        self:Exp(exp.exp, ...)
 
     elseif tag == ast.Exp.Concat then
         for i = 1, #exp.exps do
-            exp.exps[i] = self:Exp(exp.exps[i], ...) or exp.exps[i]
+            self:Exp(exp.exps[i], ...)
         end
 
     elseif tag == ast.Exp.Binop then
-        exp.lhs = self:Exp(exp.lhs, ...) or exp.lhs
-        exp.rhs = self:Exp(exp.rhs, ...) or exp.rhs
+        self:Exp(exp.lhs, ...)
+        self:Exp(exp.rhs, ...)
 
     elseif tag == ast.Exp.Cast then
-        exp.exp = self:Exp(exp.exp, ...) or exp.exp
+        self:Exp(exp.exp, ...)
         if exp.target then
-            exp.target = self:Type(exp.target, ...) or exp.target
+            self:Type(exp.target, ...)
         end
 
     else
@@ -210,7 +209,7 @@ end
 function ast_iterator:Field(field, ...)
     local tag = field._tag
     if tag == ast.Field.Field then
-        field.exp = self:Exp(field.exp, ...) or field.exp
+        self:Exp(field.exp, ...)
     else
         error("impossible")
     end


### PR DESCRIPTION
There used to be a lot of unused code in ast_iterator to support the possibility
of mutating the AST as we traverse it. We do not use this feature anymore.