### PR TITLE
Check Lua major+minor version at runtime

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1457,6 +1457,8 @@ function Coder:generate_luaopen_function()
     return (util.render([[
         int ${name}(lua_State *L)
         {
+            luaL_checkversion(L);
+
             lua_newuserdatauv(L, 0, $n_upvalues);
             int globals = lua_gettop(L);
 


### PR DESCRIPTION
It is possible to check at runtime if we are running Lua 5.4, but it is not
possible to check for a minor release (like 5.4.0 or 5.4.1)

Closes #73