### PR TITLE
Make return values be parameters of ir.Cmd.Return

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -386,11 +386,6 @@ function FunChecker:check_function(lambda, func_typ)
             local name = lambda.arg_names[i]
             self:add_local(name, typ)
         end
-        for i, typ in ipairs(func_typ.ret_types) do
-            local name = "ret"..i
-            self:add_local(name, typ)
-        end
-
         local body = self.func.body
         self:check_stat(body)
     end)

--- a/pallene/gc.lua
+++ b/pallene/gc.lua
@@ -64,10 +64,6 @@ function gc.compute_stack_slots(func)
             end
         end
     end
-    for i = 1, #func.typ.ret_types do
-        local v = ir.ret_var(func, i)
-        last_use[v] = #flat_cmds + 1
-    end
 
     -- 2) Find which variables are live at each GC and, conversely,
     --    which variables are live at some GC slot.

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -95,12 +95,6 @@ function ir.arg_var(func, i)
     return i
 end
 
-function ir.ret_var(func, i)
-    local nret = #func.typ.ret_types
-    assert(1 <= i and i <= nret)
-    return #func.typ.arg_types + i
-end
-
 --
 -- Pallene IR
 --
@@ -171,7 +165,7 @@ local ir_cmd_constructors = {
     Nop     = {},
     Seq     = {"cmds"},
 
-    Return  = {},
+    Return  = {"loc", "srcs"},
     Break   = {},
     Loop    = {"body"},
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -139,11 +139,11 @@ function ToIR:convert_stat(cmds, stat)
         self:exp_to_assignment(cmds, false, stat.call_exp)
 
     elseif tag == "ast.Stat.Return" then
+        local vals = {}
         for i, exp in ipairs(stat.exps) do
-            local dst = ir.ret_var(self.func, i)
-            self:exp_to_assignment(cmds, dst, exp)
+            vals[i] = self:exp_to_value(cmds, exp)
         end
-        table.insert(cmds, ir.Cmd.Return())
+        table.insert(cmds, ir.Cmd.Return(stat.loc, vals))
 
     elseif tag == "ast.Stat.Break" then
         table.insert(cmds, ir.Cmd.Break())

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -72,9 +72,6 @@ local function test(cmd, uninit, loop)
         end
         return true, uninit
 
-    elseif tag == "ir.Cmd.Return" then
-        return false
-
     elseif tag == "ir.Cmd.Break" then
         assert(loop)
         loop.is_infinite = false
@@ -135,7 +132,12 @@ local function test(cmd, uninit, loop)
         for _, v_id in ipairs(ir.get_dsts(cmd)) do
             uninit[v_id] = nil
         end
-        return true, uninit
+
+        if tag == "ir.Cmd.Return" then
+            return false
+        else
+            return true, uninit
+        end
     else
         error("impossible")
     end


### PR DESCRIPTION
In this PR we change the `ir.Cmd.Return` instruction to receive the return
values as a list of `ir.Value`.

Currently, the return values are implicit. They are assigned to a special group
of local variables, just like function arguments are, and it is implicitly
assumed that the return statement returns whatever is stored in these local
variables.

IIRC, the original motivation for this was because the book that I was referencing
at the time did it that way. One way to detect if the control flow reaches
the end of a non-void function without returning a value is to check if the
"return variable" is uninitialized at the end of the function.

However, this solution has proved to be a bit of a foot-gun because
`ir.get_srcs` for ir.Cmd.Return currently returns the empty list. This had
already caused a bug in the GC (PR #136), requiring special treatment in gc.lua.
Furthermore, today Leonardo ran into the same problem, while implementing
some other static analysis in the code.

To add insult to injury, we weren't even using that trick with the uninitialized
return variable, which was the whole reason why we were originally doing this.
In uninitalized.lua, we were separately keeping track of whether the function
can fall through through to the bottom without reaching a return statement
first.

So let's solve this problem for good! In this patch, the return values are now
passed as parameters to the `ir.Cmd.Return` instruction, so `ir.get_srcs` should
do the right thing.