### PR TITLE
Refactor type checker using proper bidirectional type inference

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -12,10 +12,9 @@ local check_type
 local check_top_level
 local check_decl
 local check_stat
---local check_then
 local check_var
-local check_exp
---local check_field
+local check_exp_synthesize
+local check_exp_verify
 
 -- Type-check a Pallene module
 --
@@ -45,42 +44,6 @@ local function type_error(loc, fmt, ...)
     coroutine.yield(err_msg)
 end
 
--- Checks if two types are the same, and raises an error message otherwise
---   loc: location of the term that is being compared
---   expected: type that is expected
---   found: type that was actually present
---   errmsg_fmt: format string describing what part of the program is
---               responsible for this type check
---   ...: arguments to the "errmsg_fmt" format string
-local function check_match(loc, expected, found, errmsg_fmt, ...)
-    if not types.equals(expected, found) then
-        local msg = string.format(
-            "expected %s but found %s in %s",
-            types.tostring(expected),
-            types.tostring(found),
-            string.format(errmsg_fmt, ...))
-        type_error(loc, msg)
-    end
-end
-
-local function try_coerce(exp, expected, errmsg_fmt, ...)
-    local found = exp._type
-    if types.equals(found, expected) then
-        return exp
-    elseif types.consistent(found, expected) then
-        local cast = ast.Exp.Cast(exp.loc, exp, false)
-        cast._type = expected
-        return cast
-    else
-        local msg = string.format(
-            "expected %s but found %s in %s",
-            types.tostring(expected),
-            types.tostring(found),
-            string.format(errmsg_fmt, ...))
-        type_error(exp.loc, msg)
-    end
-end
-
 local function is_numeric_type(typ)
     return typ._tag == "types.T.Integer" or typ._tag == "types.T.Float"
 end
@@ -91,7 +54,7 @@ local function coerce_numeric_exp_to_float(exp)
         name._decl = builtins.tofloat
         local tofloat = ast.Exp.Var(false, name)
         local call = ast.Exp.CallFunc(false, tofloat, {exp})
-        check_exp(call, types.T.Float())
+        check_exp_synthesize(call)
         return call
     elseif exp._type._tag == "types.T.Float" then
         return exp
@@ -226,14 +189,12 @@ check_top_level = function(tl_node)
     elseif tag == "ast.Toplevel.Var" then
         if tl_node.decl.type then
             tl_node._type = check_type(tl_node.decl.type)
-            check_exp(tl_node.value, tl_node._type)
-            check_match(tl_node.loc,
-                tl_node._type, tl_node.value._type,
+            tl_node.value = check_exp_verify(tl_node.value, tl_node._type,
                 "declaration of module variable %s", tl_node.decl.name)
         else
-            check_exp(tl_node.value, false)
-            tl_node._type = tl_node.value._type
+            check_exp_synthesize(tl_node.value)
         end
+        tl_node._type = tl_node.value._type
 
     elseif tag == "ast.Toplevel.Func" then
         if #tl_node.ret_types >= 2 then
@@ -290,11 +251,10 @@ check_stat = function(stat, ret_types)
     if     tag == "ast.Stat.Decl" then
         if stat.decl.type then
             check_decl(stat.decl)
-            check_exp(stat.exp, stat.decl._type)
-            stat.exp = try_coerce(stat.exp, stat.decl._type,
+            stat.exp = check_exp_verify(stat.exp, stat.decl._type,
                 "declaration of local variable %s", stat.decl.name)
         else
-            check_exp(stat.exp, false)
+            check_exp_synthesize(stat.exp)
             stat.decl._type = stat.exp._type
             check_decl(stat.decl)
         end
@@ -305,9 +265,8 @@ check_stat = function(stat, ret_types)
         end
 
     elseif tag == "ast.Stat.While" then
-        check_exp(stat.condition, false)
-        check_match(stat.condition.loc,
-            types.T.Boolean(), stat.condition._type,
+        stat.condition = check_exp_verify(
+            stat.condition, types.T.Boolean(),
             "while loop condition")
         check_stat(stat.block, ret_types)
 
@@ -315,62 +274,53 @@ check_stat = function(stat, ret_types)
         for _, inner_stat in ipairs(stat.block.stats) do
             check_stat(inner_stat, ret_types)
         end
-        check_exp(stat.condition, false)
-        check_match(stat.condition.loc,
-            types.T.Boolean(), stat.condition._type,
+        stat.condition = check_exp_verify(
+            stat.condition, types.T.Boolean(),
             "repeat-until loop condition")
 
     elseif tag == "ast.Stat.For" then
+
         if stat.decl.type then
             check_decl(stat.decl)
+            stat.start = check_exp_verify(stat.start, stat.decl._type,
+                "numeric for-loop initializer")
         else
-            stat.decl._type = false
-        end
-
-        check_exp(stat.start, stat.decl._type)
-        check_exp(stat.limit, stat.decl._type)
-        if stat.step then
-            check_exp(stat.step, stat.decl._type)
-        end
-        if not stat.decl.type then
+            check_exp_synthesize(stat.start)
             stat.decl._type = stat.start._type
         end
+        local loop_type = stat.decl._type
 
-        if     stat.decl._type._tag == "types.T.Integer" then
-            if not stat.step then
-                stat.step = ast.Exp.Integer(stat.limit.loc, 1)
-                stat.step._type = types.T.Integer()
-            end
-        elseif stat.decl._type._tag == "types.T.Float" then
-            if not stat.step then
-                stat.step = ast.Exp.Float(stat.limit.loc, 1.0)
-                stat.step._type = types.T.Float()
-            end
-        else
+        if  loop_type._tag ~= "types.T.Integer" and
+            loop_type._tag ~= "types.T.Float"
+        then
             type_error(stat.decl.loc,
                 "expected integer or float but found %s in for-loop control variable '%s'",
-                types.tostring(stat.decl._type),
+                types.tostring(loop_type),
                 stat.decl.name)
         end
 
-        check_match(stat.start.loc,
-            stat.decl._type, stat.start._type,
-            "numeric for-loop initializer")
-
-        check_match(stat.limit.loc,
-            stat.decl._type, stat.limit._type,
+        stat.limit = check_exp_verify(stat.limit, loop_type,
             "numeric for-loop limit")
 
-        check_match(stat.step.loc,
-            stat.decl._type, stat.step._type,
-            "numeric for-loop step")
+        if stat.step then
+            stat.step = check_exp_verify(stat.step, loop_type,
+                "numeric for-loop step")
+        else
+            if  loop_type._tag == "types.T.Integer" then
+                stat.step = ast.Exp.Integer(stat.limit.loc, 1)
+            elseif loop_type._tag == "types.T.Float" then
+                stat.step = ast.Exp.Float(stat.limit.loc, 1.0)
+            else
+                error("impossible")
+            end
+            check_exp_synthesize(stat.step)
+        end
 
         check_stat(stat.block, ret_types)
 
     elseif tag == "ast.Stat.Assign" then
         check_var(stat.var)
-        check_exp(stat.exp, stat.var._type)
-        stat.exp = try_coerce(stat.exp, stat.var._type, "assignment")
+        stat.exp = check_exp_verify(stat.exp, stat.var._type, "assignment")
         if stat.var._tag == "ast.Var.Name" and
             stat.var._decl._tag == "ast.Toplevel.Func"
         then
@@ -380,7 +330,7 @@ check_stat = function(stat, ret_types)
         end
 
     elseif tag == "ast.Stat.Call" then
-        check_exp(stat.call_exp, false)
+        check_exp_synthesize(stat.call_exp)
 
     elseif tag == "ast.Stat.Return" then
         assert(#ret_types <= 1)
@@ -391,19 +341,15 @@ check_stat = function(stat, ret_types)
         end
 
         for i = 1, #stat.exps do
-            local exp = stat.exps[i]
-            local ret_type = ret_types[i]
-            check_exp(exp, ret_type)
-            stat.exps[i] = try_coerce(exp, ret_type, "return statement")
+            stat.exps[i] = check_exp_verify(
+                stat.exps[i], ret_types[i],
+                "return statement")
         end
 
     elseif tag == "ast.Stat.If" then
-        local cond = stat.condition
-        check_exp(cond, false)
-        check_match(cond.loc,
-            types.T.Boolean(), cond._type,
+        stat.condition = check_exp_verify(
+            stat.condition, types.T.Boolean(),
             "if statement condition")
-
         check_stat(stat.then_, ret_types)
         check_stat(stat.else_, ret_types)
 
@@ -427,7 +373,7 @@ check_var = function(var)
         end
 
     elseif tag == "ast.Var.Dot" then
-        check_exp(var.exp, false)
+        check_exp_synthesize(var.exp)
         local exp_type = var.exp._type
         if exp_type._tag == "types.T.Record" then
             local field_type = exp_type.field_types[var.name]
@@ -445,28 +391,28 @@ check_var = function(var)
         end
 
     elseif tag == "ast.Var.Bracket" then
-        check_exp(var.t, false)
-        if var.t._type._tag ~= "types.T.Array" then
+        check_exp_synthesize(var.t)
+        local arr_type = var.t._type
+        if arr_type._tag ~= "types.T.Array" then
             type_error(var.t.loc,
                 "expected array but found %s in array indexing",
-                types.tostring(var.t._type))
+                types.tostring(arr_type))
         end
-        var._type = var.t._type.elem
-        check_exp(var.k, false)
-        check_match(var.k.loc,
-            types.T.Integer(), var.k._type,
+        var.k = check_exp_verify(
+            var.k, types.T.Integer(),
             "array indexing")
+        var._type = var.t._type.elem
 
     else
         error("impossible")
     end
 end
 
--- @param type_hint Expected type; Used to infer polymorphic/record constructors.
-check_exp = function(exp, type_hint)
-    assert(type_hint ~= nil)
-
+-- Infers the type of expression @exp
+-- Returns nothing
+check_exp_synthesize = function(exp)
     local tag = exp._tag
+
     if     tag == "ast.Exp.Nil" then
         exp._type = types.T.Nil()
 
@@ -483,105 +429,44 @@ check_exp = function(exp, type_hint)
         exp._type = types.T.String()
 
     elseif tag == "ast.Exp.Initlist" then
-        -- Determining the type for a table initializer *requires* a type hint.
-        -- In theory, we could try to infer the type without a type hint for
-        -- non-empty arrays whose contents are inferrable, but I am not sure
-        -- we should treat that case differently from the others...
-        --
-        if not type_hint then
-            type_error(exp.loc,
-                "missing type hint for array or record initializer")
-        end
-
-        if type_hint._tag == "types.T.Array" then
-            for _, field in ipairs(exp.fields) do
-                if field.name then
-                    type_error(field.loc,
-                        "named field %s in array initializer",
-                        field.name)
-                end
-                local field_type = type_hint.elem
-                check_exp(field.exp, field_type)
-                check_match(field.loc,
-                    field_type, field.exp._type,
-                    "array initializer")
-            end
-
-        elseif type_hint._tag == "types.T.Record" then
-            local initialized_fields = {}
-            for _, field in ipairs(exp.fields) do
-                if not field.name then
-                    type_error(field.loc,
-                        "record initializer has array part")
-                end
-
-                if initialized_fields[field.name] then
-                    type_error(field.loc,
-                        "duplicate field %s in record initializer",
-                        field.name)
-                end
-                initialized_fields[field.name] = true
-
-                local field_type = type_hint.field_types[field.name]
-                if field_type then
-                    check_exp(field.exp, field_type)
-                    check_match(field.loc,
-                        field_type, field.exp._type,
-                        "record initializer")
-                else
-                    type_error(field.loc,
-                        "invalid field %s in record initializer for %s",
-                        field.name, types.tostring(type_hint))
-                end
-            end
-
-            for field_name, _ in pairs(type_hint.field_types) do
-                if not initialized_fields[field_name] then
-                    type_error(exp.loc,
-                        "required field %s is missing from initializer",
-                        field_name)
-                end
-            end
-        else
-            type_error(exp.loc,
-                "type hint for array or record initializer is not an array or record type")
-        end
-        exp._type = type_hint
+        type_error(exp.loc,
+            "missing type hint for array or record initializer")
 
     elseif tag == "ast.Exp.Var" then
         check_var(exp.var)
         exp._type = exp.var._type
 
     elseif tag == "ast.Exp.Unop" then
-        check_exp(exp.exp, false)
+        check_exp_synthesize(exp.exp)
+        local t = exp.exp._type
         local op = exp.op
         if op == "#" then
-            if exp.exp._type._tag ~= "types.T.Array" and exp.exp._type._tag ~= "types.T.String" then
+            if t._tag ~= "types.T.Array" and t._tag ~= "types.T.String" then
                 type_error(exp.loc,
                     "trying to take the length of a %s instead of an array or string",
-                    types.tostring(exp.exp._type))
+                    types.tostring(t))
             end
             exp._type = types.T.Integer()
         elseif op == "-" then
-            if exp.exp._type._tag ~= "types.T.Integer" and exp.exp._type._tag ~= "types.T.Float" then
+            if t._tag ~= "types.T.Integer" and t._tag ~= "types.T.Float" then
                 type_error(exp.loc,
                     "trying to negate a %s instead of a number",
-                    types.tostring(exp.exp._type))
+                    types.tostring(t))
             end
-            exp._type = exp.exp._type
+            exp._type = t
         elseif op == "~" then
-            if exp.exp._type._tag ~= "types.T.Integer" then
+            if t._tag ~= "types.T.Integer" then
                 type_error(exp.loc,
                     "trying to bitwise negate a %s instead of an integer",
-                    types.tostring(exp.exp._type))
+                    types.tostring(t))
             end
             exp._type = types.T.Integer()
         elseif op == "not" then
-            if exp.exp._type._tag ~= "types.T.Boolean" then
+            if t._tag ~= "types.T.Boolean" then
                 -- We are being intentionaly restrictive here w.r.t Lua
                 type_error(exp.loc,
                     "trying to boolean negate a %s instead of a boolean",
-                    types.tostring(exp.exp._type))
+                    types.tostring(t))
             end
             exp._type = types.T.Boolean()
         else
@@ -590,63 +475,65 @@ check_exp = function(exp, type_hint)
 
     elseif tag == "ast.Exp.Concat" then
         for _, inner_exp in ipairs(exp.exps) do
-            check_exp(inner_exp, false)
-            local t_exp = inner_exp._type
-            if t_exp._tag ~= "types.T.String" then
+            check_exp_synthesize(inner_exp)
+            local t = inner_exp._type
+            if t._tag ~= "types.T.String" then
                 type_error(inner_exp.loc,
-                    "cannot concatenate with %s value", types.tostring(t_exp))
+                    "cannot concatenate with %s value", types.tostring(t))
             end
         end
         exp._type = types.T.String()
 
     elseif tag == "ast.Exp.Binop" then
-        check_exp(exp.lhs, false)
-        check_exp(exp.rhs, false)
+        check_exp_synthesize(exp.lhs); local t1 = exp.lhs._type
+        check_exp_synthesize(exp.rhs); local t2 = exp.rhs._type
         local op = exp.op
         if op == "==" or op == "~=" then
-            if (exp.lhs._type._tag == "types.T.Integer" and exp.rhs._type._tag == "types.T.Float") or
-               (exp.lhs._type._tag == "types.T.Float"   and exp.rhs._type._tag == "types.T.Integer") then
+            if (t1._tag == "types.T.Integer" and t2._tag == "types.T.Float") or
+               (t1._tag == "types.T.Float"   and t2._tag == "types.T.Integer") then
                 type_error(exp.loc,
                     "comparisons between float and integers are not yet implemented")
                 -- note: use Lua's implementation of comparison, don't just cast to float
             end
-            if not types.equals(exp.lhs._type, exp.rhs._type) then
+            if not types.equals(t1, t2) then
                 type_error(exp.loc,
                     "cannot compare %s and %s using %s",
-                    types.tostring(exp.lhs._type), types.tostring(exp.rhs._type), op)
+                    types.tostring(t1), types.tostring(t2), op)
             end
             exp._type = types.T.Boolean()
+
         elseif op == "<" or op == ">" or op == "<=" or op == ">=" then
-            if (exp.lhs._type._tag == "types.T.Integer" and exp.rhs._type._tag == "types.T.Integer") or
-               (exp.lhs._type._tag == "types.T.Float"   and exp.rhs._type._tag == "types.T.Float") or
-               (exp.lhs._type._tag == "types.T.String"  and exp.rhs._type._tag == "types.T.String") then
+            if (t1._tag == "types.T.Integer" and t2._tag == "types.T.Integer") or
+               (t1._tag == "types.T.Float"   and t2._tag == "types.T.Float") or
+               (t1._tag == "types.T.String"  and t2._tag == "types.T.String") then
                -- OK
-            elseif (exp.lhs._type._tag == "types.T.Integer" and exp.rhs._type._tag == "types.T.Float") or
-                   (exp.lhs._type._tag == "types.T.Float"   and exp.rhs._type._tag == "types.T.Integer") then
+            elseif (t1._tag == "types.T.Integer" and t2._tag == "types.T.Float") or
+                   (t1._tag == "types.T.Float"   and t2._tag == "types.T.Integer") then
+                -- note: use Lua's implementation of comparison, don't just cast to float
                 type_error(exp.loc,
                     "comparisons between float and integers are not yet implemented")
-                -- note: use Lua's implementation of comparison, don't just cast to float
             else
                 type_error(exp.loc,
                     "cannot compare %s and %s using %s",
-                    types.tostring(exp.lhs._type), types.tostring(exp.rhs._type), op)
+                    types.tostring(t1), types.tostring(t2), op)
             end
             exp._type = types.T.Boolean()
 
         elseif op == "+" or op == "-" or op == "*" or op == "%" or op == "//" then
-            if not is_numeric_type(exp.lhs._type) then
+            if not is_numeric_type(t1) then
                 type_error(exp.loc,
                     "left hand side of arithmetic expression is a %s instead of a number",
-                    types.tostring(exp.lhs._type))
+                    types.tostring(t1))
             end
-            if not is_numeric_type(exp.rhs._type) then
+            if not is_numeric_type(t2) then
                 type_error(exp.loc,
                     "right hand side of arithmetic expression is a %s instead of a number",
-                    types.tostring(exp.rhs._type))
+                    types.tostring(t2))
             end
 
-            if exp.lhs._type._tag == "types.T.Integer" and
-               exp.rhs._type._tag == "types.T.Integer" then
+            if t1._tag == "types.T.Integer" and
+               t2._tag == "types.T.Integer"
+            then
                 exp._type = types.T.Integer()
             else
                 exp.lhs = coerce_numeric_exp_to_float(exp.lhs)
@@ -655,15 +542,15 @@ check_exp = function(exp, type_hint)
             end
 
         elseif op == "/" or op == "^" then
-            if not is_numeric_type(exp.lhs._type) then
+            if not is_numeric_type(t1) then
                 type_error(exp.loc,
                     "left hand side of arithmetic expression is a %s instead of a number",
-                    types.tostring(exp.lhs._type))
+                    types.tostring(t1))
             end
-            if not is_numeric_type(exp.rhs._type) then
+            if not is_numeric_type(t2) then
                 type_error(exp.loc,
                     "right hand side of arithmetic expression is a %s instead of a number",
-                    types.tostring(exp.rhs._type))
+                    types.tostring(t2))
             end
 
             exp.lhs = coerce_numeric_exp_to_float(exp.lhs)
@@ -671,29 +558,31 @@ check_exp = function(exp, type_hint)
             exp._type = types.T.Float()
 
         elseif op == "and" or op == "or" then
-            if exp.lhs._type._tag ~= "types.T.Boolean" then
+            if t1._tag ~= "types.T.Boolean" then
                 type_error(exp.loc,
                     "left hand side of logical expression is a %s instead of a boolean",
-                    types.tostring(exp.lhs._type))
+                    types.tostring(t1))
             end
-            if exp.rhs._type._tag ~= "types.T.Boolean" then
+            if t2._tag ~= "types.T.Boolean" then
                 type_error(exp.loc,
                     "right hand side of logical expression is a %s instead of a boolean",
-                    types.tostring(exp.rhs._type))
+                    types.tostring(t2))
             end
             exp._type = types.T.Boolean()
+
         elseif op == "|" or op == "&" or op == "~" or op == "<<" or op == ">>" then
-            if exp.lhs._type._tag ~= "types.T.Integer" then
+            if t1._tag ~= "types.T.Integer" then
                 type_error(exp.loc,
                     "left hand side of bitwise expression is a %s instead of an integer",
-                    types.tostring(exp.lhs._type))
+                    types.tostring(t1))
             end
-            if exp.rhs._type._tag ~= "types.T.Integer" then
+            if t2._tag ~= "types.T.Integer" then
                 type_error(exp.loc,
                     "right hand side of bitwise expression is a %s instead of an integer",
-                    types.tostring(exp.rhs._type))
+                    types.tostring(t2))
             end
             exp._type = types.T.Integer()
+
         else
             error("impossible")
         end
@@ -702,7 +591,7 @@ check_exp = function(exp, type_hint)
         local f_exp = exp.exp
         local args = exp.args
 
-        check_exp(f_exp, false)
+        check_exp_synthesize(f_exp)
         local f_type = f_exp._type
 
         if f_type._tag == "types.T.Function" then
@@ -712,10 +601,7 @@ check_exp = function(exp, type_hint)
                     #f_type.params, #args)
             end
             for i = 1, math.min(#f_type.params, #args) do
-                local p_type = f_type.params[i]
-                local arg = args[i]
-                check_exp(arg, p_type)
-                args[i] = try_coerce(arg, p_type,
+                args[i] = check_exp_verify(args[i], f_type.params[i],
                     "argument %d of call to function", i)
             end
             assert(#f_type.ret_types <= 1)
@@ -734,17 +620,106 @@ check_exp = function(exp, type_hint)
         error("not implemented")
 
     elseif tag == "ast.Exp.Cast" then
-        local target = check_type(exp.target)
-        check_exp(exp.exp, target)
-        if not types.consistent(exp.exp._type, target) then
+        local dst_t = check_type(exp.target)
+        check_exp_synthesize(exp.exp)
+        local src_t = exp.exp._type
+        if not types.consistent(src_t, dst_t) then
             type_error(exp.loc,
                 "cannot cast %s to %s",
-                types.tostring(exp.exp._type), types.tostring(target))
+                types.tostring(src_t), types.tostring(dst_t))
         end
-        exp._type = target
+        exp._type = dst_t
 
     else
         error("impossible")
+    end
+end
+
+-- Verifies that expression @exp has type expected_type.
+-- Returnsthe typechecked expression. This may be either be the original
+-- expression, or a coersion node from the original expression to the expected
+-- type.
+--
+-- errmsg_fmt: format string describing what part of the program is
+--             responsible for this type check
+-- ...: arguments to the "errmsg_fmt" format string
+check_exp_verify = function(exp, expected_type, errmsg_fmt, ...)
+    local tag = exp._tag
+
+    if tag == "ast.Exp.Initlist" then
+
+        if expected_type._tag == "types.T.Array" then
+            for _, field in ipairs(exp.fields) do
+                if field.name then
+                    type_error(field.loc,
+                        "named field %s in array initializer",
+                        field.name)
+                end
+                field.exp = check_exp_verify(
+                    field.exp, expected_type.elem,
+                    "array initializer")
+            end
+
+        elseif expected_type._tag == "types.T.Record" then
+            local initialized_fields = {}
+            for _, field in ipairs(exp.fields) do
+                if not field.name then
+                    type_error(field.loc,
+                        "record initializer has array part")
+                end
+
+                if initialized_fields[field.name] then
+                    type_error(field.loc,
+                        "duplicate field %s in record initializer",
+                        field.name)
+                end
+                initialized_fields[field.name] = true
+
+                local field_type = expected_type.field_types[field.name]
+                if not field_type then
+                    type_error(field.loc,
+                        "invalid field %s in record initializer for %s",
+                        field.name, types.tostring(expected_type))
+                end
+
+                field.exp = check_exp_verify(
+                    field.exp, field_type,
+                    "record initializer")
+            end
+
+            for field_name, _ in pairs(expected_type.field_types) do
+                if not initialized_fields[field_name] then
+                    type_error(exp.loc,
+                        "required field %s is missing from initializer",
+                        field_name)
+                end
+            end
+        else
+            type_error(exp.loc,
+                "type hint for array or record initializer is not an array or record type")
+        end
+
+        exp._type = expected_type
+        return exp
+
+    else
+
+        check_exp_synthesize(exp)
+        local found_type = exp._type
+
+        if types.equals(found_type, expected_type) then
+            return exp
+        elseif types.consistent(found_type, expected_type) then
+            local cast = ast.Exp.Cast(exp.loc, exp, false)
+            cast._type = expected_type
+            return cast
+        else
+            type_error(exp.loc, string.format(
+                "expected %s but found %s in %s",
+                types.tostring(expected_type),
+                types.tostring(found_type),
+                string.format(errmsg_fmt, ...)))
+        end
     end
 end
 

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -685,12 +685,12 @@ check_exp = function(exp, type_hint)
         elseif op == "|" or op == "&" or op == "~" or op == "<<" or op == ">>" then
             if exp.lhs._type._tag ~= "types.T.Integer" then
                 type_error(exp.loc,
-                    "left hand side of arithmetic expression is a %s instead of an integer",
+                    "left hand side of bitwise expression is a %s instead of an integer",
                     types.tostring(exp.lhs._type))
             end
             if exp.rhs._type._tag ~= "types.T.Integer" then
                 type_error(exp.loc,
-                    "right hand side of arithmetic expression is a %s instead of an integer",
+                    "right hand side of bitwise expression is a %s instead of an integer",
                     types.tostring(exp.rhs._type))
             end
             exp._type = types.T.Integer()
@@ -738,7 +738,7 @@ check_exp = function(exp, type_hint)
         check_exp(exp.exp, target)
         if not types.consistent(exp.exp._type, target) then
             type_error(exp.loc,
-                "cannot cast '%s' to '%s'",
+                "cannot cast %s to %s",
                 types.tostring(exp.exp._type), types.tostring(target))
         end
         exp._type = target

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -63,25 +63,6 @@ local function check_match(loc, expected, found, term_fmt, ...)
     end
 end
 
-local function check_arity(loc, expected, found, term_fmt, ...)
-    if expected ~= found then
-        local term = string.format(term_fmt, ...)
-        local msg = string.format("%s: expected %d value(s) but found %d",
-            term, expected, found)
-        type_error(loc, msg)
-    end
-end
-
-local function check_is_array(loc, found, term_fmt, ...)
-    if found._tag ~= "types.T.Array" then
-        local term = string.format(term_fmt, ...)
-        local found_str = types.tostring(found)
-        local msg = string.format("%s: expected array but found %s",
-            term, found_str)
-        type_error(loc, msg)
-    end
-end
-
 local function try_coerce(exp, expected, term_fmt, ...)
     local found = exp._type
     if types.equals(found, expected) then

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -621,14 +621,15 @@ check_exp_synthesize = function(exp)
 
     elseif tag == "ast.Exp.Cast" then
         local dst_t = check_type(exp.target)
-        check_exp_synthesize(exp.exp)
-        local src_t = exp.exp._type
-        if not types.consistent(src_t, dst_t) then
-            type_error(exp.loc,
-                "cannot cast %s to %s",
-                types.tostring(src_t), types.tostring(dst_t))
-        end
+        exp.exp = check_exp_verify(exp.exp, dst_t, "cast expression")
         exp._type = dst_t
+
+        -- Remove redundant cast node if there is one
+        while exp.exp._tag == "ast.Exp.Cast" and
+            types.equals(exp.exp._type, dst_t)
+        do
+            exp.exp = exp.exp.exp
+        end
 
     else
         error("impossible")

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -49,21 +49,21 @@ end
 --   loc: location of the term that is being compared
 --   expected: type that is expected
 --   found: type that was actually present
---   term_fmt: format string describing what is being compared
---   ...: arguments to the "term" format string
-local function check_match(loc, expected, found, term_fmt, ...)
+--   errmsg_fmt: format string describing what part of the program is
+--               responsible for this type check
+--   ...: arguments to the "errmsg_fmt" format string
+local function check_match(loc, expected, found, errmsg_fmt, ...)
     if not types.equals(expected, found) then
-        local term = string.format(term_fmt, ...)
-        local expected_str = types.tostring(expected)
-        local found_str = types.tostring(found)
         local msg = string.format(
             "types in %s do not match, expected %s but found %s",
-            term, expected_str, found_str)
+            string.format(errmsg_fmt, ...),
+            types.tostring(expected),
+            types.tostring(found))
         type_error(loc, msg)
     end
 end
 
-local function try_coerce(exp, expected, term_fmt, ...)
+local function try_coerce(exp, expected, errmsg_fmt, ...)
     local found = exp._type
     if types.equals(found, expected) then
         return exp
@@ -72,12 +72,11 @@ local function try_coerce(exp, expected, term_fmt, ...)
         cast._type = expected
         return cast
     else
-        local term = string.format(term_fmt, ...)
-        local expected_str = types.tostring(expected)
-        local found_str = types.tostring(found)
         local msg = string.format(
             "%s: %s is not assignable to %s",
-            term, found_str, expected_str)
+            string.format(errmsg_fmt, ...),
+            types.tostring(found),
+            types.tostring(expected))
         type_error(exp.loc, msg)
     end
 end

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -47,7 +47,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("array expression in indexing is not an array", errs)
+        assert.match("expected array but found integer in array indexing", errs)
     end)
 
     it("catches wrong use of length operator", function()
@@ -99,7 +99,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("integer is not assignable to string", errs)
+        assert.match("expected string but found integer in assignment", errs)
     end)
 
     it("catches mismatching types in arguments", function()
@@ -109,7 +109,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("integer is not assignable to string", errs)
+        assert.match("expected string but found integer in assignment", errs)
     end)
 
     it("forbids empty array (without type annotation)", function()
@@ -141,7 +141,7 @@ describe("Pallene type checker", function()
             local xs: {integer} = {10, "hello"}
         ]])
         assert.falsy(prog_ast)
-        assert.matches("expected integer but found string", errs)
+        assert.matches("expected integer but found string in array initializer", errs)
     end)
 
     it("forbids record creation (without type annotation)", function()
@@ -165,7 +165,7 @@ describe("Pallene type checker", function()
             local p: Point = { x = 10.0, y = "hello" }
         ]])
         assert.falsy(prog_ast)
-        assert.matches("expected float but found string", errs)
+        assert.matches("expected float but found string in record initializer", errs)
     end)
 
     it("forbids wrong field name in record initializer", function()
@@ -243,7 +243,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.matches("types in while statement condition do not match, expected boolean but found integer", errs)
+        assert.matches("expected boolean but found integer in while loop condition", errs)
     end)
 
     it("requires repeat statement conditions to be boolean", function()
@@ -256,7 +256,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.matches("types in repeat statement condition do not match, expected boolean but found integer", errs)
+        assert.matches("expected boolean but found integer in repeat%-until loop condition", errs)
     end)
 
     it("requires if statement conditions to be boolean", function()
@@ -270,10 +270,10 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.matches("types in if statement condition do not match, expected boolean but found integer", errs)
+        assert.matches("expected boolean but found integer in if statement condition", errs)
     end)
 
-    it("ensures numeric 'for' variable has number type (with annotation)", function()
+    it("ensures numeric 'for' variable has number type", function()
         local prog_ast, errs = run_checker([[
             function fn(x: integer, s: string): integer
                 for i: string = 1, 10, 2 do
@@ -283,22 +283,8 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("control variable", errs)
+        assert.match("expected integer or float but found string in for%-loop control variable 'i'", errs)
     end)
-
-    it("ensures numeric 'for' variable has number type (without annotation)", function()
-        local prog_ast, errs = run_checker([[
-            function fn(x: integer, s: string): integer
-                for i = s, 10, 2 do
-                    x = x + i
-                end
-                return x
-            end
-        ]])
-        assert.falsy(prog_ast)
-        assert.match("control variable", errs)
-    end)
-
 
     it("catches 'for' errors in the start expression", function()
         local prog_ast, errs = run_checker([[
@@ -310,9 +296,8 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("numeric for loop initializer", errs)
+        assert.match("expected integer but found string in numeric for%-loop initializer", errs)
     end)
-
 
     it("catches 'for' errors in the limit expression", function()
         local prog_ast, errs = run_checker([[
@@ -324,7 +309,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("numeric for loop limit", errs)
+        assert.match("expected integer but found string in numeric for%-loop limit", errs)
     end)
 
     it("catches 'for' errors in the step expression", function()
@@ -337,7 +322,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("numeric for loop step", errs)
+        assert.match("expected integer but found string in numeric for%-loop step", errs)
     end)
 
     it("detects too many return values", function()
@@ -371,7 +356,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("return statement: string is not assignable to intege", errs)
+        assert.match("expected integer but found string in return statement", errs)
     end)
 
     it("detects missing return statements", function()
@@ -464,7 +449,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("float is not assignable to integer", errs,nil, true)
+        assert.match("expected integer but found float in argument 1 of call to function", errs)
     end)
 
     it("cannot concatenate with boolean", function()
@@ -506,7 +491,7 @@ describe("Pallene type checker", function()
                 end
             ]])
             assert.falsy(prog_ast)
-            assert.match("cannot compare .* and .* with .*", errs)
+            assert.match("cannot compare .* and .* using .*", errs)
         end)
     end
 
@@ -521,7 +506,7 @@ describe("Pallene type checker", function()
                             end
                         ]])
                         assert.falsy(prog_ast)
-                        assert.match("cannot compare .* and .* with .*", errs)
+                        assert.match("cannot compare .* and .* using .*", errs)
                     end)
                 end
             end
@@ -537,7 +522,7 @@ describe("Pallene type checker", function()
                     end
                 ]])
                 assert.falsy(prog_ast)
-                assert.match("cannot compare .* and .* with .*", errs)
+                assert.match("cannot compare .* and .* using .*", errs)
             end)
         end
     end
@@ -551,7 +536,7 @@ describe("Pallene type checker", function()
                     end
                 ]])
                 assert.falsy(prog_ast)
-                assert.match("cannot compare .* and .* with .*", errs)
+                assert.match("cannot compare .* and .* using .*", errs)
             end)
         end
     end
@@ -565,7 +550,7 @@ describe("Pallene type checker", function()
                     end
                 ]])
                 assert.falsy(prog_ast)
-                assert.match("cannot compare .* and .* with .*", errs)
+                assert.match("cannot compare .* and .* using .*", errs)
             end)
         end
     end
@@ -579,7 +564,7 @@ describe("Pallene type checker", function()
                     end
                 ]])
                 assert.falsy(prog_ast)
-                assert.match("cannot compare .* and .* with .*", errs)
+                assert.match("cannot compare .* and .* using .*", errs)
             end)
         end
     end
@@ -593,7 +578,7 @@ describe("Pallene type checker", function()
                     end
                 ]])
                 assert.falsy(prog_ast)
-                assert.match("cannot compare .* and .* with .*", errs)
+                assert.match("cannot compare .* and .* using .*", errs)
             end)
         end
     end
@@ -607,7 +592,7 @@ describe("Pallene type checker", function()
                     end
                 ]])
                 assert.falsy(prog_ast)
-                assert.match("cannot compare .* and .* with .*", errs)
+                assert.match("cannot compare .* and .* using .*", errs)
             end)
         end
     end
@@ -622,7 +607,7 @@ describe("Pallene type checker", function()
                         end
                     ]])
                     assert.falsy(prog_ast)
-                    assert.match("cannot compare .* and .* with .*", errs)
+                    assert.match("cannot compare .* and .* using .*", errs)
                 end)
             end
         end
@@ -790,7 +775,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("integer is not assignable to string", errs, nil, true)
+        assert.match("expected string but found integer in argument 1", errs, nil, true)
     end)
 
     it("typechecks table.insert (error)", function()
@@ -800,7 +785,7 @@ describe("Pallene type checker", function()
             end
         ]])
         assert.falsy(prog_ast)
-        assert.match("string is not assignable to { value }", errs, nil, true)
+        assert.match("expected { value } but found string in argument 1", errs, nil, true)
     end)
 end)
 
@@ -825,9 +810,9 @@ describe("Pallene typecheck of records", function()
     end)
 
     it("doesn't typecheck read/write with invalid types", function()
-        assert_type_error("Point is not assignable to float",
+        assert_type_error("expected float but found Point in assignment",
                           wrap_record[[ p.x = p ]])
-        assert_type_error("float is not assignable to Point",
+        assert_type_error("expected Point but found float in declaration",
                           wrap_record[[ local p: Point = p.x ]])
     end)
 end)

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -523,7 +523,7 @@ describe("Pallene type checker", function()
         for _, t1 in ipairs(typs) do
             for _, t2 in ipairs(typs) do
                 if t1 ~= t2 then
-                    optest("cannot cast $t1 to $t2", [[
+                    optest("expected $t2 but found $t1 in cast expression", [[
                         function fn(a: $t1) : $t2
                             return a as $t2
                         end

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -250,7 +250,7 @@ describe("Pallene type checker", function()
     it("ensures numeric 'for' variable has number type", function()
         assert_type_error([[
             function fn(x: integer, s: string): integer
-                for i: string = 1, 10, 2 do
+                for i: string = "hello", 10, 2 do
                     x = x + i
                 end
                 return x


### PR DESCRIPTION
This PR restructures how we type check expressions. Instead of having a single check_type function with an optional type_hint parameter, we now have two functions: `check_type_synthesize` and `check_type_verify`.

check_type_synthesize is closer to our original version of check_type. It is used when we want to compute the type of the expression by itself, ignoring the surrounding context.

check_type_verify is used where we have an expected result type. This is the only way to typecheck InitList nodes, and is also responsible for introducing automatic coercions to and from the value type.

The biggest semantic change in this set of patches is that back when we introduced the value type we should have changed all the calls to check_match into calls to try_coerce but did not. This meant that you could not use expressions of type value in while loop conditions or array indexes -- it had to be exactly boolean and integer. This set of patches fixes this and also simplifies the code so that it is easier to understand and there is only one place that is responsible for introducing type coercions. (A side-effect of this change is that all error messages were changed into the same one: "expected FOO but found BAR in BLAH").

Along the way I also took the opportunity to further clean up the checker_spec tests. I made all the tests use the assert_type_error function, and reduced some copy-paste duplication by employing for-loops similarly to what we do in other places.