### PR TITLE
Allow nils in arrays

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -138,9 +138,6 @@ function Checker:from_ast_type(ast_typ)
 
     elseif tag == "ast.Type.Array" then
         local subtype = self:from_ast_type(ast_typ.subtype)
-        if subtype._tag == "types.T.Nil" then
-            type_error(ast_typ.loc, "array of nil is not allowed")
-        end
         return types.T.Array(subtype)
 
     elseif tag == "ast.Type.Function" then

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -333,15 +333,6 @@ describe("Pallene type checker", function()
             "type hint for array or record initializer is not an array or record type")
     end)
 
-    it("forbids array of nil", function()
-        assert_error([[
-            function fn()
-                local xs: {nil} = {}
-            end
-        ]],
-            "array of nil is not allowed")
-    end)
-
     it("requires while statement conditions to be boolean", function()
         assert_error([[
             function fn(x:integer): integer

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -720,11 +720,11 @@ describe("Pallene coder /", function()
                 return #xs
             end
 
-            function get(arr: {integer}, i: integer): integer
+            function geti(arr: {integer}, i: integer): integer
                 return arr[i]
             end
 
-            function set(arr: {integer}, i: integer, v: integer)
+            function seti(arr: {integer}, i: integer, v: integer)
                 arr[i] = v
             end
 
@@ -734,6 +734,14 @@ describe("Pallene coder /", function()
 
             function remove(xs: {value}): ()
                 xs[#xs] = nil
+            end
+
+            function getvalue(xs: {value}, i:integer): value
+                return xs[i]
+            end
+
+            function getnil(xs: {nil}, i: integer): nil
+                return xs[i]
             end
         ]]))
 
@@ -759,38 +767,19 @@ describe("Pallene coder /", function()
         it("get", function()
             run_test([[
                 local arr = {10, 20, 30}
-                assert(10 == test.get(arr, 1))
-                assert(20 == test.get(arr, 2))
-                assert(30 == test.get(arr, 3))
+                assert(10 == test.geti(arr, 1))
+                assert(20 == test.geti(arr, 2))
+                assert(30 == test.geti(arr, 3))
             ]])
         end)
 
         it("set", function()
             run_test( [[
                 local arr = {10, 20, 30}
-                test.set(arr, 2, 123)
+                test.seti(arr, 2, 123)
                 assert( 10 == arr[1])
                 assert(123 == arr[2])
                 assert( 30 == arr[3])
-            ]])
-        end)
-
-        it("check out of bounds errors in get", function()
-            run_test([[
-                local arr = {10, 20, 30}
-
-                local ok, err = pcall(test.get, arr, 0)
-                assert(not ok)
-                assert(string.find(err, "invalid index", nil, true))
-
-                local ok, err = pcall(test.get, arr, 4)
-                assert(not ok)
-                assert(string.find(err, "wrong type for array element", nil, true))
-
-                table.remove(arr)
-                local ok, err = pcall(test.get, arr, 3)
-                assert(not ok)
-                assert(string.find(err, "wrong type for array element", nil, true))
             ]])
         end)
 
@@ -798,7 +787,7 @@ describe("Pallene coder /", function()
             run_test([[
                 local arr = {10, 20, "hello"}
 
-                local ok, err = pcall(test.get, arr, 3)
+                local ok, err = pcall(test.geti, arr, 3)
                 assert(not ok)
                 assert(
                     string.find(err, "wrong type for array element", nil, true))
@@ -832,6 +821,45 @@ describe("Pallene coder /", function()
                     end
                 end
             ]])
+        end)
+
+        it("out-of bounds get is a tag error", function()
+            run_test([[
+                local arr = {10, 20, 30}
+
+                local ok, err = pcall(test.geti, arr, 0)
+                assert(not ok)
+                assert(string.find(err, "invalid index", nil, true))
+
+                local ok, err = pcall(test.geti, arr, 4)
+                assert(not ok)
+                assert(string.find(err, "wrong type for array element", nil, true))
+
+                table.remove(arr)
+                local ok, err = pcall(test.geti, arr, 3)
+                assert(not ok)
+                assert(string.find(err, "wrong type for array element", nil, true))
+            ]])
+        end)
+
+        it("{nil}: in-bounds get nil", function()
+            run_test([[ assert(nil == test.getnil({10, nil, 30}, 2)) ]])
+        end)
+
+        it("{nil}: out-of-bounds get nil", function()
+            run_test([[ assert(nil == test.getnil({10, nil, 30}, 4)) ]])
+        end)
+
+        it("{value}: get non-nil", function()
+            run_test([[ assert(10  == test.getvalue({10, nil, 30}, 1)) ]])
+        end)
+
+        it("{value}: in-bounds get nil", function()
+            run_test([[ assert(nil == test.getvalue({10, nil, 30}, 2)) ]])
+        end)
+
+        it("{value}: out-of-bounds get nil", function()
+            run_test([[ assert(nil == test.getvalue({10, nil, 30}, 4)) ]])
         end)
     end)
 


### PR DESCRIPTION
This PR has two changes

The first one is that now we allow arrays of nil, aka {nil}.

I believe that the original motivation for this restriction was because it was
impossible to tell apart in "in-bound" nil from an "out of bound" nil.
However,we have since changed our interpretation of Pallene to not have a
separate "array out of bounds" error and and treat "out of bounds" nils no
differently than an in-bound nil: both are just a run-time tag errors. Under
this interpretation there is no need to forbid {nil}.

Furthermore, even if we wanted to keep the concept of "out of bounds" there
would be no need to forbid {nil} anymore. The latest version of the Lua
interpreter uses a variant LUA_TEMPTY tag to distinguish the regular nils from
the nils that live out of bounds or in array holes.

This brings us to the second change in this patch. Under the previous version of
Pallene, we would return an "empty" value when reading from an out-of-bounds
index. This would result in strange behavior because this "empty" value is not
considered to be == nil !

    function get(xs: {value}, i:integer): value
        return xs[i]
    end

    -- Lua
    local x = test.get({}, 1)
    print(x)        --> nil
    print(nil == x) --> false (!)

This patch corrects this by ensuring that we always clear the LUA_TEMPTY tag
when we read a nil from an array. At first glance it might sound wrong to have
to do a tag check when reading from an `{value}` but rawget also has to do it so
I think it is unavoidable.

Closes #89