### PR TITLE
Remove redundant "typ" field from `ir.Cmd.For`

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1225,7 +1225,7 @@ gen_cmd["SetTable"] = function(self, cmd, _func)
     local key = self:c_value(cmd.src_k)
     local v = self:c_value(cmd.src_v)
     local src_typ = cmd.src_typ
-    
+
     assert(cmd.src_k._tag == "ir.Value.String")
     local field_name = cmd.src_k.value
 
@@ -1476,7 +1476,7 @@ gen_cmd["Loop"] = function(self, cmd, func)
 end
 
 gen_cmd["For"] = function(self, cmd, func)
-    local typ = cmd.typ
+    local typ = func.vars[cmd.loop_var].typ
 
     local macro
     if     typ._tag == "types.T.Integer" then

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -175,7 +175,7 @@ local ir_cmd_constructors = {
     Loop    = {"body"},
 
     If      = {"loc", "condition", "then_", "else_"},
-    For     = {"loc", "typ", "loop_var", "start", "limit", "step", "body"},
+    For     = {"loc", "loop_var", "start", "limit", "step", "body"},
 
     -- Garbage Collection (appears after memory allocations)
     CheckGC = {},

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -78,14 +78,12 @@ function ToIR:convert_stat(cmds, stat)
         local cname = stat.decl._name
         assert(cname._tag == "checker.Name.Local")
         local v = cname.id
-        local typ = self.func.vars[v].typ
 
         local body = {}
         self:convert_stat(body, stat.block)
 
         table.insert(cmds, ir.Cmd.For(stat.loc,
-            typ, v,
-            start, limit, step,
+            v, start, limit, step,
             ir.Cmd.Seq(body)))
 
     elseif tag == "ast.Stat.Assign" then


### PR DESCRIPTION
We can get the same info from the `loop_var`