### PR TITLE
Run luacheck before busted in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   - make linux-noreadline
 
 script:
-  - busted -o gtest -v ./spec
   - luacheck ./pallene ./spec
+  - busted -o gtest -v ./spec
 
 


### PR DESCRIPTION
Running Luacheck is faster than running the whole test suite, so we might as
well do it first.