### PR TITLE
Fix floating point literals that are also integers

### DIFF
--- a/pallene/C.lua
+++ b/pallene/C.lua
@@ -37,7 +37,8 @@ function C.float(n)
     -- 17 decimal digits should be able to accurately represent any IEE-754
     -- double-precision floating point number except for NaN and infinities.
     -- The HUGE_VAL macro is a part of math.h. For more info, please see the
-    -- quotefloat function in lstrlib.c and https://stackoverflow.com/a/21162120
+    -- quotefloat function in lstrlib.c, tostringbuff in lobject.c, and
+    -- https://stackoverflow.com/a/21162120
     if n == math.huge then
         return "HUGE_VAL"
     elseif n == -math.huge then
@@ -45,7 +46,12 @@ function C.float(n)
     elseif n ~= n then
         error("NaN cannot be round-tripped")
     else
-        return string.format("%.17g", n)
+        local s = string.format("%.17g", n)
+        if s:match("^%-?[0-9]+$") then
+            -- Looks like an integer. Add a decimal point to force to be double.
+            s = s .. ".0"
+        end
+        return s
     end
 end
 

--- a/pallene/C.lua
+++ b/pallene/C.lua
@@ -39,12 +39,12 @@ function C.float(n)
     -- The HUGE_VAL macro is a part of math.h. For more info, please see the
     -- quotefloat function in lstrlib.c, tostringbuff in lobject.c, and
     -- https://stackoverflow.com/a/21162120
-    if n == math.huge then
+    if n ~= n then
+        error("NaN cannot be round-tripped")
+    elseif n == math.huge then
         return "HUGE_VAL"
     elseif n == -math.huge then
         return "-HUGE_VAL"
-    elseif n ~= n then
-        error("NaN cannot be round-tripped")
     else
         local s = string.format("%.17g", n)
         if s:match("^%-?[0-9]+$") then

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -65,6 +65,7 @@ describe("Pallene coder /", function()
             function f_string(): string    return "Hello World" end
             function pi(): float           return 3.141592653589793 end
             function e(): float            return 2.718281828459045 end
+            function one_half(): float     return 1.0 / 2.0 end
         ]]))
 
         it("nil", function()
@@ -98,6 +99,13 @@ describe("Pallene coder /", function()
                 assert(pi == test.pi())
                 assert(e  == test.e())
                 assert(pi*e*e == test.pi() * test.e() * test.e())
+            ]])
+        end)
+
+        it("floating point literals are the right type in C", function()
+            -- There was a bug where (1.0/2.0) became (1/2) in the generated C
+            run_test([[
+                assert(0.5 == test.one_half())
             ]])
         end)
     end)


### PR DESCRIPTION
After I changed the C.float() function to print floating point numbers with
string.format("%g") instead of string.format("%a"), numbers like 0.0 and 1.0
started being printed as 0 and 1, without a decimal dot.

Most of the time, this did not make a difference because C automatically coerces
integer literals to double where needed. However, it produced the wrong result
when things like (1.0/2.0) in Pallene were converted to (1/2).

In addition to being more correct, adding a decimal dot to the floating point
literals in C also makes the generated C code a bit easier to read.