### PR TITLE
Make the checker return an AST 

### DIFF
--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -64,7 +64,7 @@ declare_type("Exp", {
     Float      = {"loc", "value"},
     String     = {"loc", "value"},
     Initlist   = {"loc", "fields"},
-    Lambda     = {"loc", "arg_names", "body"},
+    Lambda     = {"loc", "arg_decls", "body"},
     CallFunc   = {"loc", "exp", "args"},
     CallMethod = {"loc", "exp", "method", "args"},
     Var        = {"loc", "var"},

--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -30,7 +30,6 @@ declare_type("Toplevel", {
     Typealias = {"loc", "name", "type"},
     Record    = {"loc", "name", "field_decls"},
     Import    = {"loc", "local_name", "mod_name"},
-    Builtin   = {"loc", "name"},
 })
 
 declare_type("Decl", {

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -487,8 +487,8 @@ function FunChecker:check_stat(stat)
     elseif tag == "ast.Stat.For" then
 
         local loop_type
-        loop_type, stat.start = self:check_initializer_exp(stat.decl, stat.start,
-            "numeric for-loop initializer")
+        loop_type, stat.start =
+            self:check_initializer_exp(stat.decl, stat.start, "numeric for-loop initializer")
 
         if  loop_type._tag ~= "types.T.Integer" and
             loop_type._tag ~= "types.T.Float"
@@ -498,22 +498,18 @@ function FunChecker:check_stat(stat)
                 types.tostring(loop_type), stat.decl.name)
         end
 
-        stat.limit = self:check_exp_verify(stat.limit, loop_type,
-            "numeric for-loop limit")
-
-        if stat.step then
-            stat.step = self:check_exp_verify(stat.step, loop_type, "numeric for-loop step")
-        else
-            local def_step
+        if not stat.step then
             if     loop_type._tag == "types.T.Integer" then
-                def_step = ast.Exp.Integer(stat.limit.loc, 1)
+                stat.step = ast.Exp.Integer(stat.limit.loc, 1)
             elseif loop_type._tag == "types.T.Float" then
-                def_step = ast.Exp.Float(stat.limit.loc, 1.0)
+                stat.step = ast.Exp.Float(stat.limit.loc, 1.0)
             else
                 error("impossible")
             end
-            stat.step = self:check_exp_synthesize(def_step)
         end
+
+        stat.limit = self:check_exp_verify(stat.limit, loop_type, "numeric for-loop limit")
+        stat.step = self:check_exp_verify(stat.step, loop_type, "numeric for-loop step")
 
         self.p.symbol_table:with_block(function()
             self:add_local(stat.decl.name, loop_type)

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -433,9 +433,9 @@ function FunChecker:check_function(lambda, func_typ)
     assert(lambda._tag == "ast.Exp.Lambda")
 
     self.p.symbol_table:with_block(function()
-        for i, parameter_type in ipairs(func_typ.arg_types) do
-            local name = lambda.arg_names[i]
-            self:add_local(name, parameter_type)
+        for i, typ in ipairs(func_typ.arg_types) do
+            local name = lambda.arg_decls[i].name
+            self:add_local(name, typ)
         end
         local body = self.func.body
         self:check_stat(body)

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -198,8 +198,7 @@ function Checker:from_ast_type(ast_typ)
         local fields = {}
         for _, field in ipairs(ast_typ.fields) do
             if fields[field.name] then
-                type_error(ast_typ.loc, "duplicate field '%s' in table",
-                           field.name)
+                type_error(ast_typ.loc, "duplicate field '%s' in table", field.name)
             end
             fields[field.name] = self:from_ast_type(field.type)
         end
@@ -234,10 +233,10 @@ function Checker:check_program(prog_ast)
     do
         -- Forbid top-level duplicates
         --
-        -- Retrieve the names for all the top-level components such as functions,
-        -- imports, builtins and variables. Construct an auxillary table with name and location
-        -- as key and value, respectively. If the current name already exists in the auxillary
-        -- table, report an error.
+        -- To avoid ambiguities that could happen if the programmer tried to export multiple
+        -- functions with the same name, we give a compilation error if there is more than one
+        -- definition in the toplevel with the same name. We might be able to get rid of this
+        -- restriction if we change the syntax for exporting functions. Please see issue #184.
         local names = {}
         for _, top_level_node in ipairs(prog_ast) do
             local top_level_names = ast.toplevel_names(top_level_node)

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -54,13 +54,13 @@ function driver.compile_internal(filename, stop_after)
         return prog_ast, errs
     end
 
-    local module
-    module, errs = checker.check(prog_ast)
-    if stop_after == "checker" or not module then
-        return module, errs
+    prog_ast, errs = checker.check(prog_ast)
+    if stop_after == "checker" or not prog_ast then
+        return prog_ast, errs
     end
 
-    module, errs = to_ir.convert(module)
+    local module
+    module, errs = to_ir.convert(prog_ast)
     if stop_after == "ir" or not module then
         return module, errs
     end

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -48,7 +48,7 @@ function ir.Function(loc, name, typ)
         name = name,         -- string
         typ = typ,           -- Type
         vars = {},           -- list of ir.VarDecl
-        body = false,        -- list of ir.Cmd
+        body = false,        -- ir.Cmd
     }
 end
 

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -78,17 +78,15 @@ function defs.opt_list(x)
 end
 
 function defs.toplevel_func(loc, is_local, name, params, ret_types, block)
-    local arg_names = {}
     local arg_types = {}
     for i, decl in ipairs(params) do
-        arg_names[i] = decl.name
         arg_types[i] = decl.type
     end
     local func_typ = ast.Type.Function(loc, arg_types, ret_types)
     return ast.Toplevel.Func(
         loc, is_local,
         ast.Decl.Decl(loc, name, func_typ),
-        ast.Exp.Lambda(loc, arg_names, block))
+        ast.Exp.Lambda(loc, params, block))
 end
 
 function defs.nil_exp(pos--[[, s ]])

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -18,14 +18,10 @@ typedecl.declare(to_ir, "to_ir", "LHS", {
     Record = {"typ", "rec", "field"},
 })
 
-local ToIR -- forward declaration
+local ToIR = util.Class()
 
-function to_ir.convert(module)
-    for _, func in ipairs(module.functions) do
-        local cmds = {}
-        ToIR.new(module, func):convert_stat(cmds, func.body)
-        func.body = ir.Cmd.Seq(cmds)
-    end
+function to_ir.convert(prog_ast)
+    local module = ToIR.new():convert_toplevel(prog_ast)
     ir.clean_all(module)
     return module, {}
 end
@@ -34,12 +30,104 @@ end
 --
 --
 
-ToIR = util.Class()
-function ToIR:init(module, func)
-    self.module = module
-    self.func = func
-    self.dsts_of_call = {} -- { ast.Exp => { var_id } }
+function ToIR:init()
+    -- Module-level variables
+    self.module = ir.Module()
+    self.rec_id_of_typ  = {} -- { types.T  => integer }
+    self.fun_id_of_decl = {} -- { ast.Decl => integer }
+    self.glb_id_of_decl = {} -- { ast.Decl => integer }
 end
+
+function ToIR:enter_function(f_id)
+    -- Function-specific variables
+    -- These are re-initialized each time.
+    self.func = self.module.functions[f_id]
+    self.loc_id_of_decl = {} -- { ast.Decl => integer }
+    self.dsts_of_call   = {} -- { ast.Exp => { var_id } }
+end
+
+function ToIR:convert_toplevel(prog_ast)
+
+    -- Create the $init function (it must have ID = 1)
+    ir.add_function(self.module, false, "$init", types.T.Function({}, {}))
+
+    -- Initialize the module-level variables
+    for _, tl_node in ipairs(prog_ast) do
+        local tag = tl_node._tag
+        if     tag == "ast.Toplevel.Func" then
+            local decl = tl_node.decl
+            self.fun_id_of_decl[decl] = ir.add_function(self.module, decl.loc, decl.name, decl._type)
+
+        elseif tag == "ast.Toplevel.Var" then
+            for _, decl in ipairs(tl_node.decls) do
+                self.glb_id_of_decl[decl] = ir.add_global(self.module, decl.name, decl._type)
+            end
+
+        elseif  tag == "ast.Toplevel.Typealias" then
+            -- skip
+
+        elseif tag == "ast.Toplevel.Record" then
+            local typ = tl_node._type
+            self.rec_id_of_typ[typ] = ir.add_record_type(self.module, typ)
+
+        elseif tag == "ast.Toplevel.Import" then
+            -- skip
+
+        else
+            error("impossible")
+        end
+    end
+
+    -- Take care of exports
+    for _, tl_node in ipairs(prog_ast) do
+        local tag = tl_node._tag
+        if     tag == "ast.Toplevel.Func" then
+            local f_id = self.fun_id_of_decl[tl_node.decl]
+            if not tl_node.is_local then
+                ir.add_export(self.module, f_id)
+            end
+        end
+    end
+
+
+    -- Convert the body of the $init function
+    do
+        self:enter_function(1)
+        local cmds = {}
+        for _, tl_node in ipairs(prog_ast) do
+            local tag = tl_node._tag
+            if tag == "ast.Toplevel.Var" then
+                for i, decl in ipairs(tl_node.decls) do
+                    local val = self:exp_to_value(cmds, tl_node.values[i])
+                    local gid = self.glb_id_of_decl[decl]
+                    table.insert(cmds, ir.Cmd.SetGlobal(tl_node.loc, gid, val))
+                end
+            end
+        end
+        self.func.body = ir.Cmd.Seq(cmds)
+    end
+
+    -- Convert the regular functions
+    for _, tl_node in ipairs(prog_ast) do
+       local tag = tl_node._tag
+       if tag == "ast.Toplevel.Func" then
+           self:enter_function(self.fun_id_of_decl[tl_node.decl])
+
+           local exp = tl_node.value
+           assert(exp._tag == "ast.Exp.Lambda")
+           for _, decl in ipairs(exp.arg_decls) do
+               self.loc_id_of_decl[decl] = ir.add_local(self.func, decl.name, decl._type)
+           end
+
+           local cmds = {}
+           self:convert_stat(cmds, exp.body)
+           self.func.body = ir.Cmd.Seq(cmds)
+       end
+   end
+
+   return self.module
+end
+
 
 function ToIR:convert_stats(cmds, stats)
     for i = 1, #stats do
@@ -82,9 +170,9 @@ function ToIR:convert_stat(cmds, stat)
         local limit = self:exp_to_value(cmds, stat.limit)
         local step  = self:exp_to_value(cmds, stat.step)
 
-        local cname = stat.decl._name
-        assert(cname._tag == "checker.Name.Local")
-        local v = cname.id
+        local decl = stat.decl
+        local v = ir.add_local(self.func, decl.name, decl._type)
+        self.loc_id_of_decl[decl] = v
 
         local body = {}
         self:convert_stat(body, stat.block)
@@ -112,7 +200,7 @@ function ToIR:convert_stat(cmds, stat)
                     local var = vars[j]
                     if  var._tag == "ast.Var.Name" and
                         var._name._tag == "checker.Name.Local" and
-                        var._name.id == val.id
+                        self.loc_id_of_decl[var._name.decl] == val.id
                     then
                         local v = ir.add_local(self.func, false, exp._type)
                         table.insert(cmds, ir.Cmd.Move(loc, v, val))
@@ -128,9 +216,11 @@ function ToIR:convert_stat(cmds, stat)
             if     var._tag == "ast.Var.Name" then
                 local cname = var._name
                 if     cname._tag == "checker.Name.Local" then
-                    table.insert(lhss, to_ir.LHS.Local(cname.id))
+                    local id = self.loc_id_of_decl[cname.decl]
+                    table.insert(lhss, to_ir.LHS.Local(id))
                 elseif cname._tag == "checker.Name.Global" then
-                    table.insert(lhss, to_ir.LHS.Global(cname.id))
+                    local id = self.glb_id_of_decl[cname.decl]
+                    table.insert(lhss, to_ir.LHS.Global(id))
                 else
                     error("impossible")
                 end
@@ -217,13 +307,11 @@ function ToIR:convert_stat(cmds, stat)
         end
 
     elseif tag == "ast.Stat.Decl" then
-        for i = 1, #stat.decls do
+        for i, decl in ipairs(stat.decls) do
+            local v = ir.add_local(self.func, decl.name, decl._type)
+            self.loc_id_of_decl[decl] = v
             if stat.exps[i] then
-                local cname = stat.decls[i]._name
-                assert(cname._tag == "checker.Name.Local")
-                local v = cname.id
-                local exp = stat.exps[i]
-                self:exp_to_assignment(cmds, v, exp)
+                self:exp_to_assignment(cmds, v, stat.exps[i])
             end
         end
 
@@ -370,13 +458,15 @@ function ToIR:exp_to_value(cmds, exp, _recursive)
         if     var._tag == "ast.Var.Name" then
             local cname = var._name
             if     cname._tag == "checker.Name.Local" then
-                return ir.Value.LocalVar(cname.id)
+                local id = self.loc_id_of_decl[cname.decl]
+                return ir.Value.LocalVar(id)
 
             elseif cname._tag == "checker.Name.Global" then
                 -- Fallthrough to default
 
             elseif cname._tag == "checker.Name.Function" then
-                return ir.Value.Function(cname.id)
+                local id = self.fun_id_of_decl[cname.decl]
+                return ir.Value.Function(id)
 
             elseif cname._tag == "checker.Name.Builtin" then
                 error("not implemented")
@@ -487,6 +577,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             exp.exp.var._name )
 
         if     cname and cname._tag == "checker.Name.Function" then
+            local f_id = assert(self.fun_id_of_decl[cname.decl])
             assert(not self.dsts_of_call[exp])
             self.dsts_of_call[exp] = {}
             self.dsts_of_call[exp][1] = dst
@@ -494,7 +585,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 self.dsts_of_call[exp][i] = false
             end
             local xs = get_xs()
-            table.insert(cmds, ir.Cmd.CallStatic(loc, f_typ, self.dsts_of_call[exp], cname.id, xs))
+            table.insert(cmds, ir.Cmd.CallStatic(loc, f_typ, self.dsts_of_call[exp], f_id, xs))
 
         elseif cname and cname._tag == "checker.Name.Builtin" then
             local xs = get_xs()
@@ -542,7 +633,8 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
         if     var._tag == "ast.Var.Name" then
             local cname = var._name
             if cname._tag == "checker.Name.Global" then
-                table.insert(cmds, ir.Cmd.GetGlobal(loc, dst, cname.id))
+                local g_id = assert(self.glb_id_of_decl[cname.decl])
+                table.insert(cmds, ir.Cmd.GetGlobal(loc, dst, g_id))
             else
                 use_exp_to_value = true
             end

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -184,7 +184,7 @@ describe("Pallene parser", function()
                             { _tag = "ast.Type.Float" }, }, } },
                 value = {
                     _tag = "ast.Exp.Lambda",
-                    arg_names  = {},
+                    arg_decls  = {},
                     body = {
                         _tag = "ast.Stat.Block",
                         stats = {} } } },
@@ -205,7 +205,7 @@ describe("Pallene parser", function()
                             { _tag = "ast.Type.Float" }, }, } },
                 value = {
                     _tag = "ast.Exp.Lambda",
-                    arg_names = { "x" },
+                    arg_decls = { { name = "x" } },
                     body = {
                         _tag = "ast.Stat.Block",
                         stats = {} } } },
@@ -227,7 +227,7 @@ describe("Pallene parser", function()
                             { _tag = "ast.Type.Float" }, }, } },
                 value = {
                     _tag = "ast.Exp.Lambda",
-                    arg_names = { "x", "y" },
+                    arg_decls = { { name = "x" }, { name = "y" } },
                     body = {
                         _tag = "ast.Stat.Block",
                         stats = {} } } },


### PR DESCRIPTION
Fixes #191.

This set of patches removes all references to IR data structures from the type checking step. This step of the compilation now returns an annotated AST instead of a weird hybrid between ir.Module and annotated AST.

The checker.Name, which is used in the _name annotations is also changed. Instead of containing the numeric identifiers for function_id, global_id and local_id it now carries pointers to the AST nodes
where said identifiers were declared. The to_ir step takes care of mapping each of these declaration
nodes to an unique numeric identifier.

This will have many merge conflicts with PR #224 so we might want to wait to merge that before merging this one. However, I think we can already open this PR now so that people can have a look at it.