### PR TITLE
Some pallene_core cleanups

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1100,7 +1100,7 @@ end
 gen_cmd["NewArr"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
     local n = C.integer(cmd.size_hint)
-    return (util.render([[ $dst = pallene_new_array(L, $n); ]], {
+    return (util.render([[ $dst = pallene_createtable(L, $n, 0); ]], {
         dst = dst, n = n,
     }))
 end
@@ -1152,7 +1152,7 @@ end
 gen_cmd["NewTable"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
     local n = C.integer(cmd.size_hint)
-    return (util.render([[ $dst = pallene_new_table(L, $n); ]], {
+    return (util.render([[ $dst = pallene_createtable(L, 0, $n); ]], {
         dst = dst,
         n = n,
     }))

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -24,9 +24,6 @@
 #define PALLENE_LIKELY(x)   __builtin_expect(!!(x), 1)
 #define PALLENE_UNLIKELY(x) __builtin_expect(!!(x), 0)
 
-#define PALLENE_LUAINTEGER_NBITS  cast_int(sizeof(lua_Integer) * CHAR_BIT)
-
-
 const char *pallene_tag_name(int raw_tag);
 
 void pallene_runtime_tag_check_error(
@@ -171,13 +168,16 @@ lua_Integer pallene_int_modi(
  * instruction.  In the dynamic case with unknown "y" this implementation is a
  * little bit faster Lua because we put the most common case under a single
  * level of branching. (~20% speedup) */
+
+#define PALLENE_NBITS  (sizeof(lua_Integer) * CHAR_BIT)
+
 static inline
 lua_Integer pallene_shiftL(lua_Integer x, lua_Integer y)
 {
-    if (PALLENE_LIKELY(l_castS2U(y) < PALLENE_LUAINTEGER_NBITS)) {
+    if (PALLENE_LIKELY(l_castS2U(y) < PALLENE_NBITS)) {
         return intop(<<, x, y);
     } else {
-        if (l_castS2U(-y) < PALLENE_LUAINTEGER_NBITS) {
+        if (l_castS2U(-y) < PALLENE_NBITS) {
             return intop(>>, x, -y);
         } else {
             return 0;
@@ -187,10 +187,10 @@ lua_Integer pallene_shiftL(lua_Integer x, lua_Integer y)
 static inline
 lua_Integer pallene_shiftR(lua_Integer x, lua_Integer y)
 {
-    if (PALLENE_LIKELY(l_castS2U(y) < PALLENE_LUAINTEGER_NBITS)) {
+    if (PALLENE_LIKELY(l_castS2U(y) < PALLENE_NBITS)) {
         return intop(>>, x, y);
     } else {
-        if (l_castS2U(-y) < PALLENE_LUAINTEGER_NBITS) {
+        if (l_castS2U(-y) < PALLENE_NBITS) {
             return intop(<<, x, -y);
         } else {
             return 0;

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -193,13 +193,14 @@ lua_Integer pallene_shiftR(lua_Integer x, lua_Integer y)
 }
 
 
-/* Similar to lua_createtable*/
+/* This version of lua_createtable bypasses the Lua stack, and can be inlined
+ * and optimized when the allocation size is known at compilation time. */
 static inline
-Table *pallene_new_array(lua_State *L, lua_Integer n)
+Table *pallene_createtable(lua_State *L, lua_Integer narray, lua_Integer nrec)
 {
     Table *t = luaH_new(L);
-    if (n > 0) {
-        luaH_resizearray(L, t, n);
+    if (narray > 0 || nrec > 0) {
+        luaH_resize(L, t, narray, nrec);
     }
     return t;
 }
@@ -224,16 +225,6 @@ static inline
 int pallene_is_truthy(const TValue *v)
 {
     return !(ttisnil(v) || (ttisboolean(v) && bvalue(v) == 0));
-}
-
-static inline
-Table *pallene_new_table(lua_State *L, lua_Integer n)
-{
-    Table *t = luaH_new(L);
-    if (n > 0) {
-        luaH_resize(L, t, 0, n);
-    }
-    return t;
 }
 
 static const TValue PALLENE_ABSENTKEY = {ABSTKEYCONSTANT};

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -76,6 +76,12 @@ int pallene_l_strcmp(
 /* Inline functions and macros */
 /* --------------------------- */
 
+static inline
+int pallene_is_truthy(const TValue *v)
+{
+    return !l_isfalse(v);
+}
+
 /* This is a workaround to avoid -Wmaybe-uninitialized warnings with GCC. If we
  * initialize a TValue with setnilvalue and then follow that with a setobj, GCC
  * complains that the setobj might be reading from an uninitialized obj->value_.
@@ -219,12 +225,6 @@ void pallene_renormalize_array(
     if (PALLENE_UNLIKELY(ui >= arr->alimit)) {
         pallene_grow_array(L, arr, ui, line);
     }
-}
-
-static inline
-int pallene_is_truthy(const TValue *v)
-{
-    return !(ttisnil(v) || (ttisboolean(v) && bvalue(v) == 0));
 }
 
 static const TValue PALLENE_ABSENTKEY = {ABSTKEYCONSTANT};

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -227,11 +227,13 @@ void pallene_renormalize_array(
     }
 }
 
+/* This function is a version of luaH_getshortstr that uses an inline cache for
+ * the hash function */
+
 static const TValue PALLENE_ABSENTKEY = {ABSTKEYCONSTANT};
 
-/* This function is a speciallization of luaH_getshortstr from ltable.c */
 static inline
-TValue *pallene_getshortstr(Table *t, TString *key, size_t *pos)
+TValue *pallene_getshortstr(Table *t, TString *key, size_t * restrict pos)
 {
     if (*pos < sizenode(t)) {
        Node *n = gnode(t, *pos);


### PR DESCRIPTION
Small cleanup changes to pallene_core.h.

1. pallene_new_table and pallene_new_array are now combined in a single pallene_createtable function.

2. pallene_is_truthy now calls l_isfalse instead of copy and pasting the definition of l_isfalse.

3. The cache parameter to pallene_getshortstr is now a restrict pointer. I didn't measure a difference but I suppose it wouldn't hurt.

4. Rename PALLENE_LUAINTEGER_BITS to PALLENE_NBITS, and move it closer to where it is used.