### PR TITLE
Small tweaks to the ir.Cmd type

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1177,9 +1177,8 @@ gen_cmd["Return"] = function(self, _cmd)
     return [[ goto done; ]]
 end
 
-gen_cmd["BreakIf"] = function(self, cmd, _func)
-    local x = self:c_value(cmd.condition)
-    return (util.render([[ if ($x) break; ]], { x = x }))
+gen_cmd["Break"] = function(self, _cmd, _func)
+    return [[ break; ]]
 end
 
 gen_cmd["If"] = function(self, cmd, func)

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -1,6 +1,7 @@
 local c_compiler = require "pallene.c_compiler"
 local checker = require "pallene.checker"
 local coder = require "pallene.coder"
+local ir = require "pallene.ir"
 local parser = require "pallene.parser"
 local to_ir = require "pallene.to_ir"
 local util = require "pallene.util"
@@ -27,7 +28,7 @@ end
 -- This is meant for unit tests.
 --
 function driver.compile_internal(filename, stop_after)
-    stop_after = stop_after or "to_ir"
+    stop_after = stop_after or "optimize"
     local err, errs
 
     local base_name
@@ -57,6 +58,14 @@ function driver.compile_internal(filename, stop_after)
     module, errs = to_ir.convert(module)
     if stop_after == "to_ir" or not module then
         return module, errs
+    end
+
+    for _, func in ipairs(module.functions) do
+        func.body = ir.clean(func.body)
+    end
+
+    if stop_after == "optimize" or not module then
+        return module, {}
     end
 
     error("impossible")

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -156,7 +156,7 @@ declare_type("Cmd", {
     Seq     = {"cmds"},
 
     Return  = {},
-    BreakIf = {"condition"},
+    Break   = {},
     If      = {"condition", "then_", "else_"},
     Loop    = {"body"},
     For     = {"typ", "loop_var", "start", "limit", "step", "body"},
@@ -248,7 +248,6 @@ end
 -- Remove some kinds of silly control flow
 --   - Empty If
 --   - if statements w/ constant condition
---   - break-if w/ constant condition
 --   - Nop and Seq statements inside Seq
 --   - Seq commands w/ no statements
 --   - Seq commans w/ only one element
@@ -291,13 +290,6 @@ function ir.clean(cmd)
             return cmd
         end
 
-    elseif tag == "ir.Cmd.BreakIf" then
-        local v = cmd.condition
-        if v._tag == "ir.Value.Bool" and v.value == false then
-            return ir.Cmd.Nop()
-        else
-            return cmd
-        end
     else
         return cmd
     end

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -40,13 +40,9 @@ function ToIR:convert_stat(cmds, stat)
         self:convert_stats(cmds, stat.stats)
 
     elseif tag == "ast.Stat.While" then
-        local not_cond = ast.Exp.Unop(
-            stat.condition.loc, "not", stat.condition)
-        not_cond._type = types.T.Boolean()
-
         local body = {}
-        local condition = self:exp_to_value(body, not_cond)
-        table.insert(body, ir.Cmd.BreakIf(condition))
+        local condition = self:exp_to_value(body, stat.condition)
+        table.insert(body, ir.Cmd.If(condition, ir.Cmd.Nop(), ir.Cmd.Break()))
         self:convert_stat(body, stat.block)
         table.insert(cmds, ir.Cmd.Loop(ir.Cmd.Seq(body)))
 
@@ -54,7 +50,7 @@ function ToIR:convert_stat(cmds, stat)
         local body = {}
         self:convert_stat(body, stat.block)
         local condition = self:exp_to_value(body, stat.condition)
-        table.insert(body, ir.Cmd.BreakIf(condition))
+        table.insert(body, ir.Cmd.If(condition, ir.Cmd.Break(), ir.Cmd.Nop()))
         table.insert(cmds, ir.Cmd.Loop(ir.Cmd.Seq(body)))
 
     elseif tag == "ast.Stat.If" then


### PR DESCRIPTION
This patch makes two changes to the ir.Cmd type. The BreakIf case is replaced by a Break case, and we add a new Seq case. Additionally, the patch also introduces a ir.clean function.

Replacing the BreakIf instruction with combinations of If + Break is a straightforward simplification. It also paves the way for introducing the `break` keyword in the future. (We don't do that yet because before we implement break we need to implement uninitialized variable declarations)

The Seq case makes it easier to write recursive traversals of the ir.Cmd type. Previously, we needed to have a pair of mutually recursive functions, one for ir.Cmd nodes and one for lists of ir.Cmd nodes. The introduction of the Seq case means that all the places in the code that used to use lists of ir.Cmd nodes can now operate on a Seq node instead. 

The introduction of the Seq node will also be useful for optimizations which transform the ir.Cmd tree. Removing a node from the tree can be implemented as replacing it by an empty Seq node, and inserting new nodes can be implemented by replacing an existing node with a non-empty Seq node. These transformations leave the tree in a "non canonical" state with nested Seq nodes, so to compensate that we also add an `ir.clean` function that flattens the tree and removes some kinds of dead code.