### PR TITLE
Builtin return

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1328,12 +1328,10 @@ gen_cmd["CallDyn"] = function(self, cmd, func)
     end
 
     local push_arguments = {}
-    table.insert(push_arguments,
-        self:push_to_stack(f_typ, self:c_value(cmd.src_f)))
+    table.insert(push_arguments, self:push_to_stack(f_typ, self:c_value(cmd.src_f)))
     for i = 1, #f_typ.arg_types do
         local typ = f_typ.arg_types[i]
-        table.insert(push_arguments,
-            self:push_to_stack(typ, self:c_value(cmd.srcs[i])))
+        table.insert(push_arguments, self:push_to_stack(typ, self:c_value(cmd.srcs[i])))
     end
 
     local pop_results = {}

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -452,11 +452,8 @@ function Coder:pallene_entry_point_definition(f_id)
 end
 
 function Coder:call_pallene_function(dsts, f_id, base, xs)
-    local func = self.module.functions[f_id]
-    local ret_types = func.typ.ret_types
 
     local args = {}
-    local temp_args = {}
     table.insert(args, "L")
     table.insert(args, "G")
     table.insert(args, base)
@@ -464,13 +461,7 @@ function Coder:call_pallene_function(dsts, f_id, base, xs)
         table.insert(args, x)
     end
     for i = 2, #dsts do
-        if dsts[i] then
-            table.insert(args, "&"..dsts[i])
-        else
-            local tmp = "temp"..i
-            table.insert(temp_args, C.declaration(ctype(ret_types[i]), tmp)..";")
-            table.insert(args, "&"..tmp)
-        end
+        table.insert(args, "&"..dsts[i])
     end
 
     local call = util.render([[$name($args);]], {
@@ -479,22 +470,9 @@ function Coder:call_pallene_function(dsts, f_id, base, xs)
     })
 
     if dsts[1] then
-        return (util.render([[
-            $temp_args
-            $dst = $call
-        ]], {
-            temp_args = table.concat(temp_args, "\n"),
-            dst = dsts[1],
-            call = call,
-        }))
+        return dsts[1].." = "..call
     else
-        return (util.render([[
-            $temp_args
-            $call
-        ]], {
-            temp_args = table.concat(temp_args, "\n"),
-            call = call,
-        }))
+        return call
     end
 end
 
@@ -1337,13 +1315,7 @@ gen_cmd["CallDyn"] = function(self, cmd, func)
     local pop_results = {}
     for i = #f_typ.ret_types, 1, -1 do
         local typ = f_typ.ret_types[i]
-        local get_slot
-        if dsts[i] then
-            get_slot = self:get_stack_slot(
-                typ, dsts[i], "slot", cmd.loc, "return value #%d", i)
-        else
-            get_slot = ""
-        end
+        local get_slot = self:get_stack_slot(typ, dsts[i], "slot", cmd.loc, "return value #%d", i)
         table.insert(pop_results, util.render([[
             {
                 L->top--;

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -561,68 +561,72 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
 
     elseif tag == "ast.Exp.CallFunc" then
 
-        local function get_xs()
-            -- "xs" should be evaluated after "f"
-            local xs = {}
-            for i, arg_exp in ipairs(exp.args) do
-                xs[i] = self:exp_to_value(cmds, arg_exp)
-            end
-            return xs
-        end
-
         local f_typ = exp.exp._type
         local cname = (
             exp.exp._tag == "ast.Exp.Var" and
             exp.exp.var._tag == "ast.Var.Name" and
             exp.exp.var._name )
 
-        if     cname and cname._tag == "checker.Name.Function" then
-            local f_id = assert(self.fun_id_of_decl[cname.decl])
-            assert(not self.dsts_of_call[exp])
-            self.dsts_of_call[exp] = {}
-            self.dsts_of_call[exp][1] = dst
-            for i = 2, #exp._types do
-                self.dsts_of_call[exp][i] = false
-            end
-            local xs = get_xs()
-            table.insert(cmds, ir.Cmd.CallStatic(loc, f_typ, self.dsts_of_call[exp], f_id, xs))
+        -- Prepare the list of destination variables.
+        -- If this is a function with multiple return values then dsts[2]..dsts[N] will be
+        -- initialized later, by ExtraRet. Unused return values are represented by `false`.
+        assert(not self.dsts_of_call[exp])
+        local dsts = {}
+        dsts[1] = dst
+        for i = 2, #exp._types do
+            dsts[i] = false
+        end
+        self.dsts_of_call[exp] = dsts
 
-        elseif cname and cname._tag == "checker.Name.Builtin" then
-            local xs = get_xs()
+        -- Evaluate the function call expression
+        local f_val
+        if  cname and (
+                cname._tag == "checker.Name.Builtin" or
+                cname._tag == "checker.Name.Function") then
+            f_val = false
+        else
+            f_val = self:exp_to_value(cmds, exp.exp)
+        end
 
+        -- Evaluate the function arguments
+        local xs = {}
+        for i, arg_exp in ipairs(exp.args) do
+            xs[i] = self:exp_to_value(cmds, arg_exp)
+        end
+
+        -- Generate the function call command
+        if     cname and cname._tag == "checker.Name.Builtin" then
             local bname = cname.name
             if     bname == "io.write" then
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinIoWrite(loc, xs))
             elseif bname == "math.sqrt" then
                 assert(#xs == 1)
-                table.insert(cmds, ir.Cmd.BuiltinMathSqrt(loc, {dst}, xs))
+                table.insert(cmds, ir.Cmd.BuiltinMathSqrt(loc, dsts, xs))
             elseif bname == "string_.char" then
                 assert(#xs == 1)
-                table.insert(cmds, ir.Cmd.BuiltinStringChar(loc, {dst}, xs))
+                table.insert(cmds, ir.Cmd.BuiltinStringChar(loc, dsts, xs))
                 table.insert(cmds, ir.Cmd.CheckGC())
             elseif bname == "string_.sub" then
                 assert(#xs == 3)
-                table.insert(cmds,
-                    ir.Cmd.BuiltinStringSub(loc, {dst}, xs))
+                table.insert(cmds, ir.Cmd.BuiltinStringSub(loc, dsts, xs))
                 table.insert(cmds, ir.Cmd.CheckGC())
             elseif bname == "tofloat" then
                 assert(#xs == 1)
-                table.insert(cmds, ir.Cmd.BuiltinToFloat(loc, {dst}, xs))
+                table.insert(cmds, ir.Cmd.BuiltinToFloat(loc, dsts, xs))
             elseif bname == "type" then
                 assert(#xs == 1)
-                table.insert(cmds, ir.Cmd.BuiltinType(loc, {dst}, xs))
+                table.insert(cmds, ir.Cmd.BuiltinType(loc, dsts, xs))
             else
                 error("impossible")
             end
 
+        elseif cname and cname._tag == "checker.Name.Function" then
+            local f_id = assert(self.fun_id_of_decl[cname.decl])
+            table.insert(cmds, ir.Cmd.CallStatic(loc, f_typ, dsts, f_id, xs))
+
         else
-            assert(not self.dsts_of_call[exp])
-            self.dsts_of_call[exp] = {}
-            self.dsts_of_call[exp][1] = dst
-            local f = self:exp_to_value(cmds, exp.exp)
-            local xs = get_xs()
-            table.insert(cmds, ir.Cmd.CallDyn(loc, f_typ, self.dsts_of_call[exp], f, xs))
+            table.insert(cmds, ir.Cmd.CallDyn(loc, f_typ, dsts, f_val, xs))
         end
 
     elseif tag == "ast.Exp.CallMethod" then

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -208,6 +208,11 @@ describe("Pallene coder /", function()
                 return 17
             end
 
+            function ignore_return_builtin(): integer
+                math.sqrt(1.0)
+                return 18
+            end
+
         ]]))
 
         it("no parameters", function()
@@ -241,6 +246,10 @@ describe("Pallene coder /", function()
 
         it("unused return value", function()
             run_test([[ assert(17 == test.ignore_return()) ]])
+        end)
+
+        it("unused return value (builtin function)", function()
+            run_test([[ assert(18 == test.ignore_return_builtin()) ]])
         end)
 
         -- Errors
@@ -311,13 +320,6 @@ describe("Pallene coder /", function()
             function callf(x:integer): integer
                 return f(x)
             end
-
-            ---------
-
-            function ignore_return(g: ()->integer): boolean
-                g()
-                return true
-            end
         ]]))
 
         it("Object identity", function()
@@ -357,13 +359,6 @@ describe("Pallene coder /", function()
                     "wrong type for return value #1, "..
                     "expected integer but found string",
                     nil, true))
-            ]])
-        end)
-
-        it("Does not type check ignored return values", function()
-            run_test([[
-                local f = function() return "hello" end
-                assert(true == test.ignore_return(f))
             ]])
         end)
     end)


### PR DESCRIPTION
Fixes #233.

In the previous implementation, the dsts array for function call instructions could contain `false` entries, corresponding to return values that were not assigned to any local variables. It was the job of the coder to take care of that. The problem was that we forgot to correctly handle these missing destination variables in the case of built-in function calls, meaning that throwing away the return value of a builtin call would crash the Pallene compiler:

    function oops()
        math.sqrt(4.0)
    end

This commit fixes this crash by getting rid of those `false` entries in the dsts array. The to_ir step now creates temporary variables for these cases.

This commit also changes Pallene's semantics in the corner case where a CallDyn function call returns the wrong type for a return value that is not used. We reverse the decision we made in #165 and #167 because now the IR does not make a distinction between used and unused return values.