### PR TITLE
Create repeated string literals only once

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -652,8 +652,10 @@ function Coder:init_upvalues()
             for _, v in ipairs(ir.get_srcs(cmd)) do
                 if v._tag == "ir.Value.String" then
                     local str = v.value
-                    table.insert(self.upvalues, coder.Upvalue.String(str))
-                    self.upvalue_of_string[str] = #self.upvalues
+                    if not self.upvalue_of_string[str] then
+                        table.insert(self.upvalues, coder.Upvalue.String(str))
+                        self.upvalue_of_string[str] = #self.upvalues
+                    end
                 end
             end
         end


### PR DESCRIPTION
The current code generates multiple userdata for strings that are equal. This PR changes that to
reuse the userdata string when it has the same value.

For example, in the following code:

```
function g()
  ... "var" ...
  ... "function" ...
end

function f()
  ...
  
  if     tag == "var"
    ...
  elseif tag == "function"
    ...
  end
  
  ...
end
```

Before this commit the result would have been:

```
int luaopen_a(lua_State *L)
{
  ...
  
  lua_newuserdatauv(L, 0, 12);
  int globals = lua_gettop(L);
  
  ...
  
  lua_pushstring(L, "var");
  lua_setiuservalue(L, globals, 1);

  lua_pushstring(L, "function");
  lua_setiuservalue(L, globals, 2);

  lua_pushstring(L, "var");          -- repeated string literal
  lua_setiuservalue(L, globals, 3);

  lua_pushstring(L, "function");     -- repeated string literal
  lua_setiuservalue(L, globals, 4);
  
  ...
```

The result with this PR would be:

```
int luaopen_a(lua_State *L)
{
  ...
  
  lua_newuserdatauv(L, 0, 12);
  int globals = lua_gettop(L);
  
  ...
  
  lua_pushstring(L, "var");
  lua_setiuservalue(L, globals, 1);

  lua_pushstring(L, "function");
  lua_setiuservalue(L, globals, 2);
  
  ...
```