### PR TITLE
Implement string comparison

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -936,6 +936,11 @@ gen_cmd["Binop"] = function(self, cmd, _func)
             dst = dst, x = x, y = y }))
     end
 
+    local function strcmp(op)
+        return (util.render([[ $dst = (pallene_l_strcmp($x, $y) $op 0); ]], {
+            dst = dst, x = x, y = y, op = op }))
+    end
+
     local op = cmd.op
     if     op == "IntAdd"    then return int_binop("+")
     elseif op == "IntSub"    then return int_binop("-")
@@ -966,6 +971,12 @@ gen_cmd["Binop"] = function(self, cmd, _func)
     elseif op == "FltGt"     then return binop_paren(">")
     elseif op == "FltLeq"    then return binop_paren("<=")
     elseif op == "FltGeq"    then return binop_paren(">=")
+    elseif op == "StrEq"     then return strcmp("==")
+    elseif op == "StrNeq"    then return strcmp("!=")
+    elseif op == "StrLt"     then return strcmp("<")
+    elseif op == "StrGt"     then return strcmp(">")
+    elseif op == "StrLeq"    then return strcmp("<=")
+    elseif op == "StrGeq"    then return strcmp(">=")
     elseif op == "BoolEq"    then return binop_paren("==")
     elseif op == "BoolNeq"   then return binop_paren("!=")
     else

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -184,6 +184,13 @@ local binops = {
     { "<=", "Float",   "Float",   "FltLeq" },
     { ">=", "Float",   "Float",   "FltGeq" },
 
+    { "==", "String",   "String",   "StrEq"  },
+    { "~=", "String",   "String",   "StrNeq" },
+    { "<" , "String",   "String",   "StrLt"  },
+    { ">" , "String",   "String",   "StrGt"  },
+    { "<=", "String",   "String",   "StrLeq" },
+    { ">=", "String",   "String",   "StrGeq" },
+
     { "==", "Boolean", "Boolean", "BoolEq" },
     { "~=", "Boolean", "Boolean", "BoolNeq" },
 }

--- a/runtime/pallene_core.c
+++ b/runtime/pallene_core.c
@@ -165,3 +165,32 @@ void pallene_io_write(lua_State *L, TString *str)
     size_t len = tsslen(str);
     fwrite(s, 1, len, stdout);
 }
+
+/* l_strcmp, copied from lvm.c
+ *
+ * Compare two strings 'ls' x 'rs', returning an integer less-equal-
+ * -greater than zero if 'ls' is less-equal-greater than 'rs'.
+ * The code is a little tricky because it allows '\0' in the strings
+ * and it uses 'strcoll' (to respect locales) for each segments
+ * of the strings. */
+int pallene_l_strcmp (const TString *ls, const TString *rs) {
+  const char *l = getstr(ls);
+  size_t ll = tsslen(ls);
+  const char *r = getstr(rs);
+  size_t lr = tsslen(rs);
+  for (;;) {  /* for each segment */
+    int temp = strcoll(l, r);
+    if (temp != 0)  /* not equal? */
+      return temp;  /* done */
+    else {  /* strings are equal up to a '\0' */
+      size_t len = strlen(l);  /* index of first '\0' in both strings */
+      if (len == lr)  /* 'rs' is finished? */
+        return (len == ll) ? 0 : 1;  /* check 'ls' */
+      else if (len == ll)  /* 'ls' is finished? */
+        return -1;  /* 'ls' is less than 'rs' ('rs' is not finished) */
+      /* both strings longer than 'len'; go on comparing after the '\0' */
+      len++;
+      l += len; ll -= len; r += len; lr -= len;
+    }
+  }
+}

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -63,6 +63,8 @@ void pallene_grow_array(
 void pallene_io_write(
     lua_State *L, TString *str);
 
+int pallene_l_strcmp(
+    const TString *ls, const TString *rs);
 
 /* --------------------------- */
 /* Inline functions and macros */

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -396,12 +396,12 @@ describe("Pallene coder /", function()
             { "le_ff",     "<=",  "float",   "float",   "boolean" },
             { "ge_ff",     ">=",  "float",   "float",   "boolean" },
 
-            -- NYI { "eq_ss",     "==",  "string",  "string",  "boolean" },
-            -- NYI { "ne_ss",     "~=",  "string",  "string",  "boolean" },
-            -- NYI { "lt_ss",     "<",   "string",  "string",  "boolean" },
-            -- NYI { "gt_ss",     ">",   "string",  "string",  "boolean" },
-            -- NYI { "le_ss",     "<=",  "string",  "string",  "boolean" },
-            -- NYI { "ge_ss",     ">=",  "string",  "string",  "boolean" },
+            { "eq_ss",     "==",  "string",  "string",  "boolean" },
+            { "ne_ss",     "~=",  "string",  "string",  "boolean" },
+            { "lt_ss",     "<",   "string",  "string",  "boolean" },
+            { "gt_ss",     ">",   "string",  "string",  "boolean" },
+            { "le_ss",     "<=",  "string",  "string",  "boolean" },
+            { "ge_ss",     ">=",  "string",  "string",  "boolean" },
 
             { "eq_bb",     "==",  "boolean",   "boolean",   "boolean" },
             { "ne_bb",     "~=",  "boolean",   "boolean",   "boolean" },


### PR DESCRIPTION
Closes #91

The nontrivial part of this patch is that l_strcmp, the function in lvm.c
responsible for string comparison, is declared as a static function, and
therefore cannot be directly called by Pallene.

Our options were to either redeclare l_strcmp as a public function, or copy it
into the Pallene runtime library. I chose the latter alternative, to minimize
our number of custom Lua patches we maintain.