### PR TITLE
Add nbody to the cbenchmarks makefile

### DIFF
--- a/cbenchmarks/conway.c
+++ b/cbenchmarks/conway.c
@@ -82,8 +82,8 @@ void draw(size_t N, size_t M, bool **cells)
 // Place a shape in the grid
 void spawn(
     size_t N, size_t M, bool **cells,
-    size_t Nshape, size_t Mshape, bool **shape,
-    size_t top, size_t left)
+    int Nshape, int Mshape, bool **shape,
+    int top, int left)
 {
     for (int i = 0; i < Nshape; i++) {
         for (int j = 0; j < Mshape; j++) {
@@ -97,11 +97,11 @@ void spawn(
 // Run one step of the simulation.
 void step(size_t N, size_t M, bool **curr_cells, bool **next_cells)
 {
-    for (int i2 = 0; i2 < N; i2++) {
+    for (int i2 = 0; i2 < (int)N; i2++) {
         int i1 = wrap(i2-1, N);
         int i3 = wrap(i2+1, N);
 
-        for (int j2 = 0; j2 < M; j2++) {
+        for (int j2 = 0; j2 < (int)M; j2++) {
             int j1 = wrap(j2-1, M);
             int j3 = wrap(j2+1, M);
 

--- a/cbenchmarks/makefile
+++ b/cbenchmarks/makefile
@@ -1,6 +1,6 @@
 CFLAGS=-std=c11 -Wall -Wextra -pedantic -O2 -lm
 
-EXES:=binsearch centroid conway matmul sieve queen
+EXES:=binsearch centroid conway matmul sieve queen nbody
 
 all: $(EXES)
 

--- a/cbenchmarks/matmul.c
+++ b/cbenchmarks/matmul.c
@@ -55,11 +55,13 @@ int main(int argc, char **argv)
     }
 
     double **C = NULL;
-    for (int i = 0; i < nrep; i++) {
+    for (size_t i = 0; i < nrep; i++) {
         free(C);
         C = matmul(A, A, N, N, N);
     }
 
     printf("%lu\n", N);
-    printf("%lf\n", C[0][0]);
+    if (N > 0) {
+        printf("%lf\n", C[0][0]);
+    }
 }

--- a/cbenchmarks/nbody.c
+++ b/cbenchmarks/nbody.c
@@ -7,9 +7,9 @@ typedef struct {
     double x, y, z, vx, vy, vz, mass;
 } Body;
 
-static const double PI = 3.141592653589793;
-static const double SOLAR_MASS = 4.0 * PI * PI;
-static const double DAYS_PER_YEAR = 365.24;
+#define PI             3.141592653589793
+#define SOLAR_MASS     (4.0 * PI * PI)
+#define DAYS_PER_YEAR  365.24
 
 #define nbodies 5
 static Body bodies[] = {

--- a/cbenchmarks/queen.c
+++ b/cbenchmarks/queen.c
@@ -2,9 +2,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-int isplaceok(size_t *a, size_t n, size_t c)
+int isplaceok(int *a, int n, int c)
 {
-    for (size_t i = 0; i < n; i++) {
+    for (int i = 0; i < n; i++) {
         int d = a[i];
         if (
             (d == c) ||
@@ -17,10 +17,10 @@ int isplaceok(size_t *a, size_t n, size_t c)
     return 1;
 }
 
-void printsolution(size_t N, size_t *a)
+void printsolution(int N, int *a)
 {
-    for (size_t i = 0; i < N; i++) {
-        for (size_t j = 0; j < N; j++) {
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
             if (a[i] == j) {
                 putchar('X');
             } else {
@@ -33,12 +33,12 @@ void printsolution(size_t N, size_t *a)
     putchar('\n');
 }
 
-void addqueen(size_t N, size_t *a, size_t n)
+void addqueen(int N, int *a, int n)
 {
     if (n >= N) {
         printsolution(N, a);
     } else {
-        for (size_t c = 0; c < N; c++) {
+        for (int c = 0; c < N; c++) {
             if (isplaceok(a, n, c)) {
                 a[n] = c;
                 addqueen(N, a, n+1);
@@ -47,18 +47,18 @@ void addqueen(size_t N, size_t *a, size_t n)
     }
 }
 
-void nqueens(size_t N)
+void nqueens(int N)
 {
-    size_t *a = malloc(N * sizeof(size_t));
+    int *a = malloc(N * sizeof(*a));
     addqueen(N, a, 0);
     free(a);
 }
 
 int main(int argc, char **argv)
 {
-    size_t N = 13;
+    int N = 13;
     if (argc > 1) {
-        int nread = sscanf(argv[1], "%zu", &N);
+        int nread = sscanf(argv[1], "%d", &N);
         if (nread != 1) return 1;
     }
 

--- a/cbenchmarks/queen.c
+++ b/cbenchmarks/queen.c
@@ -64,6 +64,6 @@ int main(int argc, char **argv)
 
     //
 
-    nqueens(13);
+    nqueens(N);
     return 0;
 }

--- a/cbenchmarks/sieve.c
+++ b/cbenchmarks/sieve.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
 
     int64_t *primes = NULL;
     size_t nprimes;
-    for (int i = 0; i < nrep; i++) {
+    for (size_t i = 0; i < nrep; i++) {
         free(primes);
         sieve(N, &primes, &nprimes);
     }


### PR DESCRIPTION
When we added the nbody benchmark in PR #127 we added it to the makefile but forgot to add it to the default make target. This means that `make` and `make clean` do not work as it should.

This commit fixes that oversight.