### PR TITLE
Generate a consistent error message when attempting to assign builtin…

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -467,7 +467,6 @@ function Checker:check_stat(stat)
 
         for i = 1, #stat.vars do
             stat.vars[i] = self:check_var(stat.vars[i])
-            stat.exps[i] = self:check_exp_verify(stat.exps[i], stat.vars[i]._type, "assignment")
             if stat.vars[i]._tag == "ast.Var.Name" then
                 local ntag = stat.vars[i]._name._tag
                 if ntag == "checker.Name.Function" then
@@ -480,6 +479,7 @@ function Checker:check_stat(stat)
                         stat.vars[i].name)
                 end
             end
+            stat.exps[i] = self:check_exp_verify(stat.exps[i], stat.vars[i]._type, "assignment")
         end
 
     elseif tag == "ast.Stat.Call" then

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -709,7 +709,6 @@ describe("Pallene type checker", function()
     end)
 
     it("catches assignment to builtin (with wrong type)", function ()
-        pending("Issue #232")
         assert_error([[
             function f(x: integer)
             end


### PR DESCRIPTION
… functions.

This commit fixes #232. When the user attempts to assign a builtin function with an
incompatible function, the compiler complains about the incompatibility. This commit
ensures that the compiler always generates an error when assigning to builtins, even
if the function you are trying to assign is the wrong type.

Further, the test case for this is not marked as pending anymore.