### PR TITLE
Find dup removal

### DIFF
--- a/pallene/symtab.lua
+++ b/pallene/symtab.lua
@@ -2,7 +2,7 @@ local util = require "pallene.util"
 
 local Symtab = util.Class()
 function Symtab:init()
-    self.blocks = {}
+    self.blocks = { {} }
 end
 
 function Symtab:open_block()

--- a/pallene/symtab.lua
+++ b/pallene/symtab.lua
@@ -35,12 +35,4 @@ function Symtab:find_symbol(name)
     return nil
 end
 
--- Determine if the given name is already being defined in the current scope.
--- This is necessary in cases where shadowing other definitions in the same
--- scope is not allowed, but shadowing outer definitions is ok. For example,
--- function argument names.
-function Symtab:find_dup(name)
-    return self.blocks[#self.blocks][name]
-end
-
 return Symtab


### PR DESCRIPTION
Two short commits

1. Remove unused and deprecated find_dup method. Close issue #82
2. Make the symbol table ready to use when it is created, removing one level of indentation from the checker toplevel.