### PR TITLE
Use udatamemoffset instead of getudatamem

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -800,10 +800,12 @@ end
 
 function RecordCoder:primitive_slot(udata, field_name)
     local out = util.render(
-        [[((${STRUCT_NAME} *)getudatamem(${UDATA}))->${FIELD_NAME}]],
+        [[((${STRUCT_NAME} *)(cast_charp(${UDATA}) +
+            udatamemoffset(${NUVALUE})))->${FIELD_NAME}]],
     {
         STRUCT_NAME = self:struct(),
         UDATA = udata,
+        NUVALUE = self.layout.gc_size,
         FIELD_NAME = self:field(field_name),
     })
     return out

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -797,6 +797,8 @@ end
 function RecordCoder:declare_getmem()
     if self.layout.prim_size == 0 then return "" end
 
+    -- This function is a specialization of the macro getudatamem that generates
+    -- a cleaner assembly because NUVALUE is a compile-time constant.
     local out = util.render([[
         static ${STRUCT} *${GETMEM}(Udata *u)
         {


### PR DESCRIPTION
By using the macro udatamemoffset directly, the C compiler can compute during
compiler time the offset of C fields in a userdata.
Even thought the compiler generates better code, I did not experience
performance improvements in my computer (Intel Code i5-7360U/Macbook Pro 2017).

Closes #66 