### PR TITLE
C.reformat now correctly ignores '{'. Also uses LPEG.

### DIFF
--- a/pallene/C.lua
+++ b/pallene/C.lua
@@ -151,17 +151,9 @@ function C.reformat(input)
 
         else
             -- Regular lines are indented based on {} and ().
-            local delta = count_braces(line)
-
             local unindent_this_line = string.match(line, "^[})]")
             nspaces = 4 * (depth - (unindent_this_line and 1 or 0))
-
-            if     delta > 0 then
-                depth = depth + 1
-            elseif delta < 0 then
-                depth = depth - 1
-            end
-
+            depth = depth + count_braces(line)
             assert(depth >= 0, "Unbalanced indentation. Too many '}'s")
         end
 

--- a/pallene/C.lua
+++ b/pallene/C.lua
@@ -147,7 +147,7 @@ function C.reformat(input)
 
         elseif line:match("^[A-Za-z_][A-Za-z_0-9]*:$") then
             -- Labels are indented halfway
-            nspaces = math.max(0, 4 * depth - 2)
+            nspaces = math.max(0, 4*depth - 2)
 
         else
             -- Regular lines are indented based on {} and ().

--- a/pallene/C.lua
+++ b/pallene/C.lua
@@ -94,10 +94,10 @@ function C.reformat(input)
     for line in input:gmatch("([^\n]*)") do
         line = line:match("^ *(.-) *$")
 
-        -- We use tab characters to mark blank lines that should be preserved
-        -- in the output, for presentation purposes. (This trick means that the
-        -- reformat fucntion is still indempotent). However, typing a \t inside
-        -- [[ ]] strings is hard so we also use /**/ as a blank line marker.
+        -- We use tab characters to mark blank lines that should be preserved in
+        -- the output. (This trick allows reformat to be idempotent). However,
+        -- typing a \t inside [[ ]] strings is hard so we also use /**/ as a
+        -- blank line marker.
         if line == "/**/" then
             line = "\t"
         end


### PR DESCRIPTION
Fixes #205.