### PR TITLE
Implement Lua 5.4 for loop overflow behavior

### DIFF
--- a/pallene/c_compiler.lua
+++ b/pallene/c_compiler.lua
@@ -10,7 +10,7 @@ local c_compiler = {}
 c_compiler.CC = "cc"
 c_compiler.CPPFLAGS = "-I./lua/src -I./runtime"
 c_compiler.CFLAGS_BASE = "-std=c99 -g -fPIC"
-c_compiler.CFLAGS_WARN = "-Wall -Wundef -Wshadow -Wpedantic -Wno-unused"
+c_compiler.CFLAGS_WARN = "-Wall -Wundef -Wpedantic -Wno-unused"
 c_compiler.CFLAGS_OPT = "-O2"
 c_compiler.S_FLAGS = "-fverbose-asm"
 

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -317,7 +317,7 @@ TValue *pallene_getshortstr(Table *t, TString *key, size_t * restrict pos)
         lua_Number _init  = A; \
         lua_Number _limit = B; \
         lua_Number _step  = C; \
-        if (_step == 0.0 ) { \
+        if (_step == 0.0) { \
             luaL_error(L, "'for' step is zero"); \
         } \
         for ( \

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -270,4 +270,66 @@ TValue *pallene_getshortstr(Table *t, TString *key, size_t * restrict pos)
     }
 }
 
+/* To avoid looping infinitely due to integer overflow, Lua 5.4 carefully
+ * computes the number of iterations before starting the loop (see OP_FORPREP).
+ *
+ * The code that implements this behavior does not look like a regular C for
+ * loop, so to help improve the readability of the generated C code we hide it
+ * behind the following set of macros. Note that some of the open braces in the
+ * BEGIN macro are only closed in the END macro, so they must always be used
+ * together.
+ *
+ * We assume that the C compiler will be able to optimize the common case where
+ * the step parameter is a compile-time constant. */
+
+#define PALLENE_INT_FOR_LOOP_BEGIN(i, A, B, C) \
+    { \
+        lua_Integer _init  = A; \
+        lua_Integer _limit = B; \
+        lua_Integer _step  = C; \
+        if (_step == 0 ) { \
+            luaL_error(L, "'for' step is zero"); \
+        } \
+        if (_step > 0 ? (_init <= _limit) : (_init >= _limit)) {        \
+            lua_Unsigned _uinit  = l_castS2U(_init);                    \
+            lua_Unsigned _ulimit = l_castS2U(_limit);                   \
+            lua_Unsigned _count = ( _step > 0                           \
+                ? (_ulimit - _uinit) / _step                            \
+                : (_uinit - _ulimit) / (l_castS2U(-(_step + 1)) + 1u)); \
+            lua_Integer _loopvar = _init; \
+            while (1) { \
+                i = _loopvar; \
+                {
+                    /* Loop body goes here*/
+
+#define PALLENE_INT_FOR_LOOP_END \
+                } \
+                if (_count == 0) break; \
+                _loopvar += _step; \
+                _count -= 1; \
+            } \
+        } \
+    }
+
+
+#define PALLENE_FLT_FOR_LOOP_BEGIN(i, A, B, C) \
+    { \
+        lua_Number _init  = A; \
+        lua_Number _limit = B; \
+        lua_Number _step  = C; \
+        if (_step == 0.0 ) { \
+            luaL_error(L, "'for' step is zero"); \
+        } \
+        for ( \
+            lua_Number _loopvar = _init; \
+            (_step > 0.0 ? (_loopvar <= _limit) : (_loopvar >= _limit)); \
+            _loopvar += _step \
+        ){ \
+            i = _loopvar;
+            /* Loop body goes here*/
+
+#define PALLENE_FLT_FOR_LOOP_END \
+        } \
+    }
+
 #endif

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1813,6 +1813,58 @@ describe("Pallene coder /", function()
                 assert(17 == test.initialize_inside_loop())
             ]])
         end)
+    end)
 
+    describe("For loop integer overflow", function()
+        setup(compile([[
+            function loop(A: integer, B: integer, C: integer): {integer}
+                local xs: {integer} = {}
+                for i = A, B, C do
+                    xs[#xs+1] = i
+                end
+                return xs
+            end
+        ]]))
+
+        it("int loop avoids overflow", function()
+            run_test([[
+                local high = math.maxinteger
+                local xs = test.loop(high-5, high, 10)
+                assert(#xs == 1)
+                assert(xs[1] == high-5)
+            ]])
+        end)
+
+        it("int loop avoids underderflow", function()
+            run_test([[
+                local low = math.mininteger
+                local xs = test.loop(low+5, low, -10)
+                assert(#xs == 1)
+                assert(xs[1] == low+5)
+            ]])
+        end)
+
+        it("very large interval (up)", function()
+            run_test([[
+                local low  = math.mininteger
+                local high = math.maxinteger
+                local xs = test.loop(low, high, high)
+                assert(#xs == 3)
+                assert(xs[1] == low)
+                assert(xs[2] == -1)
+                assert(xs[3] == high-1)
+            ]])
+        end)
+
+        it("very large interval (down)", function()
+            run_test([[
+                local low  = math.mininteger
+                local high = math.maxinteger
+                local xs = test.loop(high, low, low)
+                assert(#xs == 2)
+                assert(xs[1] == high)
+                assert(xs[2] == -1)
+            ]])
+        end)
     end)
 end)


### PR DESCRIPTION
Fixes #170.

I disabled the -Wshadow flag to let me always use the same variable names in the for-loop macro. Do you remember if that warning was enabled for some important reason? If you can't remember, do you know if there is an easy way to check the git history to find that out?