### PR TITLE
Rename 'sum' to 'sum_floats' to match the definition in sum.pln

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -33,7 +33,7 @@ The `sum.so` file can be loaded from within Lua with `require`, as usual:
 ```
 $ ./lua/src/lua
 > sum = require "sum"
-> print(sum.sum({10.0, 20.0, 30.0}))
+> print(sum.sum_floats({10.0, 20.0, 30.0}))
 ```
 
 In this example, we invoke our bundled Lua interpreter because Pallene is only compatible with a specific release version of the interpreter.


### PR DESCRIPTION
Fix a typo in the docs where `sum()` is used instead of calling the intended `sum_floats()` function defined `sum.pln`.