### PR TITLE
size_hint should be an ir.Value

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1153,7 +1153,7 @@ end
 
 gen_cmd["NewArr"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
-    local n = C.integer(cmd.size_hint)
+    local n   = self:c_value(cmd.size_hint)
     return (util.render([[ $dst = pallene_createtable(L, $n, 0); ]], {
         dst = dst, n = n,
     }))
@@ -1204,7 +1204,7 @@ end
 
 gen_cmd["NewTable"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
-    local n = C.integer(cmd.size_hint)
+    local n   = self:c_value(cmd.size_hint)
     return (util.render([[ $dst = pallene_createtable(L, 0, $n); ]], {
         dst = dst,
         n = n,

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -187,6 +187,7 @@ local  src_fields = {
     "src", "src1", "src2",
     "src_arr", "src_tab", "src_rec", "src_i", "src_k", "src_v",
     "src_f",
+    "size_hint",
     "condition", "start", "limit", "step" }
 local srcs_fields = { "srcs" }
 
@@ -234,7 +235,6 @@ local other_fields = {
     "global_id",
     "op",
     "src_typ", "dst_typ", "rec_typ", "f_typ",
-    "size_hint",
     "field_name",
     "f_id",
     "cmds", "then_", "else_",

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -431,7 +431,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
     if     tag == "ast.Exp.Initlist" then
         local typ = exp._type
         if     typ._tag == "types.T.Array" then
-            local n = #exp.fields
+            local n = ir.Value.Integer(#exp.fields)
             table.insert(cmds, ir.Cmd.NewArr(loc, dst, n))
             table.insert(cmds, ir.Cmd.CheckGC())
             for i, field in ipairs(exp.fields) do
@@ -443,7 +443,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             end
 
         elseif typ._tag == "types.T.Table" then
-            local n = #exp.fields
+            local n = ir.Value.Integer(#exp.fields)
             table.insert(cmds, ir.Cmd.NewTable(loc, dst, n))
             table.insert(cmds, ir.Cmd.CheckGC())
             for _, field in ipairs(exp.fields) do


### PR DESCRIPTION
Currently the size_hint is an integer, which works fine for tables and arrays whose length is known at compile time but won't work well for tables whose length is only known at run time, like the following one:

    local xs = {}
    for i = 1, N do
        xs[i] = 0
    end

Having size_hint be an ir.Value will allow us to use the value of `N` as the size hint for `xs`. This commit doesn't implement that optimization just yet but it paves the way for it.