### PR TITLE
Update libreadline-dev package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you want to use Pallene on Linux we also recommend installing the `readline`
 library:
 
 ```sh
-$ sudo apt install readline-dev   # for Ubuntu & Debian-based distros
+$ sudo apt install libreadline-dev   # for Ubuntu & Debian-based distros
 $ sudo dnf install readline-devel # for Fedora and OpenSUSE
 ```
 


### PR DESCRIPTION
```
$ sudo apt install readline-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package readline-dev
```

I believe the correct package name is `libreadline-dev`