### PR TITLE
Implement constant propagation of globals

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -567,11 +567,6 @@ typedecl.declare(coder, "coder", "Upvalue", {
 
 function Coder:init_upvalues()
 
-    local flattened_body = {}
-    for _, func in ipairs(self.module.functions) do
-        flattened_body[func] = ir.flatten_cmd(func.body)
-    end
-
     -- Metatables
     for _, typ in ipairs(self.module.record_types) do
         table.insert(self.upvalues, coder.Upvalue.Metatable(typ))
@@ -580,7 +575,7 @@ function Coder:init_upvalues()
 
     -- String Literals
     for _, func in ipairs(self.module.functions) do
-        for _, cmd in ipairs(flattened_body[func]) do
+        for cmd in ir.iter(func.body) do
             for _, v in ipairs(ir.get_srcs(cmd)) do
                 if v._tag == "ir.Value.String" then
                     local str = v.value
@@ -593,7 +588,7 @@ function Coder:init_upvalues()
 
     -- Functions
     for _, func in ipairs(self.module.functions) do
-        for _, cmd in ipairs(flattened_body[func]) do
+        for cmd in ir.iter(func.body) do
             for _, v in ipairs(ir.get_srcs(cmd)) do
                 if v._tag == "ir.Value.Function" then
                     local f_id = v.id
@@ -793,7 +788,7 @@ function Coder:init_gc()
 
     for _, func in ipairs(self.module.functions) do
         local max = 0
-        for _, cmd in ipairs(ir.flatten_cmd(func.body)) do
+        for cmd in ir.iter(func.body) do
             if cmd._tag == "ir.Cmd.CallDyn" then
                 local nsrcs = #cmd.srcs
                 local ndst  = 1

--- a/pallene/constant_propagation.lua
+++ b/pallene/constant_propagation.lua
@@ -1,0 +1,131 @@
+local ir = require "pallene.ir"
+
+local constant_propagation = {}
+
+local function is_constant_value(v)
+    local tag = v._tag
+    if     tag == "ir.Value.Nil"      then return true
+    elseif tag == "ir.Value.Bool"     then return true
+    elseif tag == "ir.Value.Integer"  then return true
+    elseif tag == "ir.Value.Float"    then return true
+    elseif tag == "ir.Value.String"   then return true
+    elseif tag == "ir.Value.LocalVar" then return false
+    elseif tag == "ir.Value.Function" then return true
+    else
+        error("impossible")
+    end
+end
+
+-- Replaces toplevel constant variables by their respetive values.
+--
+-- Currently assumes that the toplevel constant variable is initialized with a
+-- constant literal. Does not currently recognize non-trivial constant
+-- expressions as being constant.
+function constant_propagation.run(module)
+
+    local n_globals = #module.globals
+
+    -- 1) Find what toplevel variables are initialized to a constant in $init
+
+    local constant_initializer = {} -- { g_id => ir.Value? }
+    for i = 1, n_globals do
+        constant_initializer[i] = false
+    end
+
+    do
+        -- DFS traversal to find SetGlobal instructions with a constant
+        -- initializer. We ignore the instructions inside If, Loop, and For
+        -- statements, since those might be skipped.
+        local stack = { module.functions[1].body }
+        while #stack > 0 do
+            local cmd = table.remove(stack)
+            local tag = cmd._tag
+            if     tag == 'ir.Cmd.SetGlobal' then
+                if is_constant_value(cmd.src) then
+                    constant_initializer[cmd.global_id] = cmd.src
+                end
+            elseif tag == 'ir.Cmd.Seq' then
+                for i = #cmd.cmds, 1, -1 do
+                    table.insert(stack, cmd.cmds[i])
+                end
+            else
+                -- skip
+            end
+        end
+    end
+
+    -- 2) Find what toplevel variables are never re-initialized or never used
+
+    local n_reads  = {} -- { g_id => int }
+    local n_writes = {} -- { g_id => int }
+    for i = 1, n_globals do
+        n_reads[i]  = 0
+        n_writes[i] = 0
+    end
+
+    for _, func in ipairs(module.functions) do
+        for _, cmd in ipairs(ir.flatten_cmd(func.body)) do
+            local tag = cmd._tag
+            if     tag == "ir.Cmd.GetGlobal" then
+                local id = cmd.global_id
+                n_reads[id] = n_reads[id] + 1
+            elseif tag == "ir.Cmd.SetGlobal" then
+                local id = cmd.global_id
+                n_writes[id] = n_writes[id] + 1
+            else
+                -- skip
+            end
+        end
+    end
+
+    -- 3) Find out which constant globals should be propagated, and which
+    --    unused constant globals should be simply eliminated.
+
+    local n_new_globals = 0
+    local new_global_id = {} -- { g_id => g_id? }
+    for i = 1, n_globals do
+        if constant_initializer[i] and (n_reads[i] == 0 or n_writes[i] == 1) then
+            new_global_id[i] = false
+        else
+            n_new_globals = n_new_globals + 1
+            new_global_id[i] = n_new_globals
+        end
+    end
+
+    -- 4) Propagate the constant globals, and rename the existing ones
+    -- accordingly
+
+    for _, func in ipairs(module.functions) do
+        func.body = ir.map_cmd(func.body, function(cmd)
+            local tag = cmd._tag
+            if     tag == "ir.Cmd.GetGlobal" then
+                local old_id = cmd.global_id
+                local new_id = new_global_id[old_id]
+                if new_id then
+                    return ir.Cmd.GetGlobal(cmd.loc, cmd.dst, new_id)
+                else
+                    local v = assert(constant_initializer[old_id])
+                    return ir.Cmd.Move(cmd.loc, cmd.dst, v)
+                end
+            elseif tag == "ir.Cmd.SetGlobal" then
+                local old_id = cmd.global_id
+                local new_id = new_global_id[old_id]
+                if new_id then
+                    return ir.Cmd.SetGlobal(cmd.loc, new_id, cmd.src)
+                else
+                    return ir.Cmd.Nop()
+                end
+            else
+                -- don't modify
+                return false
+            end
+        end)
+    end
+
+    -- 5) Done
+
+    ir.clean_all(module)
+    return module, {}
+end
+
+return constant_propagation

--- a/pallene/constant_propagation.lua
+++ b/pallene/constant_propagation.lua
@@ -64,7 +64,7 @@ function constant_propagation.run(module)
     end
 
     for _, func in ipairs(module.functions) do
-        for _, cmd in ipairs(ir.flatten_cmd(func.body)) do
+        for cmd in ir.iter(func.body) do
             local tag = cmd._tag
             if     tag == "ir.Cmd.GetGlobal" then
                 local id = cmd.global_id

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -1,5 +1,6 @@
 local c_compiler = require "pallene.c_compiler"
 local checker = require "pallene.checker"
+local constant_propagation = require "pallene.constant_propagation"
 local coder = require "pallene.coder"
 local ir = require "pallene.ir"
 local parser = require "pallene.parser"
@@ -60,8 +61,9 @@ function driver.compile_internal(filename, stop_after)
         return module, errs
     end
 
-    for _, func in ipairs(module.functions) do
-        func.body = ir.clean(func.body)
+    module, errs = constant_propagation.run(module)
+    if stop_after == "constant_propagation" or not module then
+        return module, errs
     end
 
     if stop_after == "optimize" or not module then

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -214,14 +214,11 @@ function ir.get_dsts(cmd)
     return dsts
 end
 
-
--- Linearize the commands in a pre-order traversal. Makes it easier to iterate
--- over all commands, and is also helpful for register allocation.
-function ir.flatten_cmd(root_cmd)
-    local res = {}
+-- Iterate over the cmds with a pre-order traversal.
+function ir.iter(root_cmd)
 
     local function go(cmd)
-        table.insert(res, cmd)
+        coroutine.yield(cmd)
 
         local tag = cmd._tag
         if     tag == "ir.Cmd.Seq" then
@@ -238,10 +235,18 @@ function ir.flatten_cmd(root_cmd)
         else
             -- no recursion needed
         end
-
     end
 
-    go(root_cmd)
+    return coroutine.wrap(function()
+        go(root_cmd)
+    end)
+end
+
+function ir.flatten_cmd(root_cmd)
+    local res = {}
+    for cmd in ir.iter(root_cmd) do
+        table.insert(res, cmd)
+    end
     return res
 end
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -13,6 +13,7 @@ function to_ir.convert(module)
         ToIR.new(module, func):convert_stat(cmds, func.body)
         func.body = ir.Cmd.Seq(cmds)
     end
+    ir.clean_all(module)
     return module, {}
 end
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1115,4 +1115,30 @@ describe("Pallene coder /", function()
             ]])
         end)
     end)
+
+    describe("Constant propagation", function()
+        setup(compile([[
+            local x = 0 -- never read from
+            local step = 1
+            local counter = 0
+
+            local function inc(): integer
+                counter = counter + step
+                return counter
+            end
+
+            function next(): integer
+                x = inc()
+                return counter
+            end
+        ]]))
+
+        it("preserves assignment side-effects", function()
+            run_test([[
+                assert(1 == test.next())
+                assert(2 == test.next())
+                assert(3 == test.next())
+            ]])
+        end)
+    end)
 end)


### PR DESCRIPTION
This commit implements an optimization that removes module variables that are
constant or that are never read from. `GetGlobal` reads from constant variables
removed this way are replaced by a `Move` of the corresponding value.

For example, in the following code the N variable is optimized away, as if we
had written `for i = 1, 10`:

    local N = 10
    function f()
        for i = 1, N do
            blah()
        end
    end

Furthermore, in the following code the `x` variable is not created in the final
version of the code, since it is never read from. The `blah()` function still
gets called inside `f`, but its return value is thrown away.

    local x = 42
    function f()
        x = blah()
    end

The important limitation for now is that a module variable is only identified as
a constant if its initializer is a literal value (number, string, etc). This
means that in the following program `x` and `y` are NOT considered constant.

    local x = 1 + 1
    local x = y