### PR TITLE
License information comments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,10 @@
+Ahmed Karaman
+Andre Murbach Maidl
+Fabio Mascarenhas
+Gabriel de Quadros Ligneul
+Hisham Muhammad
+Hugo Musso Gualandi
+Leonardo Kaplan
+Matheus Ambrozio
+PJ Pollina
+Sérgio Queiroz

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2019, The Pallene Developers
-Copyright (c) 2018, The Titan Project Developers
+Copyright (c) 2019-2020, The Pallene Developers
+Copyright (c) 2018,      The Titan Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pallene/C.lua
+++ b/pallene/C.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local C = {}
 --
 -- This module contains some helper functions for generating C code.

--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local typedecl = require "pallene.typedecl"
 
 local ast = {}

--- a/pallene/builtins.lua
+++ b/pallene/builtins.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local types = require "pallene.types"
 
 local builtins = {}

--- a/pallene/c_compiler.lua
+++ b/pallene/c_compiler.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = require "pallene.util"
 
 local c_compiler = {}

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local ast = require "pallene.ast"
 local builtins = require "pallene.builtins"
 local ir = require "pallene.ir"

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local C = require "pallene.C"
 local gc = require "pallene.gc"
 local ir = require "pallene.ir"

--- a/pallene/constant_propagation.lua
+++ b/pallene/constant_propagation.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local ir = require "pallene.ir"
 
 local constant_propagation = {}

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local c_compiler = require "pallene.c_compiler"
 local checker = require "pallene.checker"
 local constant_propagation = require "pallene.constant_propagation"

--- a/pallene/gc.lua
+++ b/pallene/gc.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local ir = require "pallene.ir"
 local types = require "pallene.types"
 

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local typedecl = require "pallene.typedecl"
 
 -- This IR is produced as a result of typechecking the parser's AST. The main

--- a/pallene/lexer.lua
+++ b/pallene/lexer.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 --
 -- This module exports lpeg patterns that can lex Pallene source code.
 --

--- a/pallene/location.lua
+++ b/pallene/location.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 -- A Location datatype representing a point in a source code file
 local location = {}
 

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local parser = {}
 
 local re = require "relabel"

--- a/pallene/symtab.lua
+++ b/pallene/symtab.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = require "pallene.util"
 
 local Symtab = util.Class()

--- a/pallene/syntax_errors.lua
+++ b/pallene/syntax_errors.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local syntax_errors = {}
 
 local errors = {

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local ir = require "pallene.ir"
 local types = require "pallene.types"
 local util = require "pallene.util"

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local typedecl = {}
 
 -- Unique tag names:

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local typedecl = require "pallene.typedecl"
 
 local types = {}

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local ir = require "pallene.ir"
 local location = require "pallene.location"
 

--- a/pallene/util.lua
+++ b/pallene/util.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = {}
 
 function util.abort(msg)

--- a/runtime/pallene_core.c
+++ b/runtime/pallene_core.c
@@ -1,3 +1,8 @@
+/* Copyright (c) 2020, The Pallene Developers
+ * Pallene is licensed under the MIT license.
+ * Please refer to the LICENSE and AUTHORS files for details
+ * SPDX-License-Identifier: MIT */
+
 #include "pallene_core.h"
 
 #include "lua.h"

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -1,3 +1,8 @@
+/* Copyright (c) 2020, The Pallene Developers
+ * Pallene is licensed under the MIT license.
+ * Please refer to the LICENSE and AUTHORS files for details
+ * SPDX-License-Identifier: MIT */
+
 #ifndef PALLENE_CORE_H
 #define PALLENE_CORE_H
 


### PR DESCRIPTION
This PR adds license comments to the source code files, as discussed in #117.

The authors list contains everyone that made a non-trivial commit, sorted alphabetically.

The license comments were added to the files in the `pallene` and `runtime` folders. I did not add license comments to the spec files or to the benchmarks. Should we add copyright info to those as well?