### PR TITLE
Don't crash on an assignment to a builtin value

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -465,17 +465,19 @@ function Checker:check_stat(stat)
     elseif tag == "ast.Stat.Assign" then
         self:expand_function_returns(stat.vars, stat.exps)
 
-        for i, var in ipairs(stat.vars) do
+        for i = 1, #stat.vars do
             stat.vars[i] = self:check_var(stat.vars[i])
-            stat.exps[i] = self:check_exp_verify(stat.exps[i], var._type, "assignment")
-            if var._tag == "ast.Var.Name" then
-                local ntag = var._name._tag
+            stat.exps[i] = self:check_exp_verify(stat.exps[i], stat.vars[i]._type, "assignment")
+            if stat.vars[i]._tag == "ast.Var.Name" then
+                local ntag = stat.vars[i]._name._tag
                 if ntag == "checker.Name.Function" then
                     type_error(stat.loc,
-                        "attempting to assign to toplevel constant function '%s'", var.name)
+                        "attempting to assign to toplevel constant function '%s'",
+                        stat.vars[i].name)
                 elseif ntag == "checker.Name.Builtin" then
                     type_error(stat.loc,
-                        "attempting to assign to builtin function %s", var.name)
+                        "attempting to assign to builtin function %s",
+                        stat.vars[i].name)
                 end
             end
         end
@@ -852,6 +854,10 @@ end
 -- errmsg_fmt: format string describing where we got @expected_type from
 -- ... : arguments to the "errmsg_fmt" format string
 function Checker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
+    if not expected_type then
+        error("expected_type is required")
+    end
+
     local tag = exp._tag
     if tag == "ast.Exp.Initlist" then
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -696,6 +696,31 @@ describe("Pallene type checker", function()
         "attempting to assign to toplevel constant function 'f'")
     end)
 
+    it("catches assignment to builtin (with correct type)", function ()
+        assert_error([[
+            function f(x: string)
+            end
+
+            function g()
+                io.write = f
+            end
+        ]],
+        "attempting to assign to builtin function io.write")
+    end)
+
+    it("catches assignment to builtin (with wrong type)", function ()
+        pending("Issue #232")
+        assert_error([[
+            function f(x: integer)
+            end
+
+            function g()
+                io.write = f
+            end
+        ]],
+        "attempting to assign to builtin function io.write")
+    end)
+
     it("typechecks io.write (error)", function()
         assert_error([[
             function f()


### PR DESCRIPTION
This fixes a crash that was introduced in 0ea378d31ee. We also add test cases to cover assignments
to builtin functions. It turns out that we didn't have any test cases for that, which is why this
crash went unnoticed at first.