### PR TITLE
Initialize our TValue local variables

### DIFF
--- a/pallene/C.lua
+++ b/pallene/C.lua
@@ -62,14 +62,21 @@ function C.float(n)
     end
 end
 
---
--- Comments
--- (The reformater assumes that they are single-line)
-
 function C.comment(str)
-    str = str:gsub("\n", " ")
+    str = str:gsub("\n", " ")  -- (our reformatter expects single-line comments)
     str = str:gsub("%*%/", "")
     return string.format("/* %s */", str)
+end
+
+--
+-- Local variable, function argument and struct member declarations
+--
+
+function C.declaration(ctyp, name)
+    -- Put the *'s next to the name to make the pointers look nice.
+    local non_ptr, ptr = string.match(ctyp, '^(.-)([%s%*]*)$')
+    if ptr ~= "" then ptr = ptr:gsub("%s", "") end
+    return string.format("%s %s%s", non_ptr, ptr, name)
 end
 
 --

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -402,12 +402,8 @@ function Coder:pallene_entry_point_declaration(f_id)
         table.insert(args, {decl, comment})
     end
     for i = 2, #ret_types do
-        local ret_i = i
-        local decl, comment = self:ret_value_as_arg_declaration(ret_i,
-                                ret_types[i])
-        if decl then
-            table.insert(args, {decl, comment})
-        end
+        local decl, comment = self:ret_value_as_arg_declaration(i, ret_types[i])
+        table.insert(args, {decl, comment})
     end
 
     local arg_lines = {}
@@ -487,9 +483,9 @@ function Coder:call_pallene_function(dsts, f_id, base, xs)
         if dsts[i] then
             table.insert(args, "&"..dsts[i])
         else
-            local temp_i = i-1
-            table.insert(temp_args, c_declaration(ret_types[i], "temp"..temp_i)..";")
-            table.insert(args, "&temp"..temp_i)
+            local tmp = "temp"..i
+            table.insert(temp_args, c_declaration(ret_types[i], tmp)..";")
+            table.insert(args, "&"..tmp)
         end
     end
 

--- a/runtime/pallene_core.h
+++ b/runtime/pallene_core.h
@@ -91,21 +91,6 @@ int pallene_is_truthy(const TValue *v)
     return !l_isfalse(v);
 }
 
-/* This is a workaround to avoid -Wmaybe-uninitialized warnings with GCC. If we
- * initialize a TValue with setnilvalue and then follow that with a setobj, GCC
- * complains that the setobj might be reading from an uninitialized obj->value_.
- *
- * To placate the compiler we write some bogus data to the value field whenever
- * we would initialize a TValue with nil. In theory this should not have a
- * noticeable performance impact because it only affects nil literals and
- * variables of type nil. */
-static inline
-void pallene_setnilvalue(TValue *obj)
-{
-    val_(obj).i = 0;
-    setnilvalue(obj);
-}
-
 /* Starting with Lua 5.4-rc1, Lua the boolean type now has two variants,
  * LUA_VTRUE and LUA_VFALSE. The value of the boolean is encoded in the type tag
  * instead of in the `Value` union. */


### PR DESCRIPTION
Booleans are now similar to Nil in that they only use the type tag part of the TValue and don't initialize the ".value" field of the tagged usion. This means that booleans are now vulnarable to those `-W-maybe-uninitialized` errors that we had encountered with Nil.

Implementing the workaround that we used for nils in pallene_setbvalue would not be very appealing because pallene_setbvalue is called much more often than pallene_setnilvalue, meaning that adding an extra assignment to `.value` would be wasteful. So I bit the bullet and just initialized all our TValue local variables now. In theory the C compiler should be able to optimize away these initializers if it detects that the values are overwritten before they are read from.