### PR TITLE
Implement uninitialized variables

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -195,7 +195,7 @@ Creates an alias for a previously-declared type with the following syntax:
 type <name> = <type>
 ```
 
-Type alias in Pallene curretly cannot be used to declare recursive types, such as:
+Type alias in Pallene currently cannot be used to declare recursive types, such as:
 
 ```
 type T = {T}
@@ -272,6 +272,15 @@ Unlike languages like C or Java, Pallene does not require type annotations on ev
 It uses a bidirectional type-checking system that is able to infer the types of almost all variables and expressions.
 Roughly speaking, you must include type annotations for the parameters and return types of toplevel functions, and almost everything else can be inferred from that.
 For example, notice how the `sum_floats` from the Brief Overview section does not include a type annotation for the `result` and `i` variables.
+
+If a local variable declaration doesn't have an initializer, it must have a type annotation
+```
+function contrived(): integer
+    local x:integer
+    x = 10
+    return x
+end
+```
 
 ### Automatic type coercions
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -273,7 +273,7 @@ It uses a bidirectional type-checking system that is able to infer the types of 
 Roughly speaking, you must include type annotations for the parameters and return types of toplevel functions, and almost everything else can be inferred from that.
 For example, notice how the `sum_floats` from the Brief Overview section does not include a type annotation for the `result` and `i` variables.
 
-If a local variable declaration doesn't have an initializer, it must have a type annotation
+If a local variable declaration doesn't have an initializer, it must have a type annotation:
 ```
 function contrived(): integer
     local x:integer

--- a/pallene-dev-1.rockspec
+++ b/pallene-dev-1.rockspec
@@ -38,6 +38,7 @@ build = {
       ["pallene.to_ir"] =          "pallene/to_ir.lua",
       ["pallene.typedecl"] =       "pallene/typedecl.lua",
       ["pallene.types"] =          "pallene/types.lua",
+      ["pallene.uninitialized"] =  "pallene/uninitialized.lua",
       ["pallene.util"] =           "pallene/util.lua",
    },
    install = {

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -839,7 +839,6 @@ function FunChecker:check_initializer_exp(decl, exp, err_fmt, ...)
                 "uninitialized variable '%s' needs a type annotation",
                 decl.name))
         end
-
     end
 end
 

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -162,38 +162,6 @@ function Checker:from_ast_type(ast_typ)
     end
 end
 
--- Does this statement always call "return"?
-local function stat_always_returns(stat)
-    local tag = stat._tag
-    if     tag == "ast.Stat.Decl" then
-        return false
-    elseif tag == "ast.Stat.Block" then
-        for _, inner_stat in ipairs(stat.stats) do
-            if stat_always_returns(inner_stat) then
-                return true
-            end
-        end
-        return false
-    elseif tag == "ast.Stat.While" then
-        return false
-    elseif tag == "ast.Stat.Repeat" then
-        return false
-    elseif tag == "ast.Stat.For" then
-        return false
-    elseif tag == "ast.Stat.Assign" then
-        return false
-    elseif tag == "ast.Stat.Call"  then
-        return false
-    elseif tag == "ast.Stat.Return" then
-        return true
-    elseif tag == "ast.Stat.If" then
-        return stat_always_returns(stat.then_) and
-                stat_always_returns(stat.else_)
-    else
-        error("impossible")
-    end
-end
-
 function Checker:check_program(prog_ast)
 
     do
@@ -244,12 +212,10 @@ function Checker:check_program(prog_ast)
             local loc = tl_node.loc
             local value = tl_node.value
             local name = tl_node.decl.name
-            local ast_type = tl_node.decl.type
-
-            local exp = toplevel_fun_checker:check_initializer_exp(
-                value, ast_type,
+            local typ, exp = toplevel_fun_checker:check_initializer_exp(
+                tl_node.decl, value,
                 "declaration of module variable %s", name)
-            local _ = self:add_global(name, exp._type)
+            local _ = self:add_global(name, typ)
             local var = ast.Var.Name(loc, name)
             toplevel_fun_checker:check_var(var)
             table.insert(toplevel_stats,
@@ -339,23 +305,16 @@ function FunChecker:check_function(lambda, func_typ)
 
         local body = self.func.body
         self:check_stat(body)
-
-        if #func_typ.ret_types > 0 and
-            not stat_always_returns(body)
-        then
-            type_error(lambda.loc,
-                "control reaches end of function with non-empty return type")
-        end
-
     end)
 end
 
 function FunChecker:check_stat(stat)
     local tag = stat._tag
     if     tag == "ast.Stat.Decl" then
-        stat.exp = self:check_initializer_exp(stat.exp, stat.decl.type,
+        local typ
+        typ, stat.exp = self:check_initializer_exp(stat.decl, stat.exp,
             "declaration of local variable %s", stat.decl.name)
-        self:add_local(stat.decl.name, stat.exp._type)
+        self:add_local(stat.decl.name, typ)
         stat.decl._name = self.p.symbol_table:find_symbol(stat.decl.name)
 
     elseif tag == "ast.Stat.Block" then
@@ -384,9 +343,9 @@ function FunChecker:check_stat(stat)
 
     elseif tag == "ast.Stat.For" then
 
-        stat.start = self:check_initializer_exp(stat.start, stat.decl.type,
+        local loop_type
+        loop_type, stat.start = self:check_initializer_exp(stat.decl, stat.start,
             "numeric for-loop initializer")
-        local loop_type = stat.start._type
 
         if  loop_type._tag ~= "types.T.Integer" and
             loop_type._tag ~= "types.T.Float"
@@ -863,12 +822,24 @@ function FunChecker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
 end
 
 -- Checks `x : ast_typ = exp`, where ast_typ my be optional
-function FunChecker:check_initializer_exp(exp, ast_typ, err_fmt, ...)
-    if ast_typ then
-        local typ = self.p:from_ast_type(ast_typ)
-        return self:check_exp_verify(exp, typ, err_fmt, ...)
+function FunChecker:check_initializer_exp(decl, exp, err_fmt, ...)
+    if decl.type then
+        local typ = self.p:from_ast_type(decl.type)
+        if exp then
+            return typ, self:check_exp_verify(exp, typ, err_fmt, ...)
+        else
+            return typ, false
+        end
     else
-        return self:check_exp_synthesize(exp)
+        if exp then
+            local e = self:check_exp_synthesize(exp)
+            return e._type, e
+        else
+            type_error(decl.loc, string.format(
+                "uninitialized variable '%s' needs a type annotation",
+                decl.name))
+        end
+
     end
 end
 

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -308,7 +308,7 @@ function FunChecker:init(p, f_id)
 end
 
 function FunChecker:add_local(name, typ)
-    local l_id = ir.add_local(self.func, typ, name)
+    local l_id = ir.add_local(self.func, name, typ)
     self.p.symbol_table:add_symbol(name, checker.Name.Local(l_id))
     return l_id
 end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -254,13 +254,13 @@ function Coder:c_value(value)
 end
 
 -- @returns A syntactically valid function argument or variable declaration
---      for variable v_id from function f_id, and a correspong C comment, if
---      applicable. Since this may be used for either
+--      for variable v_id from function f_id. If the variable has a name,
+--      also includes it, as a C comment. Since this may be used for either
 --      a local variable or a function argument, there is no semicolon.
 function Coder:local_declaration(f_id, v_id)
     local decl = self.module.functions[f_id].vars[v_id]
     local name = self:c_var(v_id)
-    local comment = decl.comment and C.comment(decl.comment) or ""
+    local comment = decl.name and C.comment(decl.name) or ""
     return c_declaration(decl.typ, name), comment
 end
 
@@ -466,7 +466,7 @@ function Coder:lua_entry_point_definition(f_id)
 
     local type_checks = {}
     for i, typ in ipairs(arg_types) do
-        local name = func.vars[i].comment
+        local name = func.vars[i].name
         local check_tag =
             self:check_tag(typ, "slot", func.loc, "argument %s", C.string(name))
         if check_tag ~= ""  then

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -2,9 +2,9 @@ local c_compiler = require "pallene.c_compiler"
 local checker = require "pallene.checker"
 local constant_propagation = require "pallene.constant_propagation"
 local coder = require "pallene.coder"
-local ir = require "pallene.ir"
 local parser = require "pallene.parser"
 local to_ir = require "pallene.to_ir"
+local uninitialized = require "pallene.uninitialized"
 local util = require "pallene.util"
 
 local driver = {}
@@ -58,6 +58,11 @@ function driver.compile_internal(filename, stop_after)
 
     module, errs = to_ir.convert(module)
     if stop_after == "to_ir" or not module then
+        return module, errs
+    end
+
+    module, errs = uninitialized.verify_variables(module)
+    if stop_after == "uninitialized" or not module then
         return module, errs
     end
 

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -34,10 +34,10 @@ function ir.Module()
     }
 end
 
-function ir.VarDecl(typ, comment)
+function ir.VarDecl(typ, name)
     return {
-        typ = typ,          -- Type
-        comment = comment   -- string (variable name, location, etc)
+        typ = typ,   -- Type
+        name = name  -- string
     }
 end
 
@@ -78,8 +78,8 @@ end
 -- Function variables
 --
 
-function ir.add_local(func, typ, comment)
-    table.insert(func.vars, ir.VarDecl(typ, comment))
+function ir.add_local(func, typ, name)
+    table.insert(func.vars, ir.VarDecl(typ, name))
     return #func.vars
 end
 

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -34,10 +34,10 @@ function ir.Module()
     }
 end
 
-function ir.VarDecl(typ, name)
+function ir.VarDecl(name, typ)
     return {
+        name = name, -- string
         typ = typ,   -- Type
-        name = name  -- string
     }
 end
 
@@ -66,7 +66,7 @@ function ir.add_function(module, loc, name, typ, body)
 end
 
 function ir.add_global(module, name, typ)
-    table.insert(module.globals, ir.VarDecl(typ, name))
+    table.insert(module.globals, ir.VarDecl(name, typ))
     return #module.globals
 end
 
@@ -78,8 +78,8 @@ end
 -- Function variables
 --
 
-function ir.add_local(func, typ, name)
-    table.insert(func.vars, ir.VarDecl(typ, name))
+function ir.add_local(func, name, typ)
+    table.insert(func.vars, ir.VarDecl(name, typ))
     return #func.vars
 end
 

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -157,9 +157,10 @@ declare_type("Cmd", {
 
     Return  = {},
     Break   = {},
-    If      = {"condition", "then_", "else_"},
     Loop    = {"body"},
-    For     = {"typ", "loop_var", "start", "limit", "step", "body"},
+
+    If      = {"loc", "condition", "then_", "else_"},
+    For     = {"loc", "typ", "loop_var", "start", "limit", "step", "body"},
 
     -- Garbage Collection (appears after memory allocations)
     CheckGC = {},

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -288,7 +288,10 @@ end
 --   - Seq commans w/ only one element
 function ir.clean(cmd)
     local tag = cmd._tag
-    if tag == "ir.Cmd.Seq" then
+    if tag == "ir.Cmd.Nop" then
+        return cmd
+
+    elseif tag == "ir.Cmd.Seq" then
         local out = {}
         for _, c in ipairs(cmd.cmds) do
             c = ir.clean(c)
@@ -312,6 +315,8 @@ function ir.clean(cmd)
 
     elseif tag == "ir.Cmd.If" then
         local v = cmd.condition
+        cmd.then_ = ir.clean(cmd.then_)
+        cmd.else_ = ir.clean(cmd.else_)
         local t_empty = (cmd.then_._tag == "ir.Cmd.Nop")
         local e_empty = (cmd.else_._tag == "ir.Cmd.Nop")
 
@@ -324,6 +329,14 @@ function ir.clean(cmd)
         else
             return cmd
         end
+
+    elseif tag == "ir.Cmd.Loop" then
+        cmd.body = ir.clean(cmd.body)
+        return cmd
+
+    elseif tag == "ir.Cmd.For" then
+        cmd.body = ir.clean(cmd.body)
+        return cmd
 
     else
         return cmd

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -301,8 +301,8 @@ local grammar = re.compile([[
                            COMMA^CommaFor exp^Exp2For
                            (COMMA exp^Exp3For)?                  -> opt
                            DO^DoFor block END^EndFor)            -> StatFor
-                     / (P  LOCAL decl^DeclLocal ASSIGN^AssignLocal
-                                 exp^ExpLocal)                   -> StatDecl
+                     / (P  LOCAL decl^DeclLocal
+                                 (ASSIGN exp^ExpLocal)? ->opt)   -> StatDecl
                      / (P  var ASSIGN^AssignAssign
                                exp^ExpAssign)                    -> StatAssign
                      / &(exp ASSIGN) %{AssignNotToVar}

--- a/pallene/syntax_errors.lua
+++ b/pallene/syntax_errors.lua
@@ -125,8 +125,6 @@ local errors = {
 
     DeclLocal = "Expected variable declaration after 'local'.",
 
-    AssignLocal = "Expected '=' after variable declaration.",
-
     ExpLocal = "Expected an expression after '='.",
 
     AssignAssign = "Expected '=' after variable.",

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -261,7 +261,7 @@ function ToIR:exp_to_value(cmds, exp, _recursive)
     end
 
     -- Otherwise we need to create a temporary variable
-    local v = ir.add_local(self.func, exp._type)
+    local v = ir.add_local(self.func, false, exp._type)
     self:exp_to_assignment(cmds, v, exp)
     return ir.Value.LocalVar(v)
 end

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -114,10 +114,12 @@ function ToIR:convert_stat(cmds, stat)
         end
 
     elseif tag == "ast.Stat.Decl" then
-        local cname = stat.decl._name
-        assert(cname._tag == "checker.Name.Local")
-        local v = cname.id
-        self:exp_to_assignment(cmds, v, stat.exp)
+        if stat.exp then
+            local cname = stat.decl._name
+            assert(cname._tag == "checker.Name.Local")
+            local v = cname.id
+            self:exp_to_assignment(cmds, v, stat.exp)
+        end
 
     elseif tag == "ast.Stat.Call" then
         self:exp_to_assignment(cmds, false, stat.call_exp)

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -43,7 +43,7 @@ function ToIR:convert_stat(cmds, stat)
     elseif tag == "ast.Stat.While" then
         local body = {}
         local condition = self:exp_to_value(body, stat.condition)
-        table.insert(body, ir.Cmd.If(condition, ir.Cmd.Nop(), ir.Cmd.Break()))
+        table.insert(body, ir.Cmd.If(stat.loc, condition, ir.Cmd.Nop(), ir.Cmd.Break()))
         self:convert_stat(body, stat.block)
         table.insert(cmds, ir.Cmd.Loop(ir.Cmd.Seq(body)))
 
@@ -51,7 +51,7 @@ function ToIR:convert_stat(cmds, stat)
         local body = {}
         self:convert_stat(body, stat.block)
         local condition = self:exp_to_value(body, stat.condition)
-        table.insert(body, ir.Cmd.If(condition, ir.Cmd.Break(), ir.Cmd.Nop()))
+        table.insert(body, ir.Cmd.If(stat.loc, condition, ir.Cmd.Break(), ir.Cmd.Nop()))
         table.insert(cmds, ir.Cmd.Loop(ir.Cmd.Seq(body)))
 
     elseif tag == "ast.Stat.If" then
@@ -59,7 +59,7 @@ function ToIR:convert_stat(cmds, stat)
         local then_ = {}; self:convert_stat(then_, stat.then_)
         local else_ = {}; self:convert_stat(else_, stat.else_)
         table.insert(cmds, ir.Cmd.If(
-            condition,
+            stat.loc, condition,
             ir.Cmd.Seq(then_),
             ir.Cmd.Seq(else_)))
 
@@ -76,7 +76,7 @@ function ToIR:convert_stat(cmds, stat)
         local body = {}
         self:convert_stat(body, stat.block)
 
-        table.insert(cmds, ir.Cmd.For(
+        table.insert(cmds, ir.Cmd.For(stat.loc,
             typ, v,
             start, limit, step,
             ir.Cmd.Seq(body)))
@@ -403,7 +403,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             self:exp_to_assignment(cmds, dst, exp.lhs)
             local rhs_cmds = {}
             self:exp_to_assignment(rhs_cmds, dst, exp.rhs)
-            table.insert(cmds, ir.Cmd.If(
+            table.insert(cmds, ir.Cmd.If(exp.loc,
                 ir.Value.LocalVar(dst),
                 ir.Cmd.Seq(rhs_cmds),
                 ir.Cmd.Seq({})))
@@ -412,7 +412,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             self:exp_to_assignment(cmds, dst, exp.lhs)
             local rhs_cmds = {}
             self:exp_to_assignment(rhs_cmds, dst, exp.rhs)
-            table.insert(cmds, ir.Cmd.If(
+            table.insert(cmds, ir.Cmd.If(exp.loc,
                 ir.Value.LocalVar(dst),
                 ir.Cmd.Seq({}),
                 ir.Cmd.Seq(rhs_cmds)))

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -51,7 +51,7 @@ local function test(cmd, uninit, loop)
 
     local function check_use(v)
         if uninit[v] then
-            coroutine.yield({ v = v, cmd = cmd})
+            coroutine.yield({v = v, cmd = cmd})
         end
     end
 

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -1,0 +1,184 @@
+local ir = require "pallene.ir"
+local location = require "pallene.location"
+
+local uninitialized = {}
+
+-- B <- A
+local function copy(A)
+    local B = {}
+    for v, _ in pairs(A) do
+        B[v] = true
+    end
+    return B
+end
+
+-- A <- A ∪ B
+local function merge(A, B)
+    for v, _ in pairs(B) do
+        A[v] = true
+    end
+end
+
+local function new_loop()
+    return { is_infinite = true, uninit = {} }
+end
+
+-- This function detects when variables are used before being initialized, and
+-- when control flows to the end of a non-void function without returning.
+--
+-- The analysis is fundamentally a dataflow one, but we exploit the structured
+-- control flow to finish it into a single pass. In the end it sort of looks like
+-- an abstract interpretation.
+--
+-- The analysis assumes that both branches of an if statement can be taken. Make
+-- sure that you call ir.clean first, so that it does the right thing in the
+-- presence of `while true` loops.
+--
+-- `uninit` is the set of variables that are potentially uninitialized just
+-- before the command executes. We take the liberty of mutating this set
+-- in-place, so make a copy beforehand if you need to.
+--
+-- If we are inside a loop, `loop` models what will happen once we break
+-- out of the loop. `loop.is_infinite` is true if think the loop will surely
+-- loop forever. `loop.uninit` is the set of potentially uninitialized variables
+-- after the loop.
+--
+-- If the execution can possibly fall through to the next command, returns
+-- `true` and the updated set of uninitialized variables. Returns false if
+-- the execution unconditionally jumps or gets stuck in an infinite loop.
+--
+local function test(cmd, uninit, loop)
+
+    local function check_use(v)
+        if uninit[v] then
+            coroutine.yield({ v = v, cmd = cmd})
+        end
+    end
+
+    local tag = cmd._tag
+    if     tag == "ir.Cmd.Nop" then
+        return true, uninit
+
+    elseif tag == "ir.Cmd.Seq" then
+        for _, c in ipairs(cmd.cmds) do
+            local ft
+            ft, uninit = test(c, uninit, loop)
+            if not ft then return false end
+        end
+        return true, uninit
+
+    elseif tag == "ir.Cmd.Return" then
+        return false
+
+    elseif tag == "ir.Cmd.Break" then
+        assert(loop)
+        loop.is_infinite = false
+        merge(loop.uninit, uninit)
+        return false
+
+    elseif tag == "ir.Cmd.If" then
+        check_use(cmd.condition)
+
+        local ft1, uninit1 = test(cmd.then_, copy(uninit), loop)
+        local ft2, uninit2 = test(cmd.else_,      uninit , loop)
+
+        if ft1 and ft2 then
+            merge(uninit1, uninit2)
+            return true, uninit1
+        elseif ft1 then
+            return true, uninit1
+        elseif ft2 then
+            return true, uninit2
+        else
+            return false
+        end
+
+    elseif tag == "ir.Cmd.Loop" then
+        loop = new_loop()
+        test(cmd.body, uninit, loop)
+
+        if loop.is_infinite then
+            return false
+        else
+            return true, loop.uninit
+        end
+
+    elseif tag == "ir.Cmd.For" then
+        check_use(cmd.start)
+        check_use(cmd.limit)
+        check_use(cmd.step)
+
+        loop = new_loop()
+        loop.is_infinite = false
+        merge(loop.uninit, uninit)
+
+        uninit[cmd.loop_var] = nil
+        test(cmd.body, uninit, loop)
+
+        if loop.is_infinite then
+            return false
+        else
+            return true, loop.uninit
+        end
+
+    elseif string.match(tag, "^ir%.Cmd%.") then
+        for _, val in ipairs(ir.get_srcs(cmd)) do
+            if val._tag == "ir.Value.LocalVar" then
+                check_use(val.id)
+            end
+        end
+        for _, v_id in ipairs(ir.get_dsts(cmd)) do
+            uninit[v_id] = nil
+        end
+        return true, uninit
+    else
+        error("impossible")
+    end
+end
+
+function uninitialized.verify_variables(module)
+
+    local errors = {}
+
+    for _, func in ipairs(module.functions) do
+
+        local nvars = #func.vars
+        local nargs = #func.typ.arg_types
+        local nret  = #func.typ.ret_types
+
+        local falls_through
+        local analysis = coroutine.wrap(function()
+            local uninit = {}
+            for i = nargs+1, nvars do
+                uninit[i] = true
+            end
+            falls_through = test(func.body, uninit, false)
+        end)
+
+        local reported_variables = {} -- (only one error message per variable)
+        for o in analysis do
+            local cmd, v = o.cmd, o.v
+            if not reported_variables[v] then
+                reported_variables[v] = true
+                local name = assert(func.vars[v].name)
+                table.insert(errors, location.format_error(cmd.loc,
+                        "error: variable %s is used before being initialized", name))
+            end
+        end
+
+        if falls_through and nret > 0 then
+            table.insert(errors, location.format_error(func.loc,
+                "control reaches end of function with non-empty return type"))
+        end
+    end
+
+    if #errors == 0 then
+        return module, {}
+    else
+        return false, errors
+    end
+end
+
+return uninitialized
+
+

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -192,6 +192,16 @@ describe("Pallene type checker", function()
             "expected string but found integer in assignment")
     end)
 
+    it("requires a type annotation for an uninitialized variable", function()
+        assert_error([[
+            function fn(): integer
+                local x
+                x = 10
+                return x
+            end
+        ]], "uninitialized variable 'x' needs a type annotation")
+    end)
+
     it("catches mismatching types in arguments", function()
         assert_error([[
             function fn(i: integer, s: string): integer
@@ -442,44 +452,6 @@ describe("Pallene type checker", function()
             end
         ]],
             "expected integer but found string in return statement")
-    end)
-
-    it("detects missing return statements", function()
-        local code = {[[
-            function fn(): integer
-            end
-        ]],
-        [[
-            function getval(a:integer): integer
-                if a == 1 then
-                    return 10
-                elseif a == 2 then
-                else
-                    return 30
-                end
-            end
-        ]],
-        [[
-            function getval(a:integer): integer
-                if a == 1 then
-                    return 10
-                elseif a == 2 then
-                    return 20
-                else
-                    if a < 5 then
-                        if a == 3 then
-                            return 30
-                        end
-                    else
-                        return 50
-                    end
-                end
-            end
-        ]],
-        }
-        for _, c in ipairs(code) do
-            assert_error(c,"control reaches end of function with non-empty return type")
-        end
     end)
 
     it("rejects void functions in expression contexts", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1204,4 +1204,58 @@ describe("Pallene coder /", function()
             ]])
         end)
     end)
+
+    describe("Uninitialized variables", function()
+        setup(compile([[
+            function sign(x: integer): integer
+                local ret: integer
+                if     x  < 0 then
+                    ret = -1
+                elseif x == 0 then
+                    ret = 0
+                else
+                    ret = 1
+                end
+                return ret
+            end
+
+            function non_breaking_loop(): integer
+                local i = 1
+                while true do
+                    if i == 42 then return i end
+                    i = i + 1
+                end
+            end
+
+            function initialize_inside_loop(): integer
+                local x: integer
+                repeat
+                    x = 17
+                until true
+                return x
+            end
+
+        ]]))
+
+        it("can be used", function()
+            run_test([[
+                assert(-1 == test.sign(-10))
+                assert( 0 == test.sign(0))
+                assert( 1 == test.sign(10))
+            ]])
+        end)
+
+        it("infinite loops don't fall through", function()
+            run_test([[
+                assert(42 == test.non_breaking_loop())
+            ]])
+        end)
+
+        it("can initialize inside loops", function()
+            run_test([[
+                assert(17 == test.initialize_inside_loop())
+            ]])
+        end)
+
+    end)
 end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1234,7 +1234,6 @@ describe("Pallene coder /", function()
                 until true
                 return x
             end
-
         ]]))
 
         it("can be used", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -1045,10 +1045,6 @@ describe("Pallene parser", function()
         ]], "Expected variable declaration after 'local'.")
 
         assert_statements_syntax_error([[
-            local x  3
-        ]], "Expected '=' after variable declaration.")
-
-        assert_statements_syntax_error([[
             local x =
         ]], "Expected an expression after '='.")
 

--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -1,0 +1,54 @@
+local driver = require 'pallene.driver'
+local util = require 'pallene.util'
+
+local function run_uninitialized(code)
+    assert(util.set_file_contents("test.pln", code))
+    local module, errs = driver.compile_internal("test.pln", "uninitialized")
+    return module, table.concat(errs, "\n")
+end
+
+local function assert_error(code, expected_err)
+    local module, errs = run_uninitialized(code)
+    assert.falsy(module)
+    assert.match(expected_err, errs, 1, true)
+end
+
+local missing_return =
+    "control reaches end of function with non-empty return type"
+
+
+describe("Uninitialized variable analysis: ", function()
+
+    teardown(function()
+        os.remove("test.pln")
+    end)
+
+    it("empty function", function()
+        assert_error([[
+            function fn(): integer
+            end
+        ]], missing_return)
+    end)
+
+    it("missing return in elseif", function()
+        assert_error([[
+            function getval(a:integer): integer
+                if a == 1 then
+                    return 10
+                elseif a == 2 then
+                else
+                    return 30
+                end
+            end
+        ]], missing_return)
+    end)
+
+    it("catches use of uninitialized variable", function()
+        assert_error([[
+            function foo(): integer
+                local x:integer
+                return x
+            end
+        ]], "variable x is used before being initialized")
+    end)
+end)

--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -16,7 +16,6 @@ end
 local missing_return =
     "control reaches end of function with non-empty return type"
 
-
 describe("Uninitialized variable analysis: ", function()
 
     teardown(function()
@@ -43,10 +42,43 @@ describe("Uninitialized variable analysis: ", function()
         ]], missing_return)
     end)
 
+    it("missing return in deep elseif", function()
+        assert_error([[
+            function getval(a:integer): integer
+                if a == 1 then
+                    return 10
+                elseif a == 2 then
+                    return 20
+                else
+                    if a < 5 then
+                        if a == 3 then
+                            return 30
+                        end
+                    else
+                        return 50
+                    end
+                end
+            end
+        ]], missing_return)
+    end)
+
     it("catches use of uninitialized variable", function()
         assert_error([[
             function foo(): integer
                 local x:integer
+                return x
+            end
+        ]], "variable x is used before being initialized")
+    end)
+
+    it("assumes that loops might not execute", function()
+        assert_error([[
+            function foo(cond: boolean): integer
+                local x: integer
+                while cond do
+                    x = 0
+                    cond = x == 0
+                end
                 return x
             end
         ]], "variable x is used before being initialized")


### PR DESCRIPTION
This PR adds the option to declare uninitialized variables. Closes #95

    local x: integer
    if foo then
        x = 10
    else
        x = 20
    end
    return x

Instead of using a liveliness analysis pass, this patch builds upon the "always_returns" check that we used to have in checker.lua. It now works at the IR level and can also detect variables that are used before they are initialized.

Additionally, the new algorithm is smarter than the old one when analyzing loops. `while true` and `repeat until false` loops that don't contain a break statement no longer need to be followed by a return statement.

    function foo(): integer
        while true
            -- blablala
        end
        -- the compiler now knows this comment
        -- down here is unreachable
    end