### PR TITLE
Add break statement to Pallene

### DIFF
--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -41,6 +41,7 @@ declare_type("Stat", {
     Decl   = {"loc", "decl", "exp"},
     Call   = {"loc", "call_exp"},
     Return = {"loc", "exps"},
+    Break  = {"loc"},
 })
 
 declare_type("Var", {

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -377,7 +377,6 @@ function FunChecker:check_stat(stat)
         self.p.symbol_table:with_block(function()
             self:add_local(stat.decl.name, loop_type)
             stat.decl._name = self.p.symbol_table:find_symbol(stat.decl.name)
-
             self:check_stat(stat.block)
         end)
 
@@ -421,6 +420,9 @@ function FunChecker:check_stat(stat)
             "if statement condition")
         self:check_stat(stat.then_)
         self:check_stat(stat.else_)
+
+    elseif tag == "ast.Stat.Break" then
+        -- ok
 
     else
         error("impossible")

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -503,8 +503,6 @@ local function find_breaks_outside_loops(root_stat)
         elseif tag == "ast.Stat.If" then
             find_errors(stat.then_)
             find_errors(stat.else_)
-        else
-            -- ok
         end
     end
     find_errors(root_stat)

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -131,6 +131,9 @@ function ToIR:convert_stat(cmds, stat)
         end
         table.insert(cmds, ir.Cmd.Return())
 
+    elseif tag == "ast.Stat.Break" then
+        table.insert(cmds, ir.Cmd.Break())
+
     else
         error("impossible")
     end

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -614,6 +614,25 @@ describe("Pallene coder /", function()
                 until limit >= 100
                 return x
             end
+
+            function break_while() : integer
+                while true do break end
+                return 17
+            end
+
+            function break_repeat() : integer
+                repeat break until false
+                return 17
+            end
+
+            function break_for(): integer
+                local x = 0
+                for i = 1, 10 do
+                    x = x + i
+                    break
+                end
+                return x
+            end
         ]]))
 
         it("Block, Assign, Decl", function()
@@ -655,6 +674,19 @@ describe("Pallene coder /", function()
         it("Repeat until", function()
             run_test([[ assert(10 == test.repeat_until()) ]])
         end)
+
+        it("Break while loop", function()
+            run_test([[ assert(17 == test.break_while()) ]])
+        end)
+
+        it("Break repeat-until loop", function()
+            run_test([[ assert(17 == test.break_repeat()) ]])
+        end)
+
+        it("Break for loop", function()
+            run_test([[ assert(1 == test.break_for()) ]])
+        end)
+
     end)
 
     describe("Arrays /", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -638,14 +638,16 @@ describe("Pallene coder /", function()
                 while true do
                     while true do
                         break
+                        return 10
                     end
                     if x then
                         break
+                        return 20
                     else
-                        return 10
+                        return 30
                     end
                 end
-                return 20
+                return 40
             end
 
         ]]))
@@ -702,7 +704,7 @@ describe("Pallene coder /", function()
             run_test([[ assert(1 == test.break_for()) ]])
         end)
         it("Nested break", function()
-            run_test([[ assert(20 == test.nested_break(true)) ]])
+            run_test([[ assert(40 == test.nested_break(true)) ]])
         end)
 
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -633,6 +633,21 @@ describe("Pallene coder /", function()
                 end
                 return x
             end
+
+            function nested_break(x:boolean): integer
+                while true do
+                    while true do
+                        break
+                    end
+                    if x then
+                        break
+                    else
+                        return 10
+                    end
+                end
+                return 20
+            end
+
         ]]))
 
         it("Block, Assign, Decl", function()
@@ -686,6 +701,10 @@ describe("Pallene coder /", function()
         it("Break for loop", function()
             run_test([[ assert(1 == test.break_for()) ]])
         end)
+        it("Nested break", function()
+            run_test([[ assert(20 == test.nested_break(true)) ]])
+        end)
+
 
     end)
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -930,7 +930,6 @@ describe("Pallene parser", function()
         assert_type_syntax_error([[ (a, b) -> = nil ]],
             "Expected return types after `->` to finish the function type")
 
-
         assert_program_syntax_error([[
             record A
                 x  int
@@ -1108,5 +1107,13 @@ describe("Pallene parser", function()
 
         assert_expression_syntax_error([[ foo as ]],
             "Expected a type for the cast expression")
+    end)
+
+    it("catches break statements outside loops", function()
+        assert_program_syntax_error([[
+            function fn()
+                break
+            end
+        ]], "break statement outside loop")
     end)
 end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -1116,4 +1116,19 @@ describe("Pallene parser", function()
             end
         ]], "break statement outside loop")
     end)
+
+    it("catches break statements outside loops but inside other statements", function()
+        assert_program_syntax_error([[
+            function fn(x:boolean)
+                do
+                    if x then
+                        break
+                    else
+                        break
+                    end
+                end
+            end
+        ]], "break statement outside loop")
+    end)
+
 end)


### PR DESCRIPTION
The only question in this patch was where to add the check that break statements can only appear inside a loop. I put it in the parser.

Closes #96