### PR TITLE
Use coroutines instead of xpcall in typechecker

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -138,17 +138,15 @@ end
 --
 
 type_check = function(prog_ast)
-    local co = coroutine.create(function()
-        check_program(prog_ast)
-    end)
-    local ok, err_msg = coroutine.resume(co)
+    local co = coroutine.create(check_program)
+    local ok, err_msg = coroutine.resume(co, prog_ast)
     if ok then
         if coroutine.status(co) == "dead" then
             -- User's program passed type checker
-            return prog_ast, {} -- TODO:  no {}
+            return prog_ast, {}
         else
             -- User's program has a type error
-            return false, { err_msg }
+            return false, {err_msg}
         end
     else
         -- Unhandled exception in Palene's type checker

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -153,7 +153,7 @@ type_check = function(prog_ast)
     else
         -- Unhandled exception in Palene's type checker
         local stack_trace = debug.traceback(co)
-        error("typechecker " .. stack_trace)
+        error(err_msg .. "\n" .. stack_trace)
     end
 end
 

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -39,16 +39,9 @@ end
 -- local functions
 --
 
-local TypeError = {}
-TypeError.__index = TypeError
-
-function TypeError.new(msg)
-    return setmetatable({ msg = msg }, TypeError)
-end
-
 local function type_error(loc, fmt, ...)
     local err_msg = location.format_error(loc, "type error: "..fmt, ...)
-    error(TypeError.new(err_msg))
+    coroutine.yield(err_msg)
 end
 
 -- Checks if two types are the same, and logs an error message otherwise
@@ -145,15 +138,22 @@ end
 --
 
 type_check = function(prog_ast)
-    local ok, err = xpcall(check_program, debug.traceback, prog_ast)
+    local co = coroutine.create(function()
+        check_program(prog_ast)
+    end)
+    local ok, err_msg = coroutine.resume(co)
     if ok then
-        return prog_ast, {} -- TODO:  no {}
-    else
-        if getmetatable(err) == TypeError then
-            return false, { err.msg } -- TODO  no {}
+        if coroutine.status(co) == "dead" then
+            -- User's program passed type checker
+            return prog_ast, {} -- TODO:  no {}
         else
-            error(err)
+            -- User's program has a type error
+            return false, { err_msg }
         end
+    else
+        -- Unhandled exception in Palene's type checker
+        local stack_trace = debug.traceback(co)
+        error("typechecker " .. stack_trace)
     end
 end
 


### PR DESCRIPTION
I think that the coroutine version is easier to understand, and is more
idiomatic Lua. The stack traces look better and it doesn't need that "special
metatable" trick.

(Obrigado pela sugestão, Ana)