### PR TITLE
Implement string.char builtin

### DIFF
--- a/pallene/builtins.lua
+++ b/pallene/builtins.lua
@@ -2,10 +2,12 @@ local types = require "pallene.types"
 
 local builtins = {}
 
+local T = types.T
+
 for lua_name, typ in pairs({
-    ["io.write"]     = types.T.Function({types.T.String()}, {}),
-    ["math.sqrt"]    = types.T.Function({types.T.Float()}, {types.T.Float()}),
-    ["tofloat"]      = types.T.Function({types.T.Integer()}, {types.T.Float()}),
+    ["io.write"]     = T.Function({T.String()}, {}),
+    ["math.sqrt"]    = T.Function({T.Float()}, {T.Float()}),
+    ["tofloat"]      = T.Function({T.Integer()}, {T.Float()}),
 }) do
     local pallene_name = string.gsub(lua_name, "%.", "_")
     builtins[pallene_name] = {

--- a/pallene/builtins.lua
+++ b/pallene/builtins.lua
@@ -7,6 +7,7 @@ local T = types.T
 for lua_name, typ in pairs({
     ["io.write"]     = T.Function({T.String()}, {}),
     ["math.sqrt"]    = T.Function({T.Float()}, {T.Float()}),
+    ["string.char"]  = T.Function({T.Integer()}, {T.String()}),
     ["tofloat"]      = T.Function({T.Integer()}, {T.Float()}),
 }) do
     local pallene_name = string.gsub(lua_name, "%.", "_")

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1209,18 +1209,18 @@ gen_cmd["CallDyn"] = function(self, cmd, func)
     return self:wrap_function_call(call_stats)
 end
 
-gen_cmd["IoWrite"] = function(self, cmd, _func)
+gen_cmd["BuiltinIoWrite"] = function(self, cmd, _func)
     local v = self:c_value(cmd.src)
     return util.render([[ pallene_io_write(L, $v); ]], { v = v })
 end
 
-gen_cmd["MathSqrt"] = function(self, cmd, _func)
+gen_cmd["BuiltinMathSqrt"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
     local v = self:c_value(cmd.src)
     return util.render([[ $dst = sqrt($v); ]], { dst = dst, v = v })
 end
 
-gen_cmd["ToFloat"] = function(self, cmd, _func)
+gen_cmd["BuiltinToFloat"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
     local v = self:c_value(cmd.src)
     return util.render([[ $dst = (lua_Number) $v; ]], { dst = dst, v = v })

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1220,6 +1220,14 @@ gen_cmd["BuiltinMathSqrt"] = function(self, cmd, _func)
     return util.render([[ $dst = sqrt($v); ]], { dst = dst, v = v })
 end
 
+gen_cmd["BuiltinStringChar"] = function(self, cmd, _func)
+    local dst = self:c_var(cmd.dst)
+    local v = self:c_value(cmd.src)
+    local line = cmd.loc.line
+    return util.render([[ $dst = pallene_string_char(L, $v, $line); ]], {
+        dst = dst, v = v, line = C.integer(line) })
+end
+
 gen_cmd["BuiltinToFloat"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
     local v = self:c_value(cmd.src)

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -146,9 +146,10 @@ declare_type("Cmd", {
     CallDyn     = {"loc", "f_typ", "dst", "src_f", "srcs"},
 
     -- Builtin operations
-    BuiltinIoWrite  = {"loc",        "src"},
-    BuiltinMathSqrt = {"loc", "dst", "src"},
-    BuiltinToFloat  = {"loc", "dst", "src"},
+    BuiltinIoWrite    = {"loc",        "src"},
+    BuiltinMathSqrt   = {"loc", "dst", "src"},
+    BuiltinStringChar = {"loc", "dst", "src"},
+    BuiltinToFloat    = {"loc", "dst", "src"},
 
     --
     -- Control flow

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -146,9 +146,9 @@ declare_type("Cmd", {
     CallDyn     = {"loc", "f_typ", "dst", "src_f", "srcs"},
 
     -- Builtin operations
-    IoWrite    = {"loc",        "src"},
-    MathSqrt   = {"loc", "dst", "src"},
-    ToFloat    = {"loc", "dst", "src"},
+    BuiltinIoWrite  = {"loc",        "src"},
+    BuiltinMathSqrt = {"loc", "dst", "src"},
+    BuiltinToFloat  = {"loc", "dst", "src"},
 
     --
     -- Control flow

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -353,13 +353,13 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             local bname = cname.name
             if     bname == "io_write" then
                 assert(#xs == 1)
-                table.insert(cmds, ir.Cmd.IoWrite(loc, xs[1]))
+                table.insert(cmds, ir.Cmd.BuiltinIoWrite(loc, xs[1]))
             elseif bname == "math_sqrt" then
                 assert(#xs == 1)
-                table.insert(cmds, ir.Cmd.MathSqrt(loc, dst, xs[1]))
+                table.insert(cmds, ir.Cmd.BuiltinMathSqrt(loc, dst, xs[1]))
             elseif bname == "tofloat" then
                 assert(#xs == 1)
-                table.insert(cmds, ir.Cmd.ToFloat(loc, dst, xs[1]))
+                table.insert(cmds, ir.Cmd.BuiltinToFloat(loc, dst, xs[1]))
             else
                 error("impossible")
             end

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -357,6 +357,9 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             elseif bname == "math_sqrt" then
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinMathSqrt(loc, dst, xs[1]))
+            elseif bname == "string_char" then
+                assert(#xs == 1)
+                table.insert(cmds, ir.Cmd.BuiltinStringChar(loc, dst, xs[1]))
             elseif bname == "tofloat" then
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinToFloat(loc, dst, xs[1]))

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -360,6 +360,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             elseif bname == "string_char" then
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinStringChar(loc, dst, xs[1]))
+                table.insert(cmds, ir.Cmd.CheckGC())
             elseif bname == "tofloat" then
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinToFloat(loc, dst, xs[1]))

--- a/runtime/pallene_core.c
+++ b/runtime/pallene_core.c
@@ -166,6 +166,18 @@ void pallene_io_write(lua_State *L, TString *str)
     fwrite(s, 1, len, stdout);
 }
 
+TString* pallene_string_char(lua_State *L, lua_Integer c, int line)
+{
+    if (l_castS2U(c) > UCHAR_MAX) {
+        luaL_error(L, "char value out of range", line);
+    }
+
+    char buff[2];
+    buff[0] = c;
+    buff[1] = '\0';
+    return luaS_newlstr(L, buff, 1);
+}
+
 /* l_strcmp, copied from lvm.c
  *
  * Compare two strings 'ls' x 'rs', returning an integer less-equal-

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -63,6 +63,9 @@ void pallene_grow_array(
 void pallene_io_write(
     lua_State *L, TString *str);
 
+TString* pallene_string_char(
+    lua_State *L, lua_Integer c, int line);
+
 int pallene_l_strcmp(
     const TString *ls, const TString *rs);
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1082,7 +1082,7 @@ describe("Pallene coder /", function()
         end)
     end)
 
-    describe("sqrt builtin", function()
+    describe("math.sqrt builtin", function()
         setup(compile([[
             function square_root(x: float): float
                 return math_sqrt(x)
@@ -1110,6 +1110,40 @@ describe("Pallene coder /", function()
             run_test([[
                 local x = test.square_root(0.0 / 0.0)
                 assert(x ~= x)
+            ]])
+        end)
+    end)
+
+    describe("string.char builtin", function()
+        setup(compile([[
+            function chr(x: integer): string
+                return string_char(x)
+            end
+        ]]))
+
+        it("works on normal characters", function()
+            run_test([[
+                for i = 1, 255 do
+                    assert(string.char(i) == test.chr(i))
+                end
+            ]])
+        end)
+
+        it("works on zero", function()
+            run_test([[
+                assert(string.char(0) == test.chr(0))
+            ]])
+        end)
+
+        it("error case", function()
+            run_test([[
+                local ok, err = pcall(test.chr, -1)
+                assert(not ok)
+                assert(string.find(err, "out of range", nil, true))
+
+                local ok, err = pcall(test.chr, 256)
+                assert(not ok)
+                assert(string.find(err, "out of range", nil, true))
             ]])
         end)
     end)


### PR DESCRIPTION
Only the single-parameter version. LuaJIT also has a special case for that so why shouldn't we? :)

This builtin function will be used in the mandelbrot benchmark from the benchmarks game.