### PR TITLE
Fix bug with GC return values

### DIFF
--- a/pallene/gc.lua
+++ b/pallene/gc.lua
@@ -59,6 +59,10 @@ function gc.compute_stack_slots(func)
             end
         end
     end
+    for i = 1, #func.typ.ret_types do
+        local v = ir.ret_var(func, i)
+        last_use[v] = #flat_cmds + 1
+    end
 
     -- 2) Find which variables are live at each GC and, conversely,
     --    which variables are live at some GC slot.


### PR DESCRIPTION
Fix a bug where the value of `exp` in `return exp` would be garbage collected
even though it shouldn't. The problem was that we were failing to consider that
the internal "return" variables are live until the end of the function.