### PR TITLE
Luacheck script

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,7 +15,7 @@
 -- consult the instructions in the Luacheck documentation [3].
 --
 -- [1] https://luacheck.readthedocs.io/en/stable/config.html
--- [2] https://github.com/w0rp/ale
+-- [2] https://github.com/dense-analysis/ale
 -- [3] https://github.com/mpeterv/luacheck#editor-support
 
 ignore = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,9 +2,13 @@
 
 -- Luacheck configuration file [1]
 --
--- How to use Luacheck:
---    - luarocks install luacheck
---    - luacheck ./pallene ./spec ./examples
+-- Please install Luacheck to your system with Luarocks:
+--
+--    luarocks install luacheck
+--
+-- To run Luackeck, please use our lint-project script:
+--
+--    ./lint-project
 --
 -- For vim integration, I recommend ALE [2]. It supports luacheck out of the box
 -- For other editors such as Sublime, Atom, Emacs, Brackets, and VS Code,

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - make linux-noreadline
 
 script:
-  - luacheck ./pallene ./spec ./examples
+  - ./lint-project
   - busted -o gtest -v ./spec
 
 

--- a/lint-project
+++ b/lint-project
@@ -1,0 +1,2 @@
+#!/bin/sh
+luacheck pallene/ spec/ examples/


### PR DESCRIPTION
Luacheck expects us to manually pass it the list of files that should be checked and it is easy to forget to tell it to check the spec/ and examples/ directories. The new lint-project script should help with that