### PR TITLE
Create less temporaries in multiple assignments.

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1445,7 +1445,7 @@ gen_cmd["Return"] = function(self, cmd)
         return [[ return; ]]
     else
         local returns = {}
-        for i = 2, #cmd.srcs do
+        for i = #cmd.srcs, 2, -1 do
             local src = self:c_value(cmd.srcs[i])
             table.insert(returns, util.render([[ *$reti = $v; ]],
                                     { reti = self:c_ret_var(i), v = src }))

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2120,6 +2120,19 @@ describe("Pallene coder /", function()
             function func_inside_paren(): integer
                 return (f())
             end
+
+            function assign_same_var_1(): integer
+                local x: integer
+                x, x, x = f()
+                return x
+            end
+
+            function assign_same_var_2(): integer
+                local x: integer
+                local y: integer
+                x, y, y = f()
+                return y
+            end
         ]]))
 
         it("works as function arguments", function()
@@ -2160,6 +2173,20 @@ describe("Pallene coder /", function()
                 local t = table.pack(test.func_inside_paren())
                 assert(1  == t.n)
                 assert(10 == t[1])
+            ]])
+        end)
+
+        it("assigns returns values from right to left (1)", function()
+            run_test([[
+                local x = test.assign_same_var_1()
+                assert(x == 10)
+            ]])
+        end)
+
+        it("assigns returns values from right to left (2)", function()
+            run_test([[
+                local y = test.assign_same_var_2()
+                assert(y == 20)
             ]])
         end)
     end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2176,14 +2176,14 @@ describe("Pallene coder /", function()
             ]])
         end)
 
-        it("assigns returns values from right to left (1)", function()
+        it("assigns return values from right to left (1)", function()
             run_test([[
                 local x = test.assign_same_var_1()
                 assert(x == 10)
             ]])
         end)
 
-        it("assigns returns values from right to left (2)", function()
+        it("assigns return values from right to left (2)", function()
             run_test([[
                 local y = test.assign_same_var_2()
                 assert(y == 20)


### PR DESCRIPTION
This commit improves the compilation of multiple assignments by using exp_to_assignment instead of exp_to_value, when posiible. This should create less temporary variables in many cases.

The current multiple assignment code is smart enough to not create a temporary variable if the RHS is a variable name that is not reassigned to in the multiple assignment. It already does a good job in situations such as the following, where it creates a temporary for the "y" in the RHS but not for the "x".

    x, y = y, x

However, since the old algorithm always used exp_to_value it inadvertently created temporaries for anything that fell in the exp_to_assignment case. For example, the following assignments would create unnecessary temporary variables:

    x = x + 1
    x, y = f()

The second example is specially annoying because it invalidated our clever implementation of the ExtraRet case in exp_to_assignment.