### PR TITLE
Get rid of types.T.Builtin

### DIFF
--- a/pallene/builtins.lua
+++ b/pallene/builtins.lua
@@ -4,14 +4,17 @@ local types = require "pallene.types"
 
 local builtins = {}
 
-for _, lua_name in ipairs({
-    "io.write", "table.insert", "table.remove", "tofloat"
+for lua_name, typ in pairs({
+    ["io.write"]     = types.T.Function({types.T.String()}, {}),
+    ["table.insert"] = types.T.Function({types.T.Array(types.T.Value()), types.T.Value()}, {}),
+    ["table.remove"] = types.T.Function({types.T.Array(types.T.Value())}, {}),
+    ["tofloat"]      = types.T.Function({types.T.Integer()}, {types.T.Float()}),
 }) do
     local pallene_name = string.gsub(lua_name, "%.", "_")
     local loc = location.new("(builtin)", 0,0) -- (never shown to user)
 
     local obj = ast.Toplevel.Builtin(loc, lua_name)
-    obj._type = types.T.Builtin(obj)
+    obj._type = typ
 
     builtins[pallene_name] =  obj
 end

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -449,7 +449,7 @@ check_var = function(var)
             else
                 type_error(var.loc,
                     "field '%s' not found in record '%s'",
-                    var.name, exp_type.type_decl.name)
+                    var.name, types.tostring(exp_type))
             end
         else
             type_error(var.loc,
@@ -544,7 +544,7 @@ check_exp = function(exp, type_hint)
                 else
                     type_error(field.loc,
                         "invalid field %s in record initializer for %s",
-                        field.name, type_hint.type_decl.name)
+                        field.name, types.tostring(type_hint))
                 end
             end
 

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -475,48 +475,6 @@ check_var = function(var)
     end
 end
 
-local function check_exp_call_func_builtin(exp, _type_hint)
-    assert(_type_hint ~= nil)
-
-    local f_exp = exp.exp
-    local args = exp.args
-    local builtin_name = f_exp._type.builtin_decl.name
-    if builtin_name == "io.write" then
-        check_arity(exp.loc, 1, #args, "io.write arguments")
-        check_exp(args[1], false)
-        check_match(args[1].loc,
-            types.T.String(), args[1]._type,
-            "io.write argument")
-        exp._type = types.T.Void()
-    elseif builtin_name == "table.insert" then
-        check_arity(exp.loc, 2, #args, "table.insert arguments")
-        check_exp(args[1], false)
-        check_is_array(
-            args[1].loc, args[1]._type, "table.insert first argument")
-        local elem_type = args[1]._type.elem
-        check_exp(args[2], elem_type)
-        check_match(args[2].loc,
-            elem_type, args[2]._type,
-            "table.insert second argument")
-        exp._type = types.T.Void()
-    elseif builtin_name == "table.remove" then
-        check_arity(exp.loc, 1, #args, "table.insert arguments")
-        check_exp(args[1], false)
-        check_is_array(
-            args[1].loc, args[1]._type, "table.insert first argument")
-        exp._type = types.T.Void()
-    elseif builtin_name == "tofloat" then
-        check_arity(exp.loc, 1, #args, "tofloat arguments")
-        check_exp(args[1], false)
-        check_match(args[1].loc,
-            types.T.Integer(), args[1]._type,
-            "tofloat argument")
-        exp._type = types.T.Float()
-    else
-        error("impossible")
-    end
-end
-
 -- @param type_hint Expected type; Used to infer polymorphic/record constructors.
 check_exp = function(exp, type_hint)
     assert(type_hint ~= nil)
@@ -779,8 +737,6 @@ check_exp = function(exp, type_hint)
             else
                 exp._type = types.T.Void()
             end
-        elseif f_type._tag == types.T.Builtin then
-            check_exp_call_func_builtin(exp, false)
         else
             type_error(exp.loc,
                 "attempting to call a %s value",

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -2265,8 +2265,11 @@ generate_exp = function(exp, ctx)
         local fexp = exp.exp
         local fargs = exp.args
 
-        if fexp._type._tag == types.T.Builtin then
-            local builtin_name = fexp._type.builtin_decl.name
+        if fexp._tag == ast.Exp.Var and
+            fexp.var._tag == ast.Var.Name and
+            fexp.var._decl._tag == ast.Toplevel.Builtin
+        then
+            local builtin_name = fexp.var._decl.name
             if builtin_name == "io.write" then
                 return generate_exp_builtin_io_write(exp, ctx)
             elseif builtin_name == "table.insert" then

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -42,7 +42,12 @@ function types.is_gc(t)
     end
 end
 
+-- This helper function implements both the type equality relation and the and
+-- the gradual type consistency relation from gradual typing.
+-- Gradual type consistency is a relaxed form of equality where the the "value"
+-- type is considered to be consistent with all other types.
 local function equivalent(t1, t2, is_gradual)
+    assert(is_gradual ~= nil)
     local tag1 = t1._tag
     local tag2 = t2._tag
 
@@ -100,8 +105,6 @@ function types.equals(t1, t2)
     return equivalent(t1, t2, false)
 end
 
--- The type-consistency relation from gradual typing.
--- It is equality relaxed with (T ~ value) and (value ~ T)
 function types.consistent(t1, t2)
     return equivalent(t1, t2, true)
 end

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -17,7 +17,6 @@ declare_type("T", {
     Function = {"params", "ret_types"},
     Array    = {"elem"},
     Record   = {"type_decl"},
-    Builtin  = {"builtin_decl"},
 })
 
 function types.is_gc(t)
@@ -34,8 +33,7 @@ function types.is_gc(t)
            tag == types.T.String or
            tag == types.T.Function or
            tag == types.T.Array or
-           tag == types.T.Record or
-           tag == types.T.Builtin
+           tag == types.T.Record
     then
         return true
 
@@ -93,9 +91,6 @@ local function equivalent(t1, t2, is_gradual)
     elseif tag1 == types.T.Record then
         return t1.type_decl == t2.type_decl
 
-    elseif tag1 == types.T.Builtin then
-        return t1.builtin_decl == t2.builtin_decl
-
     else
         return error("impossible")
     end
@@ -126,8 +121,6 @@ function types.tostring(t)
         return "{ " .. types.tostring(t.elem) .. " }"
     elseif tag == types.T.Record then
         return t.type_decl.name
-    elseif tag == types.T.Builtin then
-        return "builtin(".. t.builtin_decl.name ..")"
     else
         error("impossible")
     end

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1270,7 +1270,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("expected string but found integer", errs, nil, true)
+        assert.match("integer is not assignable to string", errs, nil, true)
     end)
 
     it("typechecks table.insert", function()
@@ -1289,11 +1289,11 @@ describe("Pallene type checker", function()
     it("typechecks table.insert (error)", function()
         local prog_ast, errs = run_checker([[
             function f(xs: {integer})
-                table_insert(xs, "asd")
+                table_insert("asd", xs)
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("expected integer but found string", errs, nil, true)
+        assert.match("string is not assignable to { value }", errs, nil, true)
     end)
 
     it("typechecks tofloat", function()


### PR DESCRIPTION
Now that we have the value type we can get rid of the special
typechecking rules for builtin functions. A breaking change is that now the
types for table.insert are a bit more permissive as it now receives
`({value},value)` instead of `∀T.({T}, T)`

Closes #56