### PR TITLE
Create temp files for intermediate compilation steps

### DIFF
--- a/pallene/c_compiler.lua
+++ b/pallene/c_compiler.lua
@@ -56,6 +56,8 @@ function c_compiler.compile_s_to_o(in_filename, out_filename)
 end
 
 function c_compiler.compile_o_to_so(in_filename, out_filename)
+    -- There is no need to add the '-x' flag when compiling an object file without a '.o' extension.
+    -- According to GCC, any file name with no recognized suffix is treated as an object file.
     return run_cc({
         c_compiler.CFLAGS_SHARED,
         "-o", util.shell_quote(out_filename),

--- a/pallene/c_compiler.lua
+++ b/pallene/c_compiler.lua
@@ -40,6 +40,7 @@ function c_compiler.compile_c_to_s(in_filename, out_filename)
         c_compiler.CFLAGS_WARN,
         c_compiler.CFLAGS_OPT,
         c_compiler.S_FLAGS,
+        "-x c",
         "-o", util.shell_quote(out_filename),
         "-S", util.shell_quote(in_filename),
     })
@@ -47,6 +48,7 @@ end
 
 function c_compiler.compile_s_to_o(in_filename, out_filename)
     return run_cc({
+        "-x assembler",
         "-o", util.shell_quote(out_filename),
         "-c", util.shell_quote(in_filename),
     })

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -136,7 +136,11 @@ function driver.compile(argv0, input_ext, output_ext, input_file_name)
     local file_names = {}
     for i = first_step, last_step do
         local step = compiler_steps[i]
-        file_names[i] = base_name .. "." .. step.name
+        if (i == first_step or i == last_step) then
+            file_names[i] = base_name .. "." .. step.name
+        else
+            file_names[i] = os.tmpname()
+        end
     end
 
     local ok, errs


### PR DESCRIPTION
Closes #71.

- Using Lua's `os.tmpname()`, a new temp file is created for each intermediate compilation step.
- The `-x` is added to the C compiler to force it to compile in the specified language since temp files won't have any extensions.