### PR TITLE
Simplify travis.yml a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 language: python
+os: linux
 
-matrix:
-  include:
-    - os: linux
-      env:
-        - LUA="lua=5.3"
 cache:
   directories:
     - hrenv
 
 before_install:
   - pip install hererocks
-  - hererocks hrenv -rlatest --$LUA
+  - hererocks hrenv --luarocks=latest --lua=5.3
   - source hrenv/bin/activate
 
 install:


### PR DESCRIPTION
Because our build matrix has only one case we can remove the build matrix and
the environment variables.