### PR TITLE
Updates to coder_spec

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1555,7 +1555,14 @@ generate_stat = function(stat, ctx)
 
     elseif tag == "ast.Stat.Repeat" then
         ctx:begin_scope()
-        local block_cstats = generate_stat(stat.block, ctx)
+
+        -- We cannot simply call generate_stat(stat.block) because then it
+        -- would create an extra scope without the condition expression
+        local block_cstatss = {}
+        for _, inner_stat in ipairs(stat.block.stats) do
+            table.insert(block_cstatss, generate_stat(inner_stat, ctx))
+        end
+
         local cond_cstats, cond_cvalue = generate_exp(stat.condition, ctx)
         ctx:end_scope()
         local out = util.render([[
@@ -1567,7 +1574,7 @@ generate_stat = function(stat, ctx)
         ]], {
             COND_STATS = cond_cstats,
             COND = cond_cvalue,
-            BLOCK = block_cstats,
+            BLOCK = table.concat(block_cstatss, "\n"),
         })
         return out
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1,5 +1,4 @@
 local driver = require 'pallene.driver'
-local types = require 'pallene.types'
 local util = require 'pallene.util'
 
 local function run_checker(code)
@@ -513,70 +512,6 @@ describe("Pallene type checker", function()
         assert.match("float is not assignable to integer", errs,nil, true)
     end)
 
-    for _, op in ipairs({"+", "-", "*", "%", "//"}) do
-        it("coerces "..op.." to float if any side is a float", function()
-            local prog_ast, errs = run_checker([[
-                function fn()
-                    local i: integer = 1
-                    local f: float = 1.5
-                    local i_f = i ]] .. op .. [[ f
-                    local f_i = f ]] .. op .. [[ i
-                    local f_f = f ]] .. op .. [[ f
-                    local i_i = i ]] .. op .. [[ i
-                end
-            ]])
-            assert(prog_ast, errs)
-
-            assert.same(types.T.Float(), prog_ast[1].block.stats[3].exp.lhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[3].exp.rhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[3].exp._type)
-
-            assert.same(types.T.Float(), prog_ast[1].block.stats[4].exp.lhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[4].exp.rhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[4].exp._type)
-
-            assert.same(types.T.Float(), prog_ast[1].block.stats[5].exp.lhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[5].exp.rhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[5].exp._type)
-
-            assert.same(types.T.Integer(), prog_ast[1].block.stats[6].exp.lhs._type)
-            assert.same(types.T.Integer(), prog_ast[1].block.stats[6].exp.rhs._type)
-            assert.same(types.T.Integer(), prog_ast[1].block.stats[6].exp._type)
-        end)
-    end
-
-    for _, op in ipairs({"/", "^"}) do
-        it("always coerces "..op.." to float", function()
-            local prog_ast, errs = run_checker([[
-                function fn()
-                    local i: integer = 1
-                    local f: float = 1.5
-                    local i_f = i ]] .. op .. [[ f
-                    local f_i = f ]] .. op .. [[ i
-                    local f_f = f ]] .. op .. [[ f
-                    local i_i = i ]] .. op .. [[ i
-                end
-            ]])
-            assert(prog_ast, errs)
-
-            assert.same(types.T.Float(), prog_ast[1].block.stats[3].exp.lhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[3].exp.rhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[3].exp._type)
-
-            assert.same(types.T.Float(), prog_ast[1].block.stats[4].exp.lhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[4].exp.rhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[4].exp._type)
-
-            assert.same(types.T.Float(), prog_ast[1].block.stats[5].exp.lhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[5].exp.rhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[5].exp._type)
-
-            assert.same(types.T.Float(), prog_ast[1].block.stats[6].exp.lhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[6].exp.rhs._type)
-            assert.same(types.T.Float(), prog_ast[1].block.stats[6].exp._type)
-        end)
-    end
-
     it("cannot concatenate with boolean", function()
         local prog_ast, errs = run_checker([[
             function fn()
@@ -607,70 +542,6 @@ describe("Pallene type checker", function()
         assert.falsy(prog_ast)
         assert.match("cannot concatenate with { integer } value", errs)
     end)
-
-    it("can concatenate with integer and float", function()
-        local prog_ast, errs = run_checker([[
-            function fn()
-                local s = 1 .. 2.5
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    for _, op in ipairs({"==", "~="}) do
-        it("can compare arrays of same type using " .. op, function()
-            local prog_ast, errs = run_checker([[
-                function fn(a1: {integer}, a2: {integer}): boolean
-                    return a1 ]] .. op .. [[ a2
-                end
-            ]])
-            assert(prog_ast, errs)
-        end)
-    end
-
-    for _, op in ipairs({"==", "~="}) do
-        it("can compare booleans using " .. op, function()
-            local prog_ast, errs = run_checker([[
-                function fn(b1: string, b2: string): boolean
-                    return b1 ]] .. op .. [[ b2
-                end
-            ]])
-            assert(prog_ast, errs)
-        end)
-    end
-
-    for _, op in ipairs({"==", "~=", "<", ">", "<=", ">="}) do
-        it("can compare floats using " .. op, function()
-            local prog_ast, errs = run_checker([[
-                function fn(f1: string, f2: string): boolean
-                    return f1 ]] .. op .. [[ f2
-                end
-            ]])
-            assert(prog_ast, errs)
-        end)
-    end
-
-    for _, op in ipairs({"==", "~=", "<", ">", "<=", ">="}) do
-        it("can compare integers using " .. op, function()
-            local prog_ast, errs = run_checker([[
-                function fn(i1: string, i2: string): boolean
-                    return i1 ]] .. op .. [[ i2
-                end
-            ]])
-            assert(prog_ast, errs)
-        end)
-    end
-
-    for _, op in ipairs({"==", "~=", "<", ">", "<=", ">="}) do
-        it("can compare strings using " .. op, function()
-            local prog_ast, errs = run_checker([[
-                function fn(s1: string, s2: string): boolean
-                    return s1 ]] .. op .. [[ s2
-                end
-            ]])
-            assert(prog_ast, errs)
-        end)
-    end
 
     for _, op in ipairs({"==", "~="}) do
         it("cannot compare arrays of different types using " .. op, function()
@@ -824,17 +695,6 @@ describe("Pallene type checker", function()
             end)
 
         end
-    end
-
-    for _, op in ipairs({"|", "&", "<<", ">>"}) do
-        it("can use bitwise operators with integers using " .. op, function()
-            local prog_ast, errs = run_checker([[
-                function fn(i1: integer, i2: integer): integer
-                    return i1 ]] .. op .. [[ i2
-                end
-            ]])
-            assert(prog_ast, errs)
-        end)
     end
 
     for _, op in ipairs({"|", "&", "<<", ">>"}) do

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -7,11 +7,6 @@ local function run_checker(code)
     return prog_ast, table.concat(errs, "\n")
 end
 
-local function assert_type_check(code)
-    local prog_ast, errs = run_checker(code)
-    assert.truthy(prog_ast, errs)
-end
-
 local function assert_type_error(expected, code)
     local prog_ast, errs = run_checker(code)
     assert.falsy(prog_ast)
@@ -43,46 +38,6 @@ describe("Pallene type checker", function()
         ]])
         assert.falsy(prog_ast)
         assert.match("'Point' isn't a value", errs)
-    end)
-
-    it("allows constant variable initialization", function()
-        assert_type_check([[ local x1 = nil ]])
-        assert_type_check([[ local x2 = false ]])
-        assert_type_check([[ local x3 = 11 ]])
-        assert_type_check([[ local x4 = 1.1 ]])
-        assert_type_check([[ local x5 = "11" ]])
-        assert_type_check([[ local x6: {integer} = {} ]])
-        assert_type_check([[ local x7: {integer} = {1, 2} ]])
-        assert_type_check([[ local x8 = "a" .. 10 ]])
-        assert_type_check([[ local x9 = 1 + 2 ]])
-        assert_type_check([[ local x10 = not false ]])
-        assert_type_check([[ local x11 = 10.1 ]])
-    end)
-
-    it("allows non constant variable initialization", function()
-        assert_type_check([[
-            function f(): integer
-                return 10
-            end
-            local x = f() ]])
-        assert_type_check([[
-            local x = 10
-            local y = x ]])
-        assert_type_check([[
-            local x = 10
-            local y = -x ]])
-        assert_type_check([[
-            local x = 10
-            local y = 10 + x ]])
-        assert_type_check([[
-            local x = "b"
-            local y = "a" .. x ]])
-        assert_type_check([[
-            local x = 10
-            local y: integer = x ]])
-        assert_type_check([[
-            local x = 10
-            local y: {integer} = {x} ]])
     end)
 
     it("catches array expression in indexing is not an array", function()

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1,4 +1,3 @@
-local ast = require 'pallene.ast'
 local driver = require 'pallene.driver'
 local types = require 'pallene.types'
 local util = require 'pallene.util'
@@ -45,19 +44,6 @@ describe("Pallene type checker", function()
         ]])
         assert.falsy(prog_ast)
         assert.match("'Point' isn't a value", errs)
-    end)
-
-    it("for loop iteration variables don't shadow var limit and step", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: integer): integer
-                local i: string = "asdfg"
-                for i = 1, #i do
-                    x = x + i
-                end
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
     end)
 
     it("allows constant variable initialization", function()
@@ -108,15 +94,6 @@ describe("Pallene type checker", function()
         ]])
         assert.falsy(prog_ast)
         assert.match("array expression in indexing is not an array", errs)
-    end)
-
-    it("accepts correct use of length operator", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: {integer}): integer
-                return #x
-            end
-        ]])
-        assert(prog_ast, errs)
     end)
 
     it("catches wrong use of length operator", function()
@@ -171,18 +148,6 @@ describe("Pallene type checker", function()
         assert.match("integer is not assignable to string", errs)
     end)
 
-    it("function can call another function", function()
-        local prog_ast, errs = run_checker([[
-            function fn1()
-            end
-
-            function fn2()
-              fn1()
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
     it("catches mismatching types in arguments", function()
         local prog_ast, errs = run_checker([[
             function fn(i: integer, s: string): integer
@@ -191,27 +156,6 @@ describe("Pallene type checker", function()
         ]])
         assert.falsy(prog_ast)
         assert.match("integer is not assignable to string", errs)
-    end)
-
-    it("can create empty array (with type annotation)", function()
-        local prog_ast, errs = run_checker([[
-            local xs: {integer} = {}
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("can create non-empty array (with type annotation)", function()
-        local prog_ast, errs = run_checker([[
-            local xs: {integer} = {10, 20, 30}
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("can create array of array (with type annotation)", function()
-        local prog_ast, errs = run_checker([[
-            local xs: {{integer}} = {{10,20}, {30,40}}
-        ]])
-        assert(prog_ast, errs)
     end)
 
     it("forbids empty array (without type annotation)", function()
@@ -244,46 +188,6 @@ describe("Pallene type checker", function()
         ]])
         assert.falsy(prog_ast)
         assert.matches("expected integer but found string", errs)
-    end)
-
-    it("can create record (with type annotation)", function()
-        local prog_ast, errs = run_checker([[
-            record Point
-                x: float
-                y: float
-            end
-            local p: Point = { x = 10.0, y = 20.0 }
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("can create array of record (with type annotation)", function()
-        local prog_ast, errs = run_checker([[
-            record Point
-                x: float
-                y: float
-            end
-            local ps: {Point} = {
-                { x = 10.0, y = 20.0 },
-                { x = 30.0, y = 40.0 },
-            }
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("can create record of record (with type annotation)", function()
-        local prog_ast, errs = run_checker([[
-            record Point
-                x: float
-                y: float
-            end
-            record Circle
-                center: Point
-                radius: float
-            end
-            local c: Circle = { center = { x = 10.0, y = 20.0 }, radius = 5.0 }
-        ]])
-        assert(prog_ast, errs)
     end)
 
     it("forbids record creation (without type annotation)", function()
@@ -375,67 +279,6 @@ describe("Pallene type checker", function()
             errs, nil, true)
     end)
 
-    it("type-checks numeric 'for' (integer, implicit step)", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: integer): integer
-                for i:integer = 1, 10 do
-                    x = x + 1
-                end
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("type-checks numeric 'for' (integer, explicit step)", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: integer): integer
-                for i:integer = 1, 10, 2 do
-                    x = x + i
-                end
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("type-checks numeric 'for' (float, implicit step)", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: float): float
-                for i:float = 1.0, 10.0 do
-                    x = x + i
-                end
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("type-checks numeric 'for' (float, explicit step)", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: float): float
-                for i:float = 1.0, 10.0, 2.0 do
-                    x = x + i
-                end
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("type-checks 'while'", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: integer): integer
-                local i: integer = 15
-                while x < 100 do
-                    x = x + i
-                end
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
     it("requires while statement conditions to be boolean", function()
         local prog_ast, errs = run_checker([[
             function fn(x:integer): integer
@@ -449,20 +292,7 @@ describe("Pallene type checker", function()
         assert.matches("types in while statement condition do not match, expected boolean but found integer", errs)
     end)
 
-    it("type-checks 'repeat'", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: integer): integer
-                local i: integer = 15
-                repeat
-                    x = x + i
-                until x >= 100
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-     it("requires repeat statement conditions to be boolean", function()
+    it("requires repeat statement conditions to be boolean", function()
         local prog_ast, errs = run_checker([[
             function fn(x:integer): integer
                 repeat
@@ -473,23 +303,6 @@ describe("Pallene type checker", function()
         ]])
         assert.falsy(prog_ast)
         assert.matches("types in repeat statement condition do not match, expected boolean but found integer", errs)
-    end)
-
-    it("type-checks 'if'", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: integer): integer
-                local i: integer = 15
-                if x < 100 then
-                    x = x + i
-                elseif x > 100 then
-                    x = x - i
-                else
-                    x = 100
-                end
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
     end)
 
     it("requires if statement conditions to be boolean", function()
@@ -504,20 +317,6 @@ describe("Pallene type checker", function()
         ]])
         assert.falsy(prog_ast)
         assert.matches("types in if statement condition do not match, expected boolean but found integer", errs)
-    end)
-
-    it("checks code inside the 'while' block", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: integer): integer
-                local i: integer = 15
-                while i > 0 do
-                    local s: string = i
-                end
-                return x
-            end
-        ]])
-        assert.falsy(prog_ast)
-        assert.match("integer is not assignable to string", errs)
     end)
 
     it("ensures numeric 'for' variable has number type (with annotation)", function()
@@ -609,24 +408,6 @@ describe("Pallene type checker", function()
         assert.match(
             "returning 0 value(s) but function expects 1", errs,
             nil, true)
-    end)
-
-    it("accepts functions that return 0 values", function()
-        local prog_ast, errs = run_checker([[
-            function f(): ()
-                return
-            end
-        ]])
-        assert(prog_ast, errs)
-    end)
-
-    it("accepts functions that return 1 value", function()
-        local prog_ast, errs = run_checker([[
-            function f(): integer
-                return 17
-            end
-        ]])
-        assert(prog_ast, errs)
     end)
 
     it("detects when a function returns the wrong type", function()
@@ -877,18 +658,6 @@ describe("Pallene type checker", function()
                 end
             ]])
             assert(prog_ast, errs)
-        end)
-    end
-
-    for _, op in ipairs({"==", "~=", "<", ">", "<=", ">="}) do
-        it("can compare integers and floats using " .. op, function()
-            local prog_ast, errs = run_checker([[
-                function fn(i: integer, f: float): boolean
-                    return i ]] .. op .. [[ f
-                end
-            ]])
-            assert.falsy(prog_ast)
-            assert.match("comparisons between float and integers are not yet implemented", errs)
         end)
     end
 
@@ -1184,61 +953,6 @@ describe("Pallene type checker", function()
         end)
     end
 
-    for _, ts in ipairs({
-        {"downcast", "integer", "value"},
-        {"upcast",   "value", "integer"},
-    }) do
-        local description = ts[1]
-        local dst_typ     = ts[2]
-        local src_typ     = ts[3]
-
-        describe(
-            "can implicitly "..description..
-            " from "..src_typ..
-            " to "..dst_typ.."", function()
-
-                it("in variable declarations", function()
-                    local prog_ast, errs = run_checker([[
-                        function f(y : ]]..src_typ..[[)
-                            local x : ]]..dst_typ..[[ = y
-                        end
-                    ]])
-                    assert.truthy(prog_ast, errs)
-                end)
-
-                it("in variable assignments", function()
-                    local prog_ast, errs = run_checker([[
-                        function f(x : ]]..dst_typ..[[, y : ]]..src_typ..[[)
-                            x = y
-                        end
-                    ]])
-                    assert.truthy(prog_ast, errs)
-                end)
-
-                it("in function call arguments", function()
-                    local prog_ast, errs = run_checker([[
-                        function f(x : ]]..dst_typ..[[)
-                        end
-
-                        function g(y : ]]..src_typ..[[)
-                            f(y)
-                        end
-                    ]])
-                    assert.truthy(prog_ast, errs)
-                end)
-
-                it("in function return statements", function()
-                    local prog_ast, errs = run_checker([[
-                        function f(y : ]]..src_typ..[[) : ]]..dst_typ..[[
-                            return y
-                        end
-                    ]])
-                    assert.truthy(prog_ast, errs)
-                end)
-        end)
-    end
-
-
     it("catches assignment to function", function ()
         local prog_ast, errs = run_checker([[
             function f()
@@ -1254,15 +968,6 @@ describe("Pallene type checker", function()
             errs, nil, true)
     end)
 
-    it("typechecks io.write", function()
-        local prog_ast, errs = run_checker([[
-            function f()
-                io_write("Hello World\n")
-            end
-        ]])
-        assert.truthy(prog_ast, errs)
-    end)
-
     it("typechecks io.write (error)", function()
         local prog_ast, errs = run_checker([[
             function f()
@@ -1271,19 +976,6 @@ describe("Pallene type checker", function()
         ]])
         assert.falsy(prog_ast)
         assert.match("integer is not assignable to string", errs, nil, true)
-    end)
-
-    it("typechecks table.insert", function()
-        local prog_ast, errs = run_checker([[
-            function f(xs: {integer})
-                table_insert(xs, 10)
-            end
-
-            function g(xs: {float})
-                table_insert(xs, 3.14)
-            end
-        ]])
-        assert.truthy(prog_ast, errs)
     end)
 
     it("typechecks table.insert (error)", function()
@@ -1295,39 +987,9 @@ describe("Pallene type checker", function()
         assert.falsy(prog_ast)
         assert.match("string is not assignable to { value }", errs, nil, true)
     end)
-
-    it("typechecks tofloat", function()
-        local prog_ast, errs = run_checker([[
-            function fn(): integer
-                local i: integer = 12
-                local f: float = tofloat(i)
-                return 1
-            end
-        ]])
-        assert.truthy(prog_ast, errs)
-    end)
 end)
 
 describe("Pallene typecheck of records", function()
-    it("typechecks record declarations", function()
-        assert_type_check([[
-            record Point
-                x: float
-                y: float
-            end
-        ]])
-    end)
-
-    it("typechecks record as argument/return", function()
-        assert_type_check([[
-            record Point x: float; y:float end
-
-            function f(p: Point): Point
-                return p
-            end
-        ]])
-    end)
-
     local function wrap_record(code)
         return [[
             record Point x: float; y:float end
@@ -1337,14 +999,6 @@ describe("Pallene typecheck of records", function()
             end
         ]]
     end
-
-    it("typechecks record read/write", function()
-        assert_type_check(wrap_record[[
-            local x: float = 10.0
-            p.x = x
-            return p.y
-        ]])
-    end)
 
     it("doesn't typecheck read/write to non existent fields", function()
         local function assert_non_existent(code)
@@ -1362,4 +1016,3 @@ describe("Pallene typecheck of records", function()
                           wrap_record[[ local p: Point = p.x ]])
     end)
 end)
-

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -562,6 +562,15 @@ describe("Pallene coder /", function()
                 end
                 return res
             end
+
+            function repeat_until(): integer
+                local x = 0
+                repeat
+                    x = x + 1
+                    local limit = x * 10
+                until limit >= 100
+                return x
+            end
         ]]))
 
         it("Block, Assign, Decl", function()
@@ -598,6 +607,10 @@ describe("Pallene coder /", function()
 
         it("For loop (float) (going down)", function()
             run_test([[ assert(720.0 == test.factorial_float_for_dec(6.0)) ]])
+        end)
+
+        it("Repeat until", function()
+            run_test([[ assert(10 == test.repeat_until()) ]])
         end)
     end)
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -102,6 +102,34 @@ describe("Pallene coder /", function()
         end)
     end)
 
+    describe("Variables /", function()
+        setup(compile([[
+            function fst(x:integer, y:integer): integer return x end
+            function snd(x:integer, y:integer): integer return y end
+
+            local n = 0
+            function next_n(): integer
+                n = n + 1
+                return n
+            end
+        ]]))
+
+        it("local variables", function()
+            run_test([[
+                assert(10 == test.fst(10, 20))
+                assert(20 == test.snd(10, 20))
+            ]])
+        end)
+
+        it("global variables", function()
+            run_test([[
+                assert(1 == test.next_n())
+                assert(2 == test.next_n())
+                assert(3 == test.next_n())
+            ]])
+        end)
+    end)
+
     describe("Function calls /", function()
         setup(compile([[
             function f0(): integer
@@ -207,39 +235,6 @@ describe("Pallene coder /", function()
                     "wrong type for argument x, " ..
                     "expected integer but found float",
                     nil, true))
-            ]])
-        end)
-    end)
-
-    describe("Variables /", function()
-        setup(compile([[
-            function f_locals(): integer
-                local a = 1
-                local b = 1
-                do
-                    local a = 0
-                    b = a
-                end
-                local c = a
-                return 100*a + 10*b + c
-             end
-
-            local n = 0
-            function f_globals(): integer
-                n = n + 1
-                return n
-            end
-        ]]))
-
-        it("local variables", function()
-            run_test([[ assert(101 == test.f_locals()) ]])
-        end)
-
-        it("global variables", function()
-            run_test([[
-                assert(1 == test.f_globals())
-                assert(2 == test.f_globals())
-                assert(3 == test.f_globals())
             ]])
         end)
     end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -974,8 +974,6 @@ describe("Pallene coder /", function()
     end)
 
     describe("tofloat builtin", function()
-        -- This builtin is also tested further up, in automatic
-        -- arithmetic conversions.
         setup(compile([[
             function itof(x:integer): float
                 return tofloat(x)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -60,69 +60,6 @@ describe("Pallene coder /", function()
         end)
     end)
 
-    describe("Function arguments /", function()
-        setup(compile([[
-            function id_int(x: integer): integer
-                return x
-            end
-
-            function id_float(x: float): float
-                return x
-            end
-        ]]))
-
-        it("missing arguments", function()
-            run_test([[
-                local ok, err = pcall(test.id_int)
-                assert(string.find(err,
-                    "wrong number of arguments to function 'id_int', " ..
-                    "expected 1 but received 0",
-                    nil, true))
-            ]])
-        end)
-
-        it("too many arguments", function()
-            run_test([[
-                local ok, err = pcall(test.id_int, 10, 20)
-                assert(string.find(err,
-                    "wrong number of arguments to function 'id_int', " ..
-                    "expected 1 but received 2",
-                    nil, true))
-            ]])
-        end)
-
-        it("type of argument", function()
-            run_test([[
-                local ok, err = pcall(test.id_float, "abc")
-                assert(string.find(err,
-                    "wrong type for argument x, " ..
-                    "expected float but found string",
-                    nil, true))
-            ]])
-        end)
-
-        -- See if error messages show float/integer instead of "number":
-        it("expected float but found integer", function()
-            run_test([[
-                local ok, err = pcall(test.id_float, 10)
-                assert(string.find(err,
-                    "wrong type for argument x, " ..
-                    "expected float but found integer",
-                    nil, true))
-            ]])
-        end)
-
-        it("expected float but found integer", function()
-            run_test([[
-                local ok, err = pcall(test.id_int, 3.14)
-                assert(string.find(err,
-                    "wrong type for argument x, " ..
-                    "expected integer but found float",
-                    nil, true))
-            ]])
-        end)
-    end)
-
     describe("Literals /", function()
         setup(compile([[
             function f_nil(): nil          return nil  end
@@ -243,8 +180,41 @@ describe("Pallene coder /", function()
         it("void functions", function()
             run_test([[ assert(11 == test.next_x()) ]])
         end)
-    end)
 
+        -- Errors
+
+        it("missing arguments", function()
+            run_test([[
+                local ok, err = pcall(test.g1)
+                assert(string.find(err,
+                    "wrong number of arguments to function 'g1', " ..
+                    "expected 1 but received 0",
+                    nil, true))
+            ]])
+        end)
+
+        it("too many arguments", function()
+            run_test([[
+                local ok, err = pcall(test.g1, 10, 20)
+                assert(string.find(err,
+                    "wrong number of arguments to function 'g1', " ..
+                    "expected 1 but received 2",
+                    nil, true))
+            ]])
+        end)
+
+        it("type of argument", function()
+            -- Also sees if error messages say "float" and "integer"
+            -- instead of "number"
+            run_test([[
+                local ok, err = pcall(test.g1, 3.14)
+                assert(string.find(err,
+                    "wrong type for argument x, " ..
+                    "expected integer but found float",
+                    nil, true))
+            ]])
+        end)
+    end)
 
     describe("Variables /", function()
         setup(compile([[

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -416,9 +416,8 @@ describe("Pallene coder /", function()
         it("concat (..)",        function() optest("concat_str") end)
     end)
 
-    describe("Operators /", function()
-        -- The `as` operator does not exist in Lua, so it must be tested
-        -- separately.
+    describe("Coercions with dynamic type /", function()
+
         local tests = {
             ["boolean"]  = {typ = "boolean",         value = "true"},
             ["integer"]  = {typ = "integer",         value = "17"},
@@ -455,7 +454,7 @@ describe("Pallene coder /", function()
         setup(compile(table.concat(program_parts, "\n")))
 
 
-        local function to_value(name)
+        local function test_to_value(name)
             run_test(util.render([[
                 local x = ${VALUE}
                 assert(x == test.from_${NAME}(x))
@@ -465,7 +464,7 @@ describe("Pallene coder /", function()
             }))
         end
 
-        local function from_value(name)
+        local function test_from_value(name)
             run_test(util.render([[
                 local x = ${VALUE}
                 assert(x == test.to_${NAME}(x))
@@ -475,21 +474,21 @@ describe("Pallene coder /", function()
             }))
         end
 
-        it("boolean->value (as)",  function() to_value("boolean") end)
-        it("integer->value (as)",  function() to_value("integer") end)
-        it("float->value (as)",    function() to_value("float") end)
-        it("string->value (as)",   function() to_value("string") end)
-        it("function->value (as)", function() to_value("function") end)
-        it("array->value (as)",    function() to_value("array") end)
-        it("record->value (as)",   function() to_value("record") end)
+        it("boolean->value (as)",  function() test_to_value("boolean") end)
+        it("integer->value (as)",  function() test_to_value("integer") end)
+        it("float->value (as)",    function() test_to_value("float") end)
+        it("string->value (as)",   function() test_to_value("string") end)
+        it("function->value (as)", function() test_to_value("function") end)
+        it("array->value (as)",    function() test_to_value("array") end)
+        it("record->value (as)",   function() test_to_value("record") end)
 
-        it("value->boolean (as)",  function() from_value("boolean") end)
-        it("value->integer (as)",  function() from_value("integer") end)
-        it("value->float (as)",    function() from_value("float") end)
-        it("value->string (as)",   function() from_value("string") end)
-        it("value->function (as)", function() from_value("function") end)
-        it("value->array (as)",    function() from_value("array") end)
-        it("value->record (as)",   function() from_value("record") end)
+        it("value->boolean (as)",  function() test_from_value("boolean") end)
+        it("value->integer (as)",  function() test_from_value("integer") end)
+        it("value->float (as)",    function() test_from_value("float") end)
+        it("value->string (as)",   function() test_from_value("string") end)
+        it("value->function (as)", function() test_from_value("function") end)
+        it("value->array (as)",    function() test_from_value("array") end)
+        it("value->record (as)",   function() test_from_value("record") end)
 
         it("detects downcast error", function()
             run_test([[

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1151,4 +1151,44 @@ describe("Pallene coder /", function()
             run_test([[ assert( 34 == test.for_initializer() ) ]])
         end)
     end)
+
+    describe("Non-constant toplevel initializers", function()
+        setup(compile([[
+            function f(): integer
+                return 10
+            end
+
+            local x1 = f()
+            local x2 = x1
+            local x3 = -x2
+            local x4 : {integer} = { x1 }
+
+            function get_x1(): integer
+                return x1
+            end
+
+            function get_x2(): integer
+                return x2
+            end
+
+            function get_x3(): integer
+                return x3
+            end
+
+            function get_x4(): {integer}
+                return x4
+            end
+        ]]))
+
+        it("", function()
+            run_test([[
+                assert(  10 == test.get_x1() )
+                assert(  10 == test.get_x2() )
+                assert( -10 == test.get_x3() )
+                local x4 = test.get_x4()
+                assert ( 1 == #x4 )
+                assert ( 10 == x4[1] )
+            ]])
+        end)
+    end)
 end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -402,9 +402,6 @@ describe("Pallene coder /", function()
             -- NYI { "eq_bb",     "==",  "boolean",   "boolean",   "boolean" },
             -- NYI { "ne_bb",     "~=",  "boolean",   "boolean",   "boolean" },
 
-            -- NYI { "eq_fsfs",   "==",  "{boolean}", "{boolean}", "boolean" },
-            -- NYI { "ne_fsfs",   "~=",  "{boolean}", "{boolean}", "boolean" },
-
             { "and_bb",    "and", "boolean", "boolean", "boolean" },
             { "or_bb",     "or",  "boolean", "boolean", "boolean" },
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -43,13 +43,8 @@ describe("Pallene coder /", function()
 
     describe("Exported functions /", function()
         setup(compile([[
-            function f(): integer
-                return 10
-            end
-
-            local function g(): integer
-                return 11
-            end
+                  function f(): integer return 10 end
+            local function g(): integer return 11 end
         ]]))
 
         it("does not export local functions", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1046,4 +1046,53 @@ describe("Pallene coder /", function()
         end)
 
     end)
+
+    describe("Corner cases of scoping", function()
+
+        setup(compile([[
+            record Point
+                x: integer
+                y: integer
+            end
+
+            local x = 10
+
+            ------
+
+            function local_type(): integer
+                local Point: Point = { x=1, y=2 }
+                return Point.x
+            end
+
+            function local_initializer(): integer
+                local x = x + 1
+                return x
+            end
+
+            function for_initializer(): integer
+                local res = 0
+                for x = x + 1, x + 100, x-7 do
+                    res = res + 1
+                end
+                return res
+            end
+        ]]))
+
+
+        it("local variable doesn't shadow its type annotation", function()
+            run_test([[ assert( 1 == test.local_type() ) ]])
+        end)
+
+        it("local variable scope doesn't shadow its initializer", function()
+            run_test([[ assert( 11 == test.local_initializer() ) ]])
+        end)
+
+        it("for loop variable scope doesn't shadow its type annotation", function()
+            pending("requires type aliases")
+        end)
+
+        it("for loop variable scope doesn't shadow its initializers", function()
+            run_test([[ assert( 34 == test.for_initializer() ) ]])
+        end)
+    end)
 end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -341,30 +341,73 @@ describe("Pallene coder /", function()
 
         local tests = {
             { "add_ii",    "+",   "integer", "integer", "integer" },
+            { "add_if",    "+",   "integer", "float",   "float" },
+            { "add_fi",    "+",   "float",   "integer", "float" },
             { "add_ff",    "+",   "float",   "float",   "float" },
+
             { "sub_ii",    "-",   "integer", "integer", "integer" },
+            { "sub_if",    "-",   "integer", "float",   "float" },
+            { "sub_fi",    "-",   "float",   "integer", "float" },
             { "sub_ff",    "-",   "float",   "float",   "float" },
+
             { "mul_ii",    "*",   "integer", "integer", "integer" },
+            { "mul_if",    "*",   "integer", "float",   "float" },
+            { "mul_fi",    "*",   "float",   "integer", "float" },
             { "mul_ff",    "*",   "float",   "float",   "float" },
+
+            { "mod_ii",    "%",   "integer", "integer", "integer" },
+            -- NYI { "mod_if",    "%",   "integer", "float",   "float" },
+            -- NYI { "mod_fi",    "%",   "float",   "integer", "float" },
+            -- NYI { "mod_ff",    "%",   "float",   "float",   "float" },
+
             { "fltdiv_ii", "/",   "integer", "integer", "float" },
             { "fltdiv_ff", "/",   "float",   "float",   "float" },
+
             { "band",      "&",   "integer", "integer", "integer" },
             { "bor",       "|",   "integer", "integer", "integer" },
             { "bxor",      "~",   "integer", "integer", "integer" },
+
             { "lshift",    "<<",  "integer", "integer", "integer" },
             { "rshift",    ">>",  "integer", "integer", "integer" },
-            { "mod_ii",    "%",   "integer", "integer", "integer" },
+
             { "intdiv_ii", "//",  "integer", "integer", "integer" },
+            { "intdiv_if", "//",  "integer", "float",   "float" },
+            { "intdiv_fi", "//",  "float",   "integer", "float" },
             { "intdiv_ff", "//",  "float",   "float",   "float" },
+
+            { "pow_ii",    "^",   "integer", "integer", "float" },
             { "pow_ff",    "^",   "float",   "float",   "float" },
+
             { "eq_ii",     "==",  "integer", "integer", "boolean" },
             { "ne_ii",     "~=",  "integer", "integer", "boolean" },
             { "lt_ii",     "<",   "integer", "integer", "boolean" },
             { "gt_ii",     ">",   "integer", "integer", "boolean" },
             { "le_ii",     "<=",  "integer", "integer", "boolean" },
             { "ge_ii",     ">=",  "integer", "integer", "boolean" },
+
+            { "eq_ff",     "==",  "float",   "float",   "boolean" },
+            { "ne_ff",     "~=",  "float",   "float",   "boolean" },
+            { "lt_ff",     "<",   "float",   "float",   "boolean" },
+            { "gt_ff",     ">",   "float",   "float",   "boolean" },
+            { "le_ff",     "<=",  "float",   "float",   "boolean" },
+            { "ge_ff",     ">=",  "float",   "float",   "boolean" },
+
+            -- NYI { "eq_ss",     "==",  "string",  "string",  "boolean" },
+            -- NYI { "ne_ss",     "~=",  "string",  "string",  "boolean" },
+            -- NYI { "lt_ss",     "<",   "string",  "string",  "boolean" },
+            -- NYI { "gt_ss",     ">",   "string",  "string",  "boolean" },
+            -- NYI { "le_ss",     "<=",  "string",  "string",  "boolean" },
+            -- NYI { "ge_ss",     ">=",  "string",  "string",  "boolean" },
+
+            -- NYI { "eq_bb",     "==",  "boolean",   "boolean",   "boolean" },
+            -- NYI { "ne_bb",     "~=",  "boolean",   "boolean",   "boolean" },
+
+            -- NYI { "eq_fsfs",   "==",  "{boolean}", "{boolean}", "boolean" },
+            -- NYI { "ne_fsfs",   "~=",  "{boolean}", "{boolean}", "boolean" },
+
             { "and_bb",    "and", "boolean", "boolean", "boolean" },
             { "or_bb",     "or",  "boolean", "boolean", "boolean" },
+
             { "concat_ss", "..",  "string",  "string",  "string" },
         }
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -291,7 +291,6 @@ describe("Pallene coder /", function()
         end)
     end)
 
-
     describe("Operators /", function()
         local pallene_program_parts = {}
         local lua_tests = {}
@@ -573,20 +572,6 @@ describe("Pallene coder /", function()
                 end
                 return res
             end
-
-            --------------------
-
-            local i = 0
-
-            function next(): integer
-                i = i + 1
-                return i
-            end
-
-            function stat_call(): integer
-                next()
-                return next()
-            end
         ]]))
 
         it("Block, Assign, Decl", function()
@@ -623,10 +608,6 @@ describe("Pallene coder /", function()
 
         it("For loop (float) (going down)", function()
             run_test([[ assert(720.0 == test.factorial_float_for_dec(6.0)) ]])
-        end)
-
-        it("Call", function()
-            run_test([[ assert(2 == test.stat_call()) ]])
         end)
     end)
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -320,6 +320,28 @@ describe("Pallene coder /", function()
             })
         end
 
+        local function optest(name)
+            run_test(lua_tests[name])
+        end
+
+        setup_unop("neg_int" , "-",   "integer", "integer")
+        setup_unop("bnot"    , "~",   "integer", "integer")
+        setup_unop("not_bool", "not", "boolean", "boolean")
+
+        setup(compile(table.concat(pallene_program_parts, "\n")))
+
+        it("integer unary (-)",  function() optest("neg_int") end)
+        it("integer unary (~)",  function() optest("bnot") end)
+        it("boolean (not)",      function() optest("not_bool") end)
+
+
+
+    end)
+
+    describe("Operators /", function()
+        local pallene_program_parts = {}
+        local lua_tests = {}
+
         local function setup_binop(name, op, typ1, typ2, rtyp)
             table.insert(pallene_program_parts, util.render([[
                 function $name (x: $typ1, y:$typ2): $rtyp
@@ -351,10 +373,6 @@ describe("Pallene coder /", function()
             run_test(lua_tests[name])
         end
 
-        setup_unop("neg_int" , "-",   "integer", "integer")
-        setup_unop("bnot"    , "~",   "integer", "integer")
-        setup_unop("not_bool", "not", "boolean", "boolean")
-
         setup_binop("add_int"       , "+",   "integer", "integer", "integer")
         setup_binop("add_float"     , "+",   "float",   "float",   "float")
         setup_binop("sub_int"       , "-",   "integer", "integer", "integer")
@@ -383,10 +401,6 @@ describe("Pallene coder /", function()
         setup_binop("concat_str"    , "..",  "string",  "string",  "string")
 
         setup(compile(table.concat(pallene_program_parts, "\n")))
-
-        it("integer unary (-)",  function() optest("neg_int") end)
-        it("integer unary (~)",  function() optest("bnot") end)
-        it("boolean (not)",      function() optest("not_bool") end)
 
         it("integer (+)",        function() optest("add_int") end)
         it("float (+)",          function() optest("add_float") end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -231,6 +231,67 @@ describe("Pallene coder /", function()
         end)
     end)
 
+    describe("First class functions /", function()
+        setup(compile([[
+            function inc(x:integer): integer   return x + 1   end
+            function dec(x:integer): integer   return x - 1   end
+
+            --------
+
+            function call(
+                f : integer -> integer,
+                x : integer
+            ) :  integer
+                return f(x)
+            end
+
+            --------
+
+            local f: integer->integer = inc
+
+            function setf(g:integer->integer): ()
+                f = g
+            end
+
+            function getf(): integer->integer
+                return f
+            end
+
+            function callf(x:integer): integer
+                return f(x)
+            end
+        ]]))
+
+        it("Object identity", function()
+            run_test([[
+                assert(test.getf() == test.getf())
+            ]])
+        end)
+
+        it("Can call non-static functions", function()
+            run_test([[
+                local f = function(x) return x * 20 end
+                assert(200 == test.call(f, 10))
+                assert(201 == test.call(test.inc, 200))
+            ]])
+        end)
+
+        it("Can call global function vars", function()
+            run_test([[
+                assert(11 == test.callf(10))
+            ]])
+        end)
+
+        it("Can get, set, and call global function vars", function()
+            run_test([[
+                assert(11 == test.getf()(10))
+                test.setf(test.dec)
+                assert( 9 == test.getf()(10))
+            ]])
+        end)
+    end)
+
+
     describe("Operators /", function()
         local pallene_program_parts = {}
         local lua_tests = {}
@@ -690,68 +751,6 @@ describe("Pallene coder /", function()
                         assert(10*j == arr[j])
                     end
                 end
-            ]])
-        end)
-    end)
-
-    describe("First class functions /", function()
-        setup(compile([[
-            function inc(x:integer): integer
-                return x + 1
-            end
-
-            function dec(x:integer): integer
-                return x - 1
-            end
-
-            local f: integer->integer = inc
-
-            function setf(g:integer->integer): ()
-                f = g
-            end
-
-            function getf(): integer->integer
-                return f
-            end
-
-            function callf(x:integer): integer
-                return f(x)
-            end
-
-            --------
-
-            function call(
-                f : integer -> integer,
-                x : integer
-            ) :  integer
-                return f(x)
-            end
-        ]]))
-
-        it("Object identity", function()
-            run_test([[
-                assert(test.getf() == test.getf())
-            ]])
-        end)
-
-        it("Can get and set global function vars", function()
-            run_test([[
-                assert(11 == test.getf()(10))
-                test.setf(test.dec)
-                assert( 9 == test.getf()(10))
-            ]])
-        end)
-
-        it("Can call global function vars", function()
-            run_test([[
-                assert(11 == test.callf(10))
-            ]])
-        end)
-
-        it("Can call Lua functions", function()
-            run_test([[
-                local f = function(x) return x * 20 end
-                assert(200 == test.call(f, 10))
             ]])
         end)
     end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -172,16 +172,8 @@ describe("Pallene coder /", function()
 
             -----------
 
-            local x = 10
-
-            function incr_x(): ()
-                x = x + 1
-            end
-
-            function next_x(): integer
-                incr_x()
-                return x
-            end
+            function skip_a() end
+            function skip_b() skip_a(); skip_a() end
         ]]))
 
         it("no parameters", function()
@@ -201,7 +193,7 @@ describe("Pallene coder /", function()
         end)
 
         it("void functions", function()
-            run_test([[ assert(11 == test.next_x()) ]])
+            run_test([[ assert(0 == select("#", test.skip_b())) ]])
         end)
 
         -- Errors

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -125,39 +125,14 @@ describe("Pallene coder /", function()
 
     describe("Literals /", function()
         setup(compile([[
-            function f_nil(): nil
-                return nil
-            end
-
-            function f_true(): boolean
-                return true
-            end
-
-            function f_false(): boolean
-                return false
-            end
-
-            function f_integer(): integer
-                return 17
-            end
-
-            function f_float(): float
-                return 3.14
-            end
-
-            function f_string(): string
-                return "Hello World"
-            end
-
-            ------------
-
-            function pi(): float
-                return 3.141592653589793
-            end
-
-            function e(): float
-                return 2.718281828459045
-            end
+            function f_nil(): nil          return nil  end
+            function f_true(): boolean     return true end
+            function f_false(): boolean    return false end
+            function f_integer(): integer  return 17 end
+            function f_float(): float      return 3.14 end
+            function f_string(): string    return "Hello World" end
+            function pi(): float           return 3.141592653589793 end
+            function e(): float            return 2.718281828459045 end
         ]]))
 
         it("nil", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -291,20 +291,29 @@ describe("Pallene coder /", function()
         end)
     end)
 
-    describe("Operators /", function()
-        local pallene_program_parts = {}
-        local lua_tests = {}
+    describe("Unary Operators /", function()
 
-        local function setup_unop(name, op, typ, rtyp)
-            table.insert(pallene_program_parts, util.render([[
+        local tests = {
+            { "neg_i", "-",   "integer", "integer" },
+            { "bnot",  "~",   "integer", "integer" },
+            { "not_b", "not", "boolean", "boolean" },
+        }
+
+        local pallene_code = {}
+        local test_scripts = {}
+
+        for i, test in ipairs(tests) do
+            local name, op, typ, rtyp = test[1], test[2], test[3], test[4]
+
+            pallene_code[i] = util.render([[
                 function $name (x: $typ): $rtyp
                     return $op x
                 end
             ]], {
                 name = name, typ = typ, rtyp = rtyp, op = op,
-            }))
+            })
 
-            lua_tests[name] = util.render([[
+            test_scripts[name] = util.render([[
                 local test_op = require "spec.coder_test_operators"
                 test_op.check_unop(
                     $op_str,
@@ -320,38 +329,61 @@ describe("Pallene coder /", function()
             })
         end
 
-        local function optest(name)
-            run_test(lua_tests[name])
+        setup(compile(table.concat(pallene_code, "\n")))
+
+        for _, test in ipairs(tests) do
+            local name = test[1]
+            it(name, function() run_test(test_scripts[name]) end)
         end
-
-        setup_unop("neg_int" , "-",   "integer", "integer")
-        setup_unop("bnot"    , "~",   "integer", "integer")
-        setup_unop("not_bool", "not", "boolean", "boolean")
-
-        setup(compile(table.concat(pallene_program_parts, "\n")))
-
-        it("integer unary (-)",  function() optest("neg_int") end)
-        it("integer unary (~)",  function() optest("bnot") end)
-        it("boolean (not)",      function() optest("not_bool") end)
-
-
-
     end)
 
-    describe("Operators /", function()
-        local pallene_program_parts = {}
-        local lua_tests = {}
+    describe("Binary Operators /", function()
 
-        local function setup_binop(name, op, typ1, typ2, rtyp)
-            table.insert(pallene_program_parts, util.render([[
+        local tests = {
+            { "add_ii",    "+",   "integer", "integer", "integer" },
+            { "add_ff",    "+",   "float",   "float",   "float" },
+            { "sub_ii",    "-",   "integer", "integer", "integer" },
+            { "sub_ff",    "-",   "float",   "float",   "float" },
+            { "mul_ii",    "*",   "integer", "integer", "integer" },
+            { "mul_ff",    "*",   "float",   "float",   "float" },
+            { "fltdiv_ii", "/",   "integer", "integer", "float" },
+            { "fltdiv_ff", "/",   "float",   "float",   "float" },
+            { "band",      "&",   "integer", "integer", "integer" },
+            { "bor",       "|",   "integer", "integer", "integer" },
+            { "bxor",      "~",   "integer", "integer", "integer" },
+            { "lshift",    "<<",  "integer", "integer", "integer" },
+            { "rshift",    ">>",  "integer", "integer", "integer" },
+            { "mod_ii",    "%",   "integer", "integer", "integer" },
+            { "intdiv_ii", "//",  "integer", "integer", "integer" },
+            { "intdiv_ff", "//",  "float",   "float",   "float" },
+            { "pow_ff",    "^",   "float",   "float",   "float" },
+            { "eq_ii",     "==",  "integer", "integer", "boolean" },
+            { "ne_ii",     "~=",  "integer", "integer", "boolean" },
+            { "lt_ii",     "<",   "integer", "integer", "boolean" },
+            { "gt_ii",     ">",   "integer", "integer", "boolean" },
+            { "le_ii",     "<=",  "integer", "integer", "boolean" },
+            { "ge_ii",     ">=",  "integer", "integer", "boolean" },
+            { "and_bb",    "and", "boolean", "boolean", "boolean" },
+            { "or_bb",     "or",  "boolean", "boolean", "boolean" },
+            { "concat_ss", "..",  "string",  "string",  "string" },
+        }
+
+        local pallene_code = {}
+        local test_scripts = {}
+
+        for i, test in ipairs(tests) do
+            local name, op, typ1, typ2, rtyp =
+                test[1], test[2], test[3], test[4], test[5]
+
+            pallene_code[i] = util.render([[
                 function $name (x: $typ1, y:$typ2): $rtyp
                     return x ${op} y
                 end
             ]], {
                 name = name, typ1 = typ1, typ2=typ2, rtyp = rtyp, op = op,
-            }))
+            })
 
-            lua_tests[name] = util.render([[
+            test_scripts[name] = util.render([[
                 local test_op = require "spec.coder_test_operators"
                 test_op.check_binop(
                     $op_str,
@@ -369,140 +401,85 @@ describe("Pallene coder /", function()
             })
         end
 
-        local function optest(name)
-            run_test(lua_tests[name])
+        setup(compile(table.concat(pallene_code, "\n")))
+
+        for _, test in ipairs(tests) do
+            local name = test[1]
+            it(name, function() run_test(test_scripts[name]) end)
         end
-
-        setup_binop("add_int"       , "+",   "integer", "integer", "integer")
-        setup_binop("add_float"     , "+",   "float",   "float",   "float")
-        setup_binop("sub_int"       , "-",   "integer", "integer", "integer")
-        setup_binop("sub_float"     , "-",   "float",   "float",   "float")
-        setup_binop("mul_int"       , "*",   "integer", "integer", "integer")
-        setup_binop("mul_float"     , "*",   "float",   "float",   "float")
-        setup_binop("floatdiv_int"  , "/",   "integer", "integer", "float")
-        setup_binop("floatdiv_float", "/",   "float",   "float",   "float")
-        setup_binop("band"          , "&",   "integer", "integer", "integer")
-        setup_binop("bor"           , "|",   "integer", "integer", "integer")
-        setup_binop("bxor"          , "~",   "integer", "integer", "integer")
-        setup_binop("lshift"        , "<<",  "integer", "integer", "integer")
-        setup_binop("rshift"        , ">>",  "integer", "integer", "integer")
-        setup_binop("mod_int"       , "%",   "integer", "integer", "integer")
-        setup_binop("intdiv_int"    , "//",  "integer", "integer", "integer")
-        setup_binop("intdiv_float"  , "//",  "float",   "float",   "float")
-        setup_binop("pow_float"     , "^",   "float",   "float",   "float")
-        setup_binop("eq_int"        , "==",  "integer", "integer", "boolean")
-        setup_binop("neq_int"       , "~=",  "integer", "integer", "boolean")
-        setup_binop("lt_int"        , "<",   "integer", "integer", "boolean")
-        setup_binop("gt_int"        , ">",   "integer", "integer", "boolean")
-        setup_binop("le_int"        , "<=",  "integer", "integer", "boolean")
-        setup_binop("ge_int"        , ">=",  "integer", "integer", "boolean")
-        setup_binop("and_bool"      , "and", "boolean", "boolean", "boolean")
-        setup_binop("or_bool"       , "or",  "boolean", "boolean", "boolean")
-        setup_binop("concat_str"    , "..",  "string",  "string",  "string")
-
-        setup(compile(table.concat(pallene_program_parts, "\n")))
-
-        it("integer (+)",        function() optest("add_int") end)
-        it("float (+)",          function() optest("add_float") end)
-        it("integer (-)",        function() optest("sub_int")  end)
-        it("float (-)",          function() optest("sub_float")  end)
-        it("integer (*)",        function() optest("mul_int")  end)
-        it("float (*)",          function() optest("mul_float") end)
-        it("integer (/)",        function() optest("floatdiv_int") end)
-        it("float (/)",          function() optest("floatdiv_float") end)
-        it("binary and (&)",     function() optest("band") end)
-        it("binary or (|)",      function() optest("bor") end)
-        it("binary xor (~)",     function() optest("bxor") end)
-        it("left shift (<<)",    function() optest("lshift")  end)
-        it("right shift (>>)",   function() optest("rshift") end)
-        it("integer (%)",        function() optest("mod_int") end)
-        it("integer (//)",       function() optest("intdiv_int") end)
-        it("float (//)",         function() optest("intdiv_float") end)
-        it("float (^)",          function() optest("pow_float") end)
-        it("integer (==)",       function() optest("eq_int") end)
-        it("integer (~=)",       function() optest("neq_int") end)
-        it("integer (<)",        function() optest("lt_int") end)
-        it("integer (>)",        function() optest("gt_int") end)
-        it("integer (<=)",       function() optest("le_int") end)
-        it("integer (>=)",       function() optest("ge_int") end)
-        it("boolean (and)",      function() optest("and_bool") end)
-        it("boolean (or)",       function() optest("or_bool") end)
-        it("concat (..)",        function() optest("concat_str") end)
     end)
 
     describe("Coercions with dynamic type /", function()
 
         local tests = {
-            ["boolean"]  = {typ = "boolean",         value = "true"},
-            ["integer"]  = {typ = "integer",         value = "17"},
-            ["float"]    = {typ = "float",           value = "3.14"},
-            ["string"]   = {typ = "string",          value = "'hello'"},
-            ["function"] = {typ = "integer->string", value = "tostring"},
-            ["array"]    = {typ = "{integer}",       value = "{10,20}"},
-            ["record"]   = {typ = "Empty",           value = "test.new_empty()"},
-            ["value"]    = {typ = "value",           value = "17"},
+            { "boolean"  , "boolean",         "true"},
+            { "integer"  , "integer",         "17"},
+            { "float"    , "float",           "3.14"},
+            { "string"   , "string",          "'hello'"},
+            { "function" , "integer->string", "tostring"},
+            { "array"    , "{integer}",       "{10,20}"},
+            { "record"   , "Empty",           "test.new_empty()"},
+            { "value"    , "value",           "17"},
         }
 
-        local program_parts = {}
-        table.insert(program_parts,[[
+        local record_decls = [[
             record Empty
             end
             function new_empty(): Empty
                 return {}
             end
-        ]])
-        for name, test in pairs(tests) do
-            table.insert(program_parts, util.render([[
-                function from_${NAME}(x: ${T}): value
+        ]]
+
+        local pallene_code = {}
+        local test_to      = {}
+        local test_from    = {}
+
+        for i, test in pairs(tests) do
+            local name, typ, value = test[1], test[2], test[3]
+
+            pallene_code[i] = util.render([[
+                function from_${name}(x: ${typ}): value
                     return (x as value)
                 end
-                function to_${NAME}(x: value): ${T}
-                    return (x as ${T})
+                function to_${name}(x: value): ${typ}
+                    return (x as ${typ})
                 end
             ]], {
-                NAME = name,
-                T = test.typ,
-            }))
-        end
+                name = name,
+                typ = typ,
+            })
 
-        setup(compile(table.concat(program_parts, "\n")))
-
-
-        local function test_to_value(name)
-            run_test(util.render([[
-                local x = ${VALUE}
-                assert(x == test.from_${NAME}(x))
+            test_to[name] = util.render([[
+                local x = ${value}
+                assert(x == test.from_${name}(x))
             ]], {
-                NAME = name,
-                VALUE = tests[name].value
-            }))
-        end
+                name = name,
+                value = value
+            })
 
-        local function test_from_value(name)
-            run_test(util.render([[
-                local x = ${VALUE}
-                assert(x == test.to_${NAME}(x))
+            test_from[name] = util.render([[
+                local x = ${value}
+                assert(x == test.from_${name}(x))
             ]], {
-                NAME = name,
-                VALUE = tests[name].value
-            }))
+                name = name,
+                value = value
+            })
         end
 
-        it("boolean->value (as)",  function() test_to_value("boolean") end)
-        it("integer->value (as)",  function() test_to_value("integer") end)
-        it("float->value (as)",    function() test_to_value("float") end)
-        it("string->value (as)",   function() test_to_value("string") end)
-        it("function->value (as)", function() test_to_value("function") end)
-        it("array->value (as)",    function() test_to_value("array") end)
-        it("record->value (as)",   function() test_to_value("record") end)
+        setup(compile(
+            record_decls .. "\n" ..
+            table.concat(pallene_code, "\n")
+        ))
 
-        it("value->boolean (as)",  function() test_from_value("boolean") end)
-        it("value->integer (as)",  function() test_from_value("integer") end)
-        it("value->float (as)",    function() test_from_value("float") end)
-        it("value->string (as)",   function() test_from_value("string") end)
-        it("value->function (as)", function() test_from_value("function") end)
-        it("value->array (as)",    function() test_from_value("array") end)
-        it("value->record (as)",   function() test_from_value("record") end)
+        for _, test in ipairs(tests) do
+            local name = test[1]
+            it(name .. "->value", function() run_test(test_to[name]) end)
+        end
+
+        for _, test in ipairs(tests) do
+            local name = test[1]
+            it("value->" .. name, function() run_test(test_from[name]) end)
+        end
 
         it("detects downcast error", function()
             run_test([[

--- a/spec/coder_test_operators.lua
+++ b/spec/coder_test_operators.lua
@@ -1,4 +1,5 @@
--- Used in checker_spec
+-- Used by the test scripts in coder_spec, to check that Pallene operations
+-- compute the same results as their Lua analogues.
 
 local coder_test_operators = {}
 
@@ -27,11 +28,11 @@ local function are_same(a, b)
 end
 
 local function check(f_lua, f_pallene, ...)
-    local ok_lua,   r_lua   = pcall(f_lua, ...)
+    local ok_lua,     r_lua     = pcall(f_lua, ...)
     local ok_pallene, r_pallene = pcall(f_pallene, ...)
     if ok_lua ~= ok_pallene then
         return false, string.format("lua %s but pallene %s",
-            (ok_lua   and "didn't crash" or "crashed"),
+            (ok_lua     and "didn't crash" or "crashed"),
             (ok_pallene and "didn't crash" or "crashed"))
     end
     if ok_lua and ok_pallene and not are_same(r_lua, r_pallene) then

--- a/spec/coder_test_operators.lua
+++ b/spec/coder_test_operators.lua
@@ -17,6 +17,10 @@ local values = {
         "c\0d",
         "ABCDEFGHIJKLMNOPQRSTabcdefghilklmnopqrst", -- long string >= 40 chars
     },
+    ["{float}"] = {
+        {1.0},
+        {2.0},
+    }
 }
 
 local function isnan(x)

--- a/spec/coder_test_operators.lua
+++ b/spec/coder_test_operators.lua
@@ -17,10 +17,6 @@ local values = {
         "c\0d",
         "ABCDEFGHIJKLMNOPQRSTabcdefghilklmnopqrst", -- long string >= 40 chars
     },
-    ["{float}"] = {
-        {1.0},
-        {2.0},
-    }
 }
 
 local function isnan(x)

--- a/spec/scope_analysis_spec.lua
+++ b/spec/scope_analysis_spec.lua
@@ -1,9 +1,6 @@
 local driver = require "pallene.driver"
 local util = require "pallene.util"
 
-local ast = require "pallene.ast"
-local builtins = require "pallene.builtins"
-
 local function run_scope_analysis(code)
     assert(util.set_file_contents("test.pln", code))
     local prog_ast, errs = driver.test_ast("scope_analysis", "test.pln")
@@ -14,77 +11,6 @@ describe("Scope analysis: ", function()
 
     teardown(function()
         os.remove("test.pln")
-    end)
-
-    it("global variables work", function()
-        local prog_ast, errs = run_scope_analysis([[
-            local x: integer = 10
-            function fn(): integer
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1], -- x
-            prog_ast[2].block.stats[1].exps[1].var._decl)
-    end)
-
-    it("function parameters work", function()
-        local prog_ast, errs = run_scope_analysis([[
-            function fn(x: integer): integer
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1].params[1], -- x
-            prog_ast[1].block.stats[1].exps[1].var._decl)
-    end)
-
-    it("local variables work", function()
-        local prog_ast, errs = run_scope_analysis([[
-            function fn(): integer
-                local x = 17
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1].block.stats[1].decl, -- x
-            prog_ast[1].block.stats[2].exps[1].var._decl)
-    end)
-
-    it("functions can be recursive", function()
-        local prog_ast, errs = run_scope_analysis([[
-            function fac(n: integer): integer
-                if n == 0 then
-                    return 1
-                else
-                    return n * fac(n-1)
-                end
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1], -- fac
-            prog_ast[1].block.stats[1].else_.stats[1].exps[1].rhs.exp.var._decl)
-    end)
-
-    it("builtins work", function()
-        local prog_ast, errs = run_scope_analysis([[
-            function fn(xs:{integer})
-                table_insert(xs, 17)
-            end
-        ]])
-        assert(prog_ast, errs)
-        local exp = prog_ast[1].block.stats[1].call_exp
-        assert.are.equal("ast.Exp.CallFunc", exp._tag)
-        local f_exp = exp.exp
-        assert.are.equal("ast.Exp.Var", f_exp._tag)
-        local var = f_exp.var
-        assert.are.equal("ast.Var.Name", var._tag)
-        local decl = var._decl
-        assert.are_equal(builtins.table_insert, decl)
     end)
 
     it("forbids variables from being used before they are defined", function()
@@ -126,44 +52,6 @@ describe("Scope analysis: ", function()
         assert.match("variable 'x' is not declared", errs)
     end)
 
-    it("local variable scope doesn't shadow its type annotation", function()
-        local prog_ast, errs = run_scope_analysis([[
-            record x
-                x: integer
-                y: integer
-            end
-
-            function fn(): integer
-                local x: x = { x=1, y=2 }
-                return x.x
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1], -- global x
-            prog_ast[2].block.stats[1].decl.type._decl)
-        assert.are.equal(
-            prog_ast[2].block.stats[1].decl, -- local x
-            prog_ast[2].block.stats[2].exps[1].var.exp.var._decl)
-    end)
-
-    it("local variable scope doesn't shadow its initializer", function()
-        local prog_ast, errs = run_scope_analysis([[
-            local x = 17
-            function fn(): integer
-                local x = x + 1
-                return x
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1], -- global x
-            prog_ast[2].block.stats[1].exp.lhs.var._decl)
-        assert.are.equal(
-            prog_ast[2].block.stats[1].decl, -- local x
-            prog_ast[2].block.stats[2].exps[1].var._decl)
-    end)
-
     it("repeat-until scope includes the condition", function()
         local prog_ast, errs = run_scope_analysis([[
             function fn(): integer
@@ -179,67 +67,6 @@ describe("Scope analysis: ", function()
         assert.are.equal(
             prog_ast[1].block.stats[2].block.stats[2].decl, -- local limit
             prog_ast[1].block.stats[2].condition.lhs.var._decl)
-    end)
-
-    it("for loop variable scope doesn't shadow its type annotation", function()
-        local prog_ast, errs = run_scope_analysis([[
-            record x
-                x: integer
-                y: integer
-            end
-            function fn(): integer
-                for x: x = 1, 10 do
-                   return x
-                end
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1], -- global x
-            prog_ast[2].block.stats[1].decl.type._decl)
-        assert.are.equal(
-            prog_ast[2].block.stats[1].decl, -- local x
-            prog_ast[2].block.stats[1].block.stats[1].exps[1].var._decl)
-    end)
-
-    it("for loop variable scope doesn't shadow its initializers", function()
-        local prog_ast, errs = run_scope_analysis([[
-            function fn(): integer
-                local x = 10
-                for x: integer = x, x, x do
-                   return x
-                end
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1].block.stats[1].decl, -- local x
-            prog_ast[1].block.stats[2].start.var._decl)
-        assert.are.equal(
-            prog_ast[1].block.stats[1].decl,
-            prog_ast[1].block.stats[2].limit.var._decl)
-        assert.are.equal(
-            prog_ast[1].block.stats[1].decl,
-            prog_ast[1].block.stats[2].step.var._decl)
-        assert.are.equal(
-            prog_ast[1].block.stats[2].decl, -- for x
-            prog_ast[1].block.stats[2].block.stats[1].exps[1].var._decl)
-    end)
-
-    it("allows recursive functions", function()
-        local prog_ast, errs = run_scope_analysis([[
-            local function fat(n: integer): integer
-                if n == 0 then
-                    return 1
-                else
-                    return n * fat(n - 1)
-                end
-            end
-        ]])
-        assert(prog_ast, errs)
-        assert.are.equal(
-            prog_ast[1], -- fat
-            prog_ast[1].block.stats[1].else_.stats[1].exps[1].rhs.exp.var._decl)
     end)
 
     it("forbids mutually recursive definitions", function()


### PR DESCRIPTION
As previously discussed the first step towards introducing the new IR is to move all of the non-error tests from scope_analysis_spec and checker_spec into coder_spec. This means that there should be no unit tests left after the parser that inspect the structure of the program AST, and that we are now free to change our internal representations without breaking tests.

In the process I discovered a bug with our implementation of repeat-until loops. It used to pass the type checker but fail at code generation. The fix is a bit ugly, but the new IR should take care of that soon enough.

In addition to that, I also could not resist reorganizing and cleaning up coder_spec while I was working on it. This is why this PR is so big.

----

By the way, it seems that Travis is currently having trouble building the project. It complains that busted cannot be installed. I would appreciate if you could pull and test the changes in your own machine for now.