### PR TITLE
Enable maybe-uninitialized warning

### DIFF
--- a/pallene/c_compiler.lua
+++ b/pallene/c_compiler.lua
@@ -5,8 +5,7 @@ local c_compiler = {}
 c_compiler.CC = "cc"
 c_compiler.CPPFLAGS = "-I./lua/src -I./runtime"
 c_compiler.CFLAGS_BASE = "-std=c99 -g -fPIC"
-c_compiler.CFLAGS_WARN = "-Wall -Wundef -Wshadow -Wpedantic -Wno-unused " ..
-                         "-Wno-maybe-uninitialized -Wno-unknown-warning-option"
+c_compiler.CFLAGS_WARN = "-Wall -Wundef -Wshadow -Wpedantic -Wno-unused"
 c_compiler.CFLAGS_OPT = "-O2"
 c_compiler.S_FLAGS = "-fverbose-asm"
 

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -103,7 +103,7 @@ end
 local function set_stack_slot(typ, dst_slot, value)
     local tmpl
     local tag = typ._tag
-    if     tag == "types.T.Nil"      then tmpl = "setnilvalue($dst);"
+    if     tag == "types.T.Nil"      then tmpl = "pallene_setnilvalue($dst);"
     elseif tag == "types.T.Boolean"  then tmpl = "setbvalue($dst, $src);"
     elseif tag == "types.T.Integer"  then tmpl = "setivalue($dst, $src);"
     elseif tag == "types.T.Float"    then tmpl = "setfltvalue($dst, $src);"
@@ -1066,6 +1066,7 @@ gen_cmd["GetArr"] = function(self, cmd, _func)
     if dst_typ._tag == "types.T.Value" then
         -- Remove "EMPTY" variant tag from out-of-bound nils
         -- note: rawget in lapi.c also needs to do this.
+        -- note: pallene_setnilvalue not needed since dst is already initialized
         table.insert(parts,
             util.render([[ if (isempty(&$dst)) { setnilvalue(&$dst); } ]], {
                 dst = dst }))

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -70,6 +70,20 @@ int pallene_l_strcmp(
 /* Inline functions and macros */
 /* --------------------------- */
 
+/* This is a workaround to avoid -Wmaybe-uninitialized warnings with GCC. If we
+ * initialize a TValue with setnilvalue and then follow that with a setobj, GCC
+ * complains that the setobj might be reading from an uninitialized obj->value_.
+ *
+ * To placate the compiler we write some bogus data to the value field whenever
+ * we would initialize a TValue with nil. In theory this should not have a
+ * noticeable performance impact because it only affects nil literals and
+ * variables of type nil. */
+static inline
+void pallene_setnilvalue(TValue *obj)
+{
+    val_(obj).b = 0;
+    setnilvalue(obj);
+}
 
 /* We must call these write barriers whenever we set "v" as an element of "p",
  * in order to preserve the color invariants of the incremental GC.


### PR DESCRIPTION
Closes #93, following Gabriel's suggestion. (Always initialize obj->value_)