### PR TITLE
Allow table field names longer than 40 character

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -162,9 +162,6 @@ function Checker:from_ast_type(ast_typ)
                 type_error(ast_typ.loc, "duplicate field '%s' in table",
                            field.name)
             end
-            if #field.name > 40 then
-                type_error(ast_typ.loc, "field name '%s' too long", field.name)
-            end
             fields[field.name] = self:from_ast_type(field.type)
         end
         return types.T.Table(fields)

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1202,7 +1202,6 @@ gen_cmd["GetTable"] = function(self, cmd, _func)
     local tab = self:c_value(cmd.src_tab)
     local key = self:c_value(cmd.src_k)
     local dst_typ = cmd.dst_typ
-    local line = C.integer(cmd.loc.line)
 
     assert(cmd.src_k._tag == "ir.Value.String")
     local field_name = cmd.src_k.value

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1222,7 +1222,7 @@ gen_cmd["GetTable"] = function(self, cmd, _func)
     -- Else, use Lua's default getStr method
     else
         find_slot = util.render([[
-            TValue *slot = luaH_getstr($tab, $key);
+            TValue *slot = cast(TValue *, luaH_getstr($tab, $key));
         ]], ops)
     end
 
@@ -1260,7 +1260,7 @@ gen_cmd["SetTable"] = function(self, cmd, _func)
     -- Else, use Lua's default getStr method
     else
         find_slot = util.render([[
-            TValue *slot = luaH_getstr($tab, $key);
+            TValue *slot = cast(TValue *, luaH_getstr($tab, $key));
         ]], ops)
     end
 

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1209,7 +1209,7 @@ gen_cmd["GetTable"] = function(self, cmd, _func)
     return util.render([[
         {
             static size_t cache = UINT_MAX;
-            TValue *slot = pallene_get_fieldslot($field_len, $tab, $key, &cache);
+            TValue *slot = pallene_getstr($field_len, $tab, $key, &cache);
             ${get_slot}
         }
     ]], {
@@ -1232,7 +1232,7 @@ gen_cmd["SetTable"] = function(self, cmd, _func)
     return util.render([[
         {
             static size_t cache = UINT_MAX;
-            TValue *slot = pallene_get_fieldslot($field_len, $tab, $key, &cache);
+            TValue *slot = pallene_getstr($field_len, $tab, $key, &cache);
             if (PALLENE_UNLIKELY(isabstkey(slot))) {
                 TValue keyv;
                 setsvalue(L, &keyv, $key);

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1208,8 +1208,8 @@ gen_cmd["GetTable"] = function(self, cmd, _func)
 
     return util.render([[
         {
-            TValue *slot;
-            pallene_getfieldslot($field_len, $tab, $key, slot);
+            static size_t cache = UINT_MAX;
+            TValue *slot = pallene_get_fieldslot($field_len, $tab, $key, &cache);
             ${get_slot}
         }
     ]], {
@@ -1231,8 +1231,8 @@ gen_cmd["SetTable"] = function(self, cmd, _func)
 
     return util.render([[
         {
-            TValue *slot;
-            pallene_getfieldslot($field_len, $tab, $key, slot);
+            static size_t cache = UINT_MAX;
+            TValue *slot = pallene_get_fieldslot($field_len, $tab, $key, &cache);
             if (PALLENE_UNLIKELY(isabstkey(slot))) {
                 TValue keyv;
                 setsvalue(L, &keyv, $key);

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1209,7 +1209,6 @@ gen_cmd["GetTable"] = function(self, cmd, _func)
     local ops = {
         tab = tab,
         key = key,
-        line = line,
     }
 
     -- If the table field size is smaller than 40, use the optimized getStr Pallene implementation

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -332,4 +332,15 @@ TValue *pallene_getshortstr(Table *t, TString *key, size_t * restrict pos)
         } \
     }
 
+/* If the table field size is smaller than LUAI_MAXSHORTLEN, use the optimized getStr Pallene implementation.
+ * Else, use Lua's default getStr method. */
+#define pallene_getfieldslot(field_len, tab, key, slot) \
+    if (field_len < LUAI_MAXSHORTLEN) { \
+        static size_t cache = UINT_MAX; \
+        slot = pallene_getshortstr(tab, key, &cache); \
+    } \
+    else { \
+        slot = cast(TValue *, luaH_getstr(tab, key)); \
+    }
+
 #endif

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -332,15 +332,17 @@ TValue *pallene_getshortstr(Table *t, TString *key, size_t * restrict pos)
         } \
     }
 
-/* If the table field size is smaller than LUAI_MAXSHORTLEN, use the optimized getStr Pallene implementation.
- * Else, use Lua's default getStr method. */
-#define pallene_getfieldslot(field_len, tab, key, slot) \
-    if (field_len < LUAI_MAXSHORTLEN) { \
-        static size_t cache = UINT_MAX; \
-        slot = pallene_getshortstr(tab, key, &cache); \
-    } \
-    else { \
-        slot = cast(TValue *, luaH_getstr(tab, key)); \
+/* If the table field size is smaller than LUAI_MAXSHORTLEN, use the optimized
+ * getStr Pallene implementation, else, use use Lua's default getStr method. */
+static inline
+TValue *pallene_get_fieldslot(
+        size_t field_len, Table *tab, TString *key, size_t *restrict cache)
+{
+    if (field_len < LUAI_MAXSHORTLEN) {
+        return pallene_getshortstr(tab, key, cache);
+    } else {
+        return cast(TValue *, luaH_getstr(tab, key));
     }
+}
 
 #endif

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -270,6 +270,19 @@ TValue *pallene_getshortstr(Table *t, TString *key, size_t * restrict pos)
     }
 }
 
+/* If the table field size is smaller than LUAI_MAXSHORTLEN, use the optimized
+ * getStr Pallene implementation, else, use use Lua's default getStr method. */
+static inline
+TValue *pallene_getstr(
+        size_t field_len, Table *tab, TString *key, size_t *restrict cache)
+{
+    if (field_len < LUAI_MAXSHORTLEN) {
+        return pallene_getshortstr(tab, key, cache);
+    } else {
+        return cast(TValue *, luaH_getstr(tab, key));
+    }
+}
+
 /* To avoid looping infinitely due to integer overflow, Lua 5.4 carefully
  * computes the number of iterations before starting the loop (see OP_FORPREP).
  *
@@ -331,18 +344,5 @@ TValue *pallene_getshortstr(Table *t, TString *key, size_t * restrict pos)
 #define PALLENE_FLT_FOR_LOOP_END \
         } \
     }
-
-/* If the table field size is smaller than LUAI_MAXSHORTLEN, use the optimized
- * getStr Pallene implementation, else, use use Lua's default getStr method. */
-static inline
-TValue *pallene_get_fieldslot(
-        size_t field_len, Table *tab, TString *key, size_t *restrict cache)
-{
-    if (field_len < LUAI_MAXSHORTLEN) {
-        return pallene_getshortstr(tab, key, cache);
-    } else {
-        return cast(TValue *, luaH_getstr(tab, key));
-    }
-}
 
 #endif

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -130,6 +130,14 @@ describe("Pallene type checker", function()
             "duplicate field 'x' in table")
     end)
 
+    it("allows tables with fields with more than LUAI_MAXSHORTLEN chars", function()
+        local field = string.rep('a', 41)
+        local module, _ = run_checker([[
+            function f(t: {]].. field ..[[: float}) end
+        ]])
+        assert.truthy(module)
+    end)
+
     it("catches array expression in indexing is not an array", function()
         assert_error([[
             function fn(x: integer)

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -130,14 +130,6 @@ describe("Pallene type checker", function()
             "duplicate field 'x' in table")
     end)
 
-    it("prohibits tables with fields with more than LUAI_MAXSHORTLEN chars", function()
-        local field = string.rep('a', 41)
-        assert_error([[
-            function f(t: {]].. field ..[[: float}) end
-        ]],
-            "field name '".. field .. "' too long")
-    end)
-
     it("catches array expression in indexing is not an array", function()
         assert_error([[
             function fn(x: integer)


### PR DESCRIPTION
- This PR implements issue #154.

- The code compiles and runs successfully for both long and short table field names, but with the following warning in case of long fields:

    ![warning](https://user-images.githubusercontent.com/20889958/74613053-b02a1d80-5113-11ea-9379-c094989f4df9.PNG)
I tried some fixes for this warning but they involved modifying the source code of the used Lua version.