### PR TITLE
Value conditions

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -247,7 +247,7 @@ Pallene functions can refer to functions defined before them but not to function
 Pallene uses the same set of operators and control-flow statements as Lua.
 The only difference is that the type system is more restrictive:
 
-* Logic operators (`not`, `and`, `or`) only operate on booleans
+* The logic operators (`not`, `and`, `or`) only operate on expressions of type `boolean` or of type `value`
 * The condition of `if`, `while` and `repeat` must be of type `boolean` or of type `value`
 * Relational operators (`==`, `<`, etc) must receive two arguments of the same type.
 * The arithmetic and concatenation operators don't automatically coerce between numbers and strings.

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -248,7 +248,7 @@ Pallene uses the same set of operators and control-flow statements as Lua.
 The only difference is that the type system is more restrictive:
 
 * Logic operators (`not`, `and`, `or`) only operate on booleans
-* The condition for `if`, `while` and `repeat` must be a boolean
+* The condition of `if`, `while` and `repeat` must be of type `boolean` or of type `value`
 * Relational operators (`==`, `<`, etc) must receive two arguments of the same type.
 * The arithmetic and concatenation operators don't automatically coerce between numbers and strings.
 
@@ -285,8 +285,7 @@ end
 ### Automatic type coercions
 
 In some places in a Pallene program there is a natural "expected type".
-For example, the type of the condition of an if-statement is expected to be a boolean,
-and the type of a parameter being passed to a function is expected to be the type described by the corresponding function type.
+For example, the type of a parameter being passed to a function is expected to be the type described by the corresponding function type.
 Similarly, there is also an expected type for expressions surrounded by a type annotation, or values being assigned to a variable of known type.
 
 If the expected type of an expression is `value` but the inferred type is something else, Pallene will automatically insert an upcast to `value`.

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1044,12 +1044,18 @@ gen_cmd["FromDyn"] = function(self, cmd, _func)
     }))
 end
 
+gen_cmd["IsTruthy"] = function(self, cmd, _func)
+    local dst = self:c_var(cmd.dst)
+    local src = self:c_value(cmd.src)
+    return (util.render([[ $dst = pallene_is_truthy(&$src); ]], {
+        dst = dst, src = src }))
+end
+
 gen_cmd["NewArr"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
     local n = C.integer(cmd.size_hint)
     return (util.render([[ $dst = pallene_new_array(L, $n); ]], {
-        dst = dst,
-        n = n,
+        dst = dst, n = n,
     }))
 end
 

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -127,6 +127,7 @@ declare_type("Cmd", {
     --- Dynamic Value
     ToDyn      = {"loc", "src_typ", "dst", "src"},
     FromDyn    = {"loc", "dst_typ", "dst", "src"},
+    IsTruthy   = {"loc", "dst", "src"},
 
     -- Arrays
     NewArr     = {"loc", "dst", "size_hint"},

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -46,6 +46,30 @@ function types.is_gc(t)
     end
 end
 
+function types.is_condition(t)
+    local tag = t._tag
+    if     tag == "types.T.Value" or
+           tag == "types.T.Boolean"
+    then
+        return true
+
+    elseif tag == "types.T.Void" or
+           tag == "types.T.Nil" or
+           tag == "types.T.Integer" or
+           tag == "types.T.Float" or
+           tag == "types.T.String" or
+           tag == "types.T.Function" or
+           tag == "types.T.Array" or
+           tag == "types.T.Record"
+    then
+        return false
+
+    else
+        error("impossible")
+    end
+
+end
+
 -- This helper function implements both the type equality relation and the and
 -- the gradual type consistency relation from gradual typing.
 -- Gradual type consistency is a relaxed form of equality where the the "value"

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -220,5 +220,10 @@ void pallene_renormalize_array(
     }
 }
 
+static inline
+int pallene_is_truthy(const TValue *v)
+{
+    return !(ttisnil(v) || (ttisboolean(v) && bvalue(v) == 0));
+}
 
 #endif

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -342,7 +342,7 @@ describe("Pallene type checker", function()
                 return 20
             end
         ]],
-            "expected boolean but found integer in while loop condition")
+            "expression passed to while loop condition has type integer")
     end)
 
     it("requires repeat statement conditions to be boolean", function()
@@ -354,7 +354,7 @@ describe("Pallene type checker", function()
                 return 20
             end
         ]],
-            "expected boolean but found integer in repeat-until loop condition")
+            "expression passed to repeat-until loop condition has type integer")
     end)
 
     it("requires if statement conditions to be boolean", function()
@@ -367,7 +367,7 @@ describe("Pallene type checker", function()
                 end
             end
         ]],
-            "expected boolean but found integer in if statement condition")
+            "expression passed to if statement condition has type integer")
     end)
 
     it("ensures numeric 'for' variable has number type", function()

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -178,7 +178,7 @@ describe("Pallene type checker", function()
                 return not nil
             end
         ]],
-            "trying to boolean negate a nil")
+            "expression passed to 'not' operator has type nil")
     end)
 
     it("catches mismatching types in locals", function()
@@ -552,7 +552,7 @@ describe("Pallene type checker", function()
                 }) do
                     local dir, t1, t2 = test[1], test[2], test[3]
                     optest(
-       "$dir hand side of logical expression is a $t instead of a boolean", [[
+       "$dir hand side of '$op' has type $t", [[
                         function fn(x: $t1, y: $t2) : boolean
                             return x $op y
                         end

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -309,6 +309,7 @@ describe("Pallene coder /", function()
             { "neg_i", "-",   "integer", "integer" },
             { "bnot",  "~",   "integer", "integer" },
             { "not_b", "not", "boolean", "boolean" },
+            { "not_v", "not", "value",   "value"   },
         }
 
         local pallene_code = {}
@@ -416,6 +417,9 @@ describe("Pallene coder /", function()
 
             { "and_bb",    "and", "boolean", "boolean", "boolean" },
             { "or_bb",     "or",  "boolean", "boolean", "boolean" },
+
+            { "and_vv",    "and", "value", "value", "value" },
+            { "or_vv",     "or",  "value", "value", "value" },
 
             { "concat_ss", "..",  "string",  "string",  "string" },
         }
@@ -1220,7 +1224,6 @@ describe("Pallene coder /", function()
                 until x
                 return out
             end
-
         ]]))
 
         --
@@ -1278,8 +1281,6 @@ describe("Pallene coder /", function()
                 assert(2 == test.repeat_value(nil))
             ]])
         end)
-
-
     end)
 
     describe("Corner cases of scoping", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1192,6 +1192,35 @@ describe("Pallene coder /", function()
             function write(xs:{value}, i:integer, x:value): ()
                 xs[i] = x
             end
+
+            function if_value(x:value): boolean
+                if x then
+                    return true
+                else
+                    return false
+                end
+            end
+
+            function while_value(x:value): integer
+                local out = 0
+                while x do
+                    out = out + 1
+                    x = false
+                end
+                return out
+            end
+
+            function repeat_value(x:value): integer
+                local out = 0
+                repeat
+                    out = out + 1
+                    if out == 2 then
+                        break
+                    end
+                until x
+                return out
+            end
+
         ]]))
 
         --
@@ -1222,6 +1251,35 @@ describe("Pallene coder /", function()
                 assert("hello" == xs[2])
             ]])
         end)
+
+        it("can use value in if-statement condition", function()
+            run_test([[
+                assert(true == test.if_value(0))
+                assert(true == test.if_value(true))
+                assert(false == test.if_value(false))
+                assert(false == test.if_value(nil))
+            ]])
+        end)
+
+        it("can use value in while-statement condition", function()
+            run_test([[
+                assert(1 == test.while_value(0))
+                assert(1 == test.while_value(true))
+                assert(0 == test.while_value(false))
+                assert(0 == test.while_value(nil))
+            ]])
+        end)
+
+        it("can use value in repeat-until-statement condition", function()
+            run_test([[
+                assert(1 == test.repeat_value(0))
+                assert(1 == test.repeat_value(true))
+                assert(2 == test.repeat_value(false))
+                assert(2 == test.repeat_value(nil))
+            ]])
+        end)
+
+
     end)
 
     describe("Corner cases of scoping", function()

--- a/spec/coder_test_operators.lua
+++ b/spec/coder_test_operators.lua
@@ -19,6 +19,23 @@ local values = {
     },
 }
 
+do
+    local typs = {}
+    for k, _ in pairs(values) do
+        table.insert(typs, k)
+    end
+    table.sort(typs)
+
+    local all_values = {}
+    for _, typ in ipairs(typs) do
+        for _, v in ipairs(values[typ]) do
+            table.insert(all_values, v)
+        end
+    end
+
+    values["value"] = all_values
+end
+
 local function isnan(x)
     return x ~= x
 end


### PR DESCRIPTION
This PR allows expressions of type `value` to be used as the condition of if-statements, while-statements, and repeat-until statements, as well as the `and`, `or` and `not` operators. The semantics is the same as Lua's.