### PR TITLE
Raise runtime errors for __len and __index metamethods

### DIFF
--- a/runtime/pallene_core.c
+++ b/runtime/pallene_core.c
@@ -109,6 +109,13 @@ int pallene_runtime_record_index_error(
     PALLENE_UNREACHABLE;
 }
 
+void pallene_runtime_array_metatable_error(
+    lua_State *L, int line
+){
+    luaL_error(L, "arrays in Pallene must not have a metatable. Line %d", line);
+    PALLENE_UNREACHABLE;
+}
+
 static void copy_strings_to_buffer(char *out_buf, size_t n, TString **ss)
 {
     char *b = out_buf;

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -56,6 +56,10 @@ int pallene_runtime_record_index_error(
     lua_State *L, const char *key)
     PALLENE_NORETURN;
 
+void pallene_runtime_array_metatable_error(
+    lua_State *L, int line)
+    PALLENE_NORETURN;
+
 TString *pallene_string_concatN(
     lua_State *L, size_t n, TString **ss);
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1046,6 +1046,16 @@ describe("Pallene coder /", function()
         it("{any}: out-of-bounds get nil", function()
             run_test([[ assert(nil == test.getany({10, nil, 30}, 4)) ]])
         end)
+
+        it("length operator rejects tables with a metatable", function()
+            run_test([[
+                local arr = {}
+                setmetatable(arr, { __len = function(self) return 42 end })
+                local ok, err = pcall(test.len, arr)
+                assert(not ok)
+                assert(string.find(err, "must not have a metatable", nil, true))
+            ]])
+        end)
     end)
 
     describe("Tables /", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1047,11 +1047,21 @@ describe("Pallene coder /", function()
             run_test([[ assert(nil == test.getany({10, nil, 30}, 4)) ]])
         end)
 
-        it("length operator rejects tables with a metatable", function()
+        it("length operator rejects arrays with a metatable", function()
             run_test([[
                 local arr = {}
                 setmetatable(arr, { __len = function(self) return 42 end })
                 local ok, err = pcall(test.len, arr)
+                assert(not ok)
+                assert(string.find(err, "must not have a metatable", nil, true))
+            ]])
+        end)
+
+        it("indexing operator rejects arrays with a metatable", function()
+            run_test([[
+                local arr = {}
+                setmetatable(arr, { __index = function(self, k) return 42 end })
+                local ok, err = pcall(test.getany, arr, 1)
                 assert(not ok)
                 assert(string.find(err, "must not have a metatable", nil, true))
             ]])
@@ -1159,6 +1169,16 @@ describe("Pallene coder /", function()
             run_test([[
                 local t = {]].. maxlenfield ..[[ = 10}
                 assert(10 == test.getmax(t))
+            ]])
+        end)
+
+        it("table field access rejects tables with a metatable", function()
+            run_test([[
+                local tab = {}
+                setmetatable(tab, { __index = function(self, k) return 42 end })
+                local ok, err = pcall(test.getany, tab)
+                assert(not ok)
+                assert(string.find(err, "must not have a metatable", nil, true))
             ]])
         end)
     end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1181,6 +1181,16 @@ describe("Pallene coder /", function()
                 assert(string.find(err, "must not have a metatable", nil, true))
             ]])
         end)
+
+        it("table field access rejects tables with a metatable", function()
+            run_test([[
+                local tab = {}
+                setmetatable(tab, { __index = function(self, k) return 42 end })
+                local ok, err = pcall(test.getnil, tab)
+                assert(not ok)
+                assert(string.find(err, "must not have a metatable", nil, true))
+            ]])
+        end)
     end)
 
     describe("Strings", function()


### PR DESCRIPTION
This PR contains two related changes.

The first is that the `#` operator now raises an error if the array contains a metatable. This is to preserve the gradual guarantee when the array has a __len metamethod. This fixes #114 

The second change is that reading from an array or Lua record now raises an error if we read a nil and the table has a metatable. This is also to preserve the gradual guarantee, but for the __index metamethod.