### PR TITLE
Change temp test file names

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -2,8 +2,8 @@ local driver = require 'pallene.driver'
 local util = require 'pallene.util'
 
 local function run_checker(code)
-    assert(util.set_file_contents("test.pln", code))
-    local module, errs = driver.compile_internal("test.pln", "checker")
+    assert(util.set_file_contents("__test__.pln", code))
+    local module, errs = driver.compile_internal("__test__.pln", "checker")
     return module, table.concat(errs, "\n")
 end
 
@@ -16,7 +16,7 @@ end
 describe("Scope analysis: ", function()
 
     teardown(function()
-        os.remove("test.pln")
+        os.remove("__test__.pln")
     end)
 
     it("forbids variables from being used before they are defined", function()
@@ -97,7 +97,7 @@ end)
 describe("Pallene type checker", function()
 
     teardown(function()
-        os.remove("test.pln")
+        os.remove("__test__.pln")
     end)
 
     it("detects when a non-type is used in a type variable", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -3,33 +3,33 @@ local util = require "pallene.util"
 
 local function compile(pallene_code)
     return function()
-        assert(util.set_file_contents("test.pln", pallene_code))
+        assert(util.set_file_contents("__test__.pln", pallene_code))
         local ok, errors =
-            driver.compile("pallenec-tests", "pln", "so", "test.pln")
+            driver.compile("pallenec-tests", "pln", "so", "__test__.pln")
         assert(ok, errors[1])
     end
 end
 
 local function run_test(test_script)
-    util.set_file_contents("test_script.lua", util.render([[
-        local test = require "test"
+    util.set_file_contents("__test__script__.lua", util.render([[
+        local test = require "__test__"
         ${TEST_SCRIPT}
     ]], {
         TEST_SCRIPT = test_script
     }))
-    assert(util.execute("./lua/src/lua test_script.lua > test_output.txt"))
+    assert(util.execute("./lua/src/lua __test__script__.lua > __test__output__.txt"))
 end
 
 local function assert_test_output(expected)
-    local output = assert(util.get_file_contents("test_output.txt"))
+    local output = assert(util.get_file_contents("__test__output__.txt"))
     assert.are.same(expected, output)
 end
 
 local function cleanup()
-    os.remove("test.pln")
-    os.remove("test.so")
-    os.remove("test_script.lua")
-    os.remove("test_output.txt")
+    os.remove("__test__.pln")
+    os.remove("__test__.so")
+    os.remove("__test__script__.lua")
+    os.remove("__test__output__.txt")
 end
 
 describe("Pallene coder /", function()

--- a/spec/pallenec_spec.lua
+++ b/spec/pallenec_spec.lua
@@ -2,49 +2,49 @@ local util = require "pallene.util"
 
 describe("pallenec", function()
     before_each(function()
-        util.set_file_contents("test.pln", [[
+        util.set_file_contents("__test__.pln", [[
             function f(x:integer): integer
                 return x + 17
             end
         ]])
-        util.set_file_contents("test_script.lua", [[
-            local test = require "test"
+        util.set_file_contents("__test__script__.lua", [[
+            local test = require "__test__"
             print(test.f(0))
         ]])
     end)
 
     after_each(function()
-        os.remove("test.pln")
-        os.remove("test.c")
-        os.remove("test.s")
-        os.remove("test.so")
-        os.remove("test_script.lua")
+        os.remove("__test__.pln")
+        os.remove("__test__.c")
+        os.remove("__test__.s")
+        os.remove("__test__.so")
+        os.remove("__test__script__.lua")
     end)
 
     it("Can compile pallene files", function()
-        assert(util.execute("./pallenec test.pln"))
-        local ok, err, out, _ = util.outputs_of_execute("./lua/src/lua test_script.lua")
+        assert(util.execute("./pallenec __test__.pln"))
+        local ok, err, out, _ = util.outputs_of_execute("./lua/src/lua __test__script__.lua")
         assert(ok, err)
         assert.equals("17\n", out)
     end)
 
     it("Can compile C files", function()
-        assert(util.execute("./pallenec --emit-c test.pln"))
-        assert(util.execute("./pallenec --compile-c test.c"))
-        local ok, err, out, _ = util.outputs_of_execute("./lua/src/lua test_script.lua")
+        assert(util.execute("./pallenec --emit-c __test__.pln"))
+        assert(util.execute("./pallenec --compile-c __test__.c"))
+        local ok, err, out, _ = util.outputs_of_execute("./lua/src/lua __test__script__.lua")
         assert(ok, err)
         assert.equals("17\n", out)
     end)
 
     it("Can create asm files", function()
-        assert(util.execute("./pallenec --emit-c test.pln"))
-        assert(util.execute("./pallenec --emit-asm test.c"))
-        local s, err = util.get_file_contents("test.s")
+        assert(util.execute("./pallenec --emit-c __test__.pln"))
+        assert(util.execute("./pallenec --emit-asm __test__.c"))
+        local s, err = util.get_file_contents("__test__.s")
         assert(s, err)
     end)
 
     it("Can detect conflicting arguments", function()
-        local ok, err, _, abortMsg = util.outputs_of_execute("./pallenec --emit-c --emit-asm test.pln")
+        local ok, err, _, abortMsg = util.outputs_of_execute("./pallenec --emit-c --emit-asm __test__.pln")
         assert.is_false(ok, err)
         assert.equals("./pallenec: flags --emit-c and --emit-asm are mutually exclusive\n", abortMsg)
     end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -34,8 +34,8 @@ end
 --
 
 local function parse(program_str)
-    assert(util.set_file_contents("test.pln", program_str))
-    return driver.compile_internal("test.pln", "parser")
+    assert(util.set_file_contents("__test__.pln", program_str))
+    return driver.compile_internal("__test__.pln", "parser")
 end
 
 local function assert_parses_successfuly(program_str)
@@ -149,7 +149,7 @@ describe("Pallene parser", function()
 
     teardown(function()
         assert:set_parameter("TableFormatLevel", ORIGINAL_FORMAT_LEVEL)
-        os.remove("test.pln")
+        os.remove("__test__.pln")
     end)
 
     it("can parse programs starting with whitespace or comments", function()

--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -2,8 +2,8 @@ local driver = require 'pallene.driver'
 local util = require 'pallene.util'
 
 local function run_uninitialized(code)
-    assert(util.set_file_contents("test.pln", code))
-    local module, errs = driver.compile_internal("test.pln", "uninitialized")
+    assert(util.set_file_contents("__test__.pln", code))
+    local module, errs = driver.compile_internal("__test__.pln", "uninitialized")
     return module, table.concat(errs, "\n")
 end
 
@@ -19,7 +19,7 @@ local missing_return =
 describe("Uninitialized variable analysis: ", function()
 
     teardown(function()
-        os.remove("test.pln")
+        os.remove("__test__.pln")
     end)
 
     it("empty function", function()


### PR DESCRIPTION
Fixes #17.

This PR renames the following temp files generated when running `busted`:
- `test.pln`	->	`__test__.pln`
- `test.c`		->	`__test__.c`
- `test.s`		->	`__test__.s`
- `test.so`		->	`__test__.so`
- `test_script.lua`	->	`__test__script__.lua`
- `test_output.txt`	->	`__test__output__.txt`