### PR TITLE
Allow functions with repeated argument names

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -410,18 +410,6 @@ end
 
 function FunChecker:check_function(lambda, func_typ)
     assert(lambda._tag == "ast.Exp.Lambda")
-
-    do
-        local names = {}
-        for _, name in ipairs(lambda.arg_names) do
-            if names[name] then
-                scope_error(lambda.loc,
-                    "function has multiple parameters named '%s'", name)
-            end
-            names[name] = true
-        end
-    end
-
     self.p.symbol_table:with_block(function()
         for i, typ in ipairs(func_typ.arg_types) do
             local name = lambda.arg_names[i]

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -102,14 +102,6 @@ describe("Scope analysis: ", function()
             "variable 'a' is not declared")
     end)
 
-    it("forbids multiple function arguments with the same name", function()
-        assert_error([[
-            function fn(x: integer, x:string)
-            end
-        ]],
-            "function has multiple parameters named 'x'")
-    end)
-
     it("forbids typealias to non-existent type", function()
         assert_error([[
             typealias point = foo

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1645,6 +1645,10 @@ describe("Pallene coder /", function()
                 local tofloat = 1.0
                 return (x + tofloat)
             end
+
+            function duplicate_parameter(x: integer, x:integer) : integer
+                return x
+            end
         ]]))
 
         it("local variable doesn't shadow its type annotation", function()
@@ -1665,6 +1669,10 @@ describe("Pallene coder /", function()
 
         it("tofloat in coercions doesn't get shadowed", function()
             run_test([[ assert( 21.0 == test.tofloat_shadowing(20) ) ]])
+        end)
+
+        it("allows functions with repeated argument names", function()
+            run_test([[ assert( 20 == test.duplicate_parameter(10, 20) )]])
         end)
     end)
 


### PR DESCRIPTION
I don't remember why we originally forbade multiple function arguments with the same name but I think we should reconsider that decision. Allowing repeated argument names lets us delete some lines of code from the type checker and also has the bonus of bringing Pallene closer to Lua (although to be honest it isn't likely to come up very often).