### PR TITLE
Export top-level components from Pallene module

### DIFF
--- a/benchmarks/binarytrees/pallene.pln
+++ b/benchmarks/binarytrees/pallene.pln
@@ -1,4 +1,4 @@
-function BottomUpTree(depth: integer): {any}
+export function BottomUpTree(depth: integer): {any}
     if depth > 0 then
         depth = depth - 1
         local left  = BottomUpTree(depth)
@@ -9,7 +9,7 @@ function BottomUpTree(depth: integer): {any}
     end
 end
 
-function ItemCheck(tree: {any}): integer
+export function ItemCheck(tree: {any}): integer
     if tree[1] then
         return 1 + ItemCheck(tree[1]) + ItemCheck(tree[2])
     else
@@ -17,7 +17,7 @@ function ItemCheck(tree: {any}): integer
     end
 end
 
-function Stress(mindepth: integer, maxdepth: integer, depth: integer): {integer}
+export function Stress(mindepth: integer, maxdepth: integer, depth: integer): {integer}
     local iterations = 1 << (maxdepth - depth + mindepth)
     local check = 0
     for _ = 1, iterations do

--- a/benchmarks/binsearch/pallene.pln
+++ b/benchmarks/binsearch/pallene.pln
@@ -1,4 +1,4 @@
-function binsearch(t: {integer}, x: integer) : integer
+export function binsearch(t: {integer}, x: integer) : integer
     -- lo <= x <= hi
     local lo = 1
     local hi = #t
@@ -24,7 +24,7 @@ function binsearch(t: {integer}, x: integer) : integer
     return steps
 end
 
-function test(t: {integer}, nrep:integer): integer
+export function test(t: {integer}, nrep:integer): integer
     local s = 0
     for i = 1, nrep do
         if binsearch(t, i) ~= 22 then

--- a/benchmarks/centroid/pallene.pln
+++ b/benchmarks/centroid/pallene.pln
@@ -1,8 +1,8 @@
-function new(x: float, y: float): {float}
+export function new(x: float, y: float): {float}
     return { x, y }
 end
 
-function centroid(points: {{float}}, nrep: integer): {float}
+export function centroid(points: {{float}}, nrep: integer): {float}
     local x = 0.0
     local y = 0.0
     local npoints = #points

--- a/benchmarks/conway/pallene.pln
+++ b/benchmarks/conway/pallene.pln
@@ -2,7 +2,7 @@ local ALIVE = "*"
 local DEAD  = " "
 
 -- Create a new grid for the simulation.
-function new_canvas(N:integer, M:integer): {{integer}}
+export function new_canvas(N:integer, M:integer): {{integer}}
     local t:{{integer}} = {}
     for i = 1, N do
         local line : {integer} = {}
@@ -15,12 +15,12 @@ function new_canvas(N:integer, M:integer): {{integer}}
 end
 
 -- Our grid has a toroidal topology with wraparound
-function wrap(i:integer, N:integer): integer
+export function wrap(i:integer, N:integer): integer
     return (i - 1) % N + 1
 end
 
 -- Print the grid to stdout.
-function draw(N:integer, M:integer, cells:{{integer}})
+export function draw(N:integer, M:integer, cells:{{integer}})
     local out = "" -- accumulate to reduce flicker
     for i = 1, N do
         local cellsi = cells[i]
@@ -38,7 +38,7 @@ function draw(N:integer, M:integer, cells:{{integer}})
 end
 
 -- Place a shape in the grid
-function spawn(N:integer, M:integer, cells:{{integer}}, shape:{{integer}},
+export function spawn(N:integer, M:integer, cells:{{integer}}, shape:{{integer}},
 top:integer, left:integer)
     for i = 1, #shape do
         local ci = wrap(i+top-1, N)
@@ -52,7 +52,7 @@ top:integer, left:integer)
 end
 
 -- Run one step of the simulation.
-function step(N:integer, M:integer, curr_cells:{{integer}},
+export function step(N:integer, M:integer, curr_cells:{{integer}},
 next_cells:{{integer}}) : ()
     for i2 = 1, N do
         local i1 = wrap(i2-1, N)

--- a/benchmarks/fannkuchredux/pallene.pln
+++ b/benchmarks/fannkuchredux/pallene.pln
@@ -1,4 +1,4 @@
-function fannkuch(N: integer): {integer}
+export function fannkuch(N: integer): {integer}
 
     local initial_perm : {integer} = {}
     for i = 1, N do

--- a/benchmarks/fasta/pallene.pln
+++ b/benchmarks/fasta/pallene.pln
@@ -14,7 +14,7 @@ local function print_fasta_header(id: string, desc: string)
     io.write(">" .. id .. " " .. desc .. "\n")
 end
 
-function repeat_fasta(id: string, desc: string, alu: string, n: integer)
+export function repeat_fasta(id: string, desc: string, alu: string, n: integer)
     print_fasta_header(id, desc)
 
     local alusize = #alu
@@ -48,7 +48,7 @@ local function linear_search(ps: {float}, p: float): integer
     return 1
 end
 
-function random_fasta(id: string, desc: string, frequencies: {{any}}, n: integer)
+export function random_fasta(id: string, desc: string, frequencies: {{any}}, n: integer)
     print_fasta_header(id, desc)
 
     -- Prepare the cummulative probability table

--- a/benchmarks/mandelbrot/pallene.pln
+++ b/benchmarks/mandelbrot/pallene.pln
@@ -1,4 +1,4 @@
-function mandelbrot(N: integer)
+export function mandelbrot(N: integer)
     local bits  = 0
     local nbits = 0
 

--- a/benchmarks/matmul/pallene.pln
+++ b/benchmarks/matmul/pallene.pln
@@ -1,4 +1,4 @@
-function matmul(A: {{float}}, B:{{float}}): {{float}}
+export function matmul(A: {{float}}, B:{{float}}): {{float}}
     local C : {{float}} = {}
     local NI = #A
     local NK = #B

--- a/benchmarks/matmulsum/pallene.pln
+++ b/benchmarks/matmulsum/pallene.pln
@@ -1,7 +1,7 @@
-function matmul(A: {{float}}, B:{{float}}): float
+export function matmul(A: {{float}}, B:{{float}}): float
     local s = 0.0
     local NI = #A
-    local NK = #B 
+    local NK = #B
     local NJ = #B[1]
     for k = 1, NK do
         local Bk = B[k]

--- a/benchmarks/nbody/pallene.pln
+++ b/benchmarks/nbody/pallene.pln
@@ -8,7 +8,7 @@ record Body
     mass: float
 end
 
-function new_body(
+export function new_body(
     x: float, y: float, z: float,
     vx: float, vy: float, vz: float, mass: float): Body
 
@@ -23,7 +23,7 @@ function new_body(
     }
 end
 
-function offset_momentum(bodies: {Body})
+export function offset_momentum(bodies: {Body})
     local n = #bodies
     local px = 0.0
     local py = 0.0
@@ -43,7 +43,7 @@ function offset_momentum(bodies: {Body})
     sun.vz = sun.vz - pz / solar_mass
 end
 
-function advance(bodies: {Body}, dt: float)
+export function advance(bodies: {Body}, dt: float)
     local n = #bodies
     for i = 1, n do
         local bi = bodies[i]
@@ -75,13 +75,13 @@ function advance(bodies: {Body}, dt: float)
     end
 end
 
-function advance_multiple_steps(nsteps: integer, bodies: {Body}, dt: float)
+export function advance_multiple_steps(nsteps: integer, bodies: {Body}, dt: float)
     for _ = 1, nsteps do
         advance(bodies, dt)
     end
 end
 
-function energy(bodies: {Body}): float
+export function energy(bodies: {Body}): float
     local n = #bodies
     local e = 0.0
     for i = 1, n do

--- a/benchmarks/objmandelbrot/pallene.pln
+++ b/benchmarks/objmandelbrot/pallene.pln
@@ -1,24 +1,24 @@
-function new(x: float, y: float): {float}
+export function new(x: float, y: float): {float}
     return { x, y }
 end
 
-function clone(x: {float}): {float}
+export function clone(x: {float}): {float}
     return new(x[1], x[2])
 end
 
-function conj(x: {float}): {float}
+export function conj(x: {float}): {float}
     return new(x[1], -x[2])
 end
 
-function add(x: {float}, y: {float}): {float}
+export function add(x: {float}, y: {float}): {float}
     return new(x[1] + y[1], x[2] + y[2])
 end
 
-function mul(x: {float}, y: {float}): {float}
+export function mul(x: {float}, y: {float}): {float}
     return new(x[1] * y[1] - x[2] * y[2], x[1] * y[2] + x[2] * y[1])
 end
 
-function norm2(x: {float}): float
+export function norm2(x: {float}): float
     local n = mul(x, conj(x))
     return n[1]
 end

--- a/benchmarks/sieve/pallene.pln
+++ b/benchmarks/sieve/pallene.pln
@@ -1,4 +1,4 @@
-function sieve(N: integer): {integer}
+export function sieve(N: integer): {integer}
     local is_prime: {boolean} = {}
     is_prime[1] = false
     for n: integer = 2, N do

--- a/benchmarks/spectralnorm/pallene.pln
+++ b/benchmarks/spectralnorm/pallene.pln
@@ -38,7 +38,7 @@ local function MultiplyAtAv(N: integer, v: {float}, out: {float})
     MultiplyAtv(N, u, out)
 end
 
-function Approximate(N: integer): float
+export function Approximate(N: integer): float
     -- Create unit vector
     local u: {float} = {}
     for i = 1, N do

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -297,7 +297,7 @@ end
 
 Unlike languages like C or Java, Pallene does not require type annotations on every variable.
 It uses a bidirectional type-checking system that is able to infer the types of almost all variables and expressions.
-Roughly speaking, you must include type annotations for the parameters and return types of toplevel functions, and almost everything else can be inferred from that.
+Roughly speaking, you must include type annotations for the parameters and return types of top-level functions, and almost everything else can be inferred from that.
 For example, notice how the `sum_floats` from the Brief Overview section does not include a type annotation for the `result` and `i` variables.
 
 If a local variable declaration doesn't have an initializer, it must have a type annotation:
@@ -357,6 +357,24 @@ insert(ns, "boom!")
 local x1 : integer = ns[1]
 local x2 : integer = ns[4] -- run-time error
 ```
+
+## Exporting top-level components
+
+The `export` keyword can be used to export top-level components such as variables and functions from a Pallene module.
+The keyword `export` can be used in the same places where the `local` keyword can be used.
+Every top-level component declaration should have either `local` or `export` modifier because Pallene does not support global variables.
+
+In the following example, we export `foo` and `name` from our module.
+```lua
+export function foo(x: integer): integer
+    return x + 1
+end
+
+export name: string = "Hello"
+```
+
+You can export on top-level components from a Pallene module.
+Further, it is an error to export the same name twice.
 
 ## The Complete Syntax of Pallene
 

--- a/examples/arithmetic/arithmetic.pln
+++ b/examples/arithmetic/arithmetic.pln
@@ -3,10 +3,10 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-function add(a: any, b: any): integer
+export function add(a: any, b: any): integer
     return (a as integer) + (b as integer)
 end
 
-function subtract(a: any, b: any): float
+export function subtract(a: any, b: any): float
     return (a as float) - (b as float)
 end

--- a/examples/factorial/factorial.pln
+++ b/examples/factorial/factorial.pln
@@ -3,7 +3,7 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-function factorial(n: integer): integer
+export function factorial(n: integer): integer
     if n <= 1 then
         return 1
     else

--- a/examples/fibonacci/fibonacci.pln
+++ b/examples/fibonacci/fibonacci.pln
@@ -3,7 +3,7 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-function fibonacci(N: integer): { integer }
+export function fibonacci(N: integer): { integer }
     local result: { integer } = {}
     local a, b = 0, 1
     for i = 1, N do

--- a/examples/rectangle/rectangle.pln
+++ b/examples/rectangle/rectangle.pln
@@ -5,7 +5,7 @@
 
 typealias rectangle = { width: float, height: float }
 
-function find_area(r: rectangle): float
+export function find_area(r: rectangle): float
 	local result = r.width * r.height
 	return result
 end

--- a/examples/sum_of_array/sum_of_array.pln
+++ b/examples/sum_of_array/sum_of_array.pln
@@ -3,7 +3,7 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-function sum(array: { float }): float
+export function sum(array: { float }): float
     local result = 0.0
     for i = 1, #array do
         result = result + array[i]

--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -26,7 +26,7 @@ declare_type("Type", {
 
 declare_type("Toplevel", {
     Func      = {"loc", "is_local", "decl", "value"},
-    Var       = {"loc", "decls", "values"},
+    Var       = {"loc", "is_local", "decls", "values"},
     Typealias = {"loc", "name", "type"},
     Record    = {"loc", "name", "field_decls"},
     Import    = {"loc", "local_name", "mod_name"},

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -244,16 +244,17 @@ function Checker:check_program(prog_ast)
             for _, name in ipairs(top_level_names) do
                 local old_location = names[name]
                 if old_location then
-                    if top_level_node._tag == "ast.Toplevel.Func" then
+                    if top_level_node._tag == "ast.Toplevel.Func" or
+                        top_level_node._tag == "ast.Toplevel.Var" then
+                        -- temorary fix
+                        if top_level_node.is_local == nil then
+                            top_level_node.is_local = true
+                        end
                         if not top_level_node.is_local then
                             scope_error(node_location,
-                                "duplicate exported function '%s', previous one at line %d",
+                                "duplicate export '%s', previous one at line %d",
                                 name, old_location.line)
                         end
-                    else
-                        scope_error(node_location,
-                            "duplicate toplevel declaration for '%s', previous one at line %d",
-                            name, old_location.line)
                     end
                 end
                 names[name] = node_location

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -235,8 +235,7 @@ function Checker:check_program(prog_ast)
         --
         -- To avoid ambiguities that could happen if the programmer tried to export multiple
         -- functions with the same name, we give a compilation error if there is more than one
-        -- definition in the toplevel with the same name. We might be able to get rid of this
-        -- restriction if we change the syntax for exporting functions. Please see issue #184.
+        -- definition in the toplevel with the same name.
         local names = {}
         for _, top_level_node in ipairs(prog_ast) do
             local top_level_names = ast.toplevel_names(top_level_node)
@@ -246,10 +245,6 @@ function Checker:check_program(prog_ast)
                 if old_location then
                     if top_level_node._tag == "ast.Toplevel.Func" or
                         top_level_node._tag == "ast.Toplevel.Var" then
-                        -- temorary fix
-                        if top_level_node.is_local == nil then
-                            top_level_node.is_local = true
-                        end
                         if not top_level_node.is_local then
                             scope_error(node_location,
                                 "duplicate export '%s', previous one at line %d",

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -244,9 +244,17 @@ function Checker:check_program(prog_ast)
             for _, name in ipairs(top_level_names) do
                 local old_location = names[name]
                 if old_location then
-                    scope_error(node_location,
-                        "duplicate toplevel declaration for '%s', previous one at line %d",
-                        name, old_location.line)
+                    if top_level_node._tag == "ast.Toplevel.Func" then
+                        if not top_level_node.is_local then
+                            scope_error(node_location,
+                                "duplicate exported function '%s', previous one at line %d",
+                                name, old_location.line)
+                        end
+                    else
+                        scope_error(node_location,
+                            "duplicate toplevel declaration for '%s', previous one at line %d",
+                            name, old_location.line)
+                    end
                 end
                 names[name] = node_location
             end

--- a/pallene/lexer.lua
+++ b/pallene/lexer.lua
@@ -171,7 +171,7 @@ local keywords = {
     "and", "break", "do", "else", "elseif", "end", "for", "false",
     "function", "goto", "if", "in", "local", "nil", "not", "or",
     "repeat", "return", "then", "true", "until", "while", "import",
-    "record", "as", "typealias",
+    "record", "as", "typealias", "export",
 
     "boolean", "integer", "float", "string", "any"
 }

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -249,7 +249,8 @@ local grammar = re.compile([[
     toplevelrecord  <- (P  RECORD NAME^NameRecord recordfields
                            END^EndRecord)                        -> ToplevelRecord
 
-    modifier        <- (LOCAL / EXPORT)                            -> opt_bool
+    modifier        <- LOCAL -> to_true
+                     / EXPORT -> to_false
 
     import          <- (P  LOCAL NAME^NameImport ASSIGN^AssignImport
                            IMPORT^ImportImport

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -236,11 +236,11 @@ local grammar = re.compile([[
                            / toplevelrecord
                            / import )* |} !.
 
-    toplevelfunc    <- (P  modifier FUNCTION NAME^NameFunc
+    toplevelfunc    <- (P  export_or_local FUNCTION NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            rettypeopt block END^EndFunc)         -> toplevel_func
 
-    toplevelvar     <- (P  modifier decllist ASSIGN^AssignVar
+    toplevelvar     <- (P  export_or_local decllist ASSIGN^AssignVar
                            !IMPORT explist1^ExpVarDec)           -> ToplevelVar
 
     typealias       <- (P  TYPEALIAS NAME^NameTypeAlias ASSIGN^AssignTypeAlias
@@ -249,7 +249,7 @@ local grammar = re.compile([[
     toplevelrecord  <- (P  RECORD NAME^NameRecord recordfields
                            END^EndRecord)                        -> ToplevelRecord
 
-    modifier        <- LOCAL -> to_true
+    export_or_local <- LOCAL -> to_true
                      / EXPORT -> to_false
 
     import          <- (P  LOCAL NAME^NameImport ASSIGN^AssignImport

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -236,7 +236,7 @@ local grammar = re.compile([[
                            / toplevelrecord
                            / import )* |} !.
 
-    toplevelfunc    <- (P  localopt FUNCTION NAME^NameFunc
+    toplevelfunc    <- (P  modifier FUNCTION NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            rettypeopt block END^EndFunc)         -> toplevel_func
 
@@ -249,7 +249,7 @@ local grammar = re.compile([[
     toplevelrecord  <- (P  RECORD NAME^NameRecord recordfields
                            END^EndRecord)                        -> ToplevelRecord
 
-    localopt        <- (LOCAL)?                                  -> opt_bool
+    modifier        <- (LOCAL / EXPORT)                            -> opt_bool
 
     import          <- (P  LOCAL NAME^NameImport ASSIGN^AssignImport
                            IMPORT^ImportImport
@@ -443,6 +443,7 @@ local grammar = re.compile([[
     IF              <- %IF SKIP*
     IN              <- %IN SKIP*
     LOCAL           <- %LOCAL SKIP*
+    EXPORT          <- %EXPORT SKIP*
     NIL             <- %NIL SKIP*
     NOT             <- %NOT SKIP*
     OR              <- %OR SKIP*

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -240,7 +240,7 @@ local grammar = re.compile([[
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            rettypeopt block END^EndFunc)         -> toplevel_func
 
-    toplevelvar     <- (P  LOCAL decllist ASSIGN^AssignVar
+    toplevelvar     <- (P  modifier decllist ASSIGN^AssignVar
                            !IMPORT explist1^ExpVarDec)           -> ToplevelVar
 
     typealias       <- (P  TYPEALIAS NAME^NameTypeAlias ASSIGN^AssignTypeAlias

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -63,13 +63,13 @@ describe("Scope analysis: ", function()
             "duplicate export 'f', previous one at line 1")
     end)
 
-    -- Shouldn't this be removed?
-    -- it("forbids multiple toplevel variable declarations with the same name", function()
-    --     assert_error([[
-    --         local a, a = 1, 2
-    --     ]],
-    --         "duplicate toplevel declaration for 'a'")
-    -- end)
+    pending("forbids multiple toplevel declarations with the same name for exported function and variable", function()
+        assert_error([[
+            export function f() end
+            export f = 1
+        ]],
+            "duplicate export 'f', previous one at line 1")
+    end)
 
     it("ensure toplevel variables are not in scope in their initializers", function()
         assert_error([[

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -21,7 +21,7 @@ describe("Scope analysis: ", function()
 
     it("forbids variables from being used before they are defined", function()
         assert_error([[
-            function fn(): nil
+            export function fn(): nil
                 x = 17
                 local x = 18
             end
@@ -31,7 +31,7 @@ describe("Scope analysis: ", function()
 
     it("forbids type variables from being used before they are defined", function()
         assert_error([[
-            function fn(p: Point): integer
+            export function fn(p: Point): integer
                 return p.x
             end
 
@@ -45,7 +45,7 @@ describe("Scope analysis: ", function()
 
     it("do-end limits variable scope", function()
         assert_error([[
-            function fn(): nil
+            export function fn(): nil
                 do
                     local x = 17
                 end
@@ -133,11 +133,11 @@ describe("Pallene type checker", function()
 
     it('catches incompatible function type assignments', function()
         assert_error([[
-            function f(a: integer, b: float): float
+            export function f(a: integer, b: float): float
                 return 3.14
             end
 
-            function test(g: () -> integer)
+            export function test(g: () -> integer)
                 g = f
             end
         ]],
@@ -146,7 +146,7 @@ describe("Pallene type checker", function()
 
     it("detects when a non-type is used in a type variable", function()
         assert_error([[
-            function fn()
+            export function fn()
                 local foo: integer = 10
                 local bar: foo = 11
             end
@@ -160,7 +160,7 @@ describe("Pallene type checker", function()
                 x: integer
                 y: integer
             end
-            function fn()
+            export function fn()
                 local bar: integer = Point
             end
         ]],
@@ -169,7 +169,7 @@ describe("Pallene type checker", function()
 
     it("catches table type with repeated fields", function()
         assert_error([[
-            function fn(t: {x: float, x: integer}) end
+            export function fn(t: {x: float, x: integer}) end
         ]],
             "duplicate field 'x' in table")
     end)
@@ -177,14 +177,14 @@ describe("Pallene type checker", function()
     it("allows tables with fields with more than LUAI_MAXSHORTLEN chars", function()
         local field = string.rep('a', 41)
         local module, _ = run_checker([[
-            function f(t: {]].. field ..[[: float}) end
+            export function f(t: {]].. field ..[[: float}) end
         ]])
         assert.truthy(module)
     end)
 
     it("catches array expression in indexing is not an array", function()
         assert_error([[
-            function fn(x: integer)
+            export function fn(x: integer)
                 x[1] = 2
             end
         ]],
@@ -193,7 +193,7 @@ describe("Pallene type checker", function()
 
     it("catches wrong use of length operator", function()
         assert_error([[
-            function fn(x: integer): integer
+            export function fn(x: integer): integer
                 return #x
             end
         ]],
@@ -202,7 +202,7 @@ describe("Pallene type checker", function()
 
     it("catches wrong use of unary minus", function()
         assert_error([[
-            function fn(x: boolean): boolean
+            export function fn(x: boolean): boolean
                 return -x
             end
         ]],
@@ -211,7 +211,7 @@ describe("Pallene type checker", function()
 
     it("catches wrong use of bitwise not", function()
         assert_error([[
-            function fn(x: boolean): boolean
+            export function fn(x: boolean): boolean
                 return ~x
             end
         ]],
@@ -220,7 +220,7 @@ describe("Pallene type checker", function()
 
     it("catches wrong use of boolean not", function()
         assert_error([[
-            function fn(): boolean
+            export function fn(): boolean
                 return not nil
             end
         ]],
@@ -229,7 +229,7 @@ describe("Pallene type checker", function()
 
     it("catches mismatching types in locals", function()
         assert_error([[
-            function fn()
+            export function fn()
                 local i: integer = 1
                 local s: string = "foo"
                 s = i
@@ -240,7 +240,7 @@ describe("Pallene type checker", function()
 
     it("requires a type annotation for an uninitialized variable", function()
         assert_error([[
-            function fn(): integer
+            export function fn(): integer
                 local x
                 x = 10
                 return x
@@ -250,7 +250,7 @@ describe("Pallene type checker", function()
 
     it("catches mismatching types in arguments", function()
         assert_error([[
-            function fn(i: integer, s: string): integer
+            export function fn(i: integer, s: string): integer
                 s = i
             end
         ]],
@@ -259,7 +259,7 @@ describe("Pallene type checker", function()
 
     it("forbids empty array (without type annotation)", function()
         assert_error([[
-            function fn()
+            export function fn()
                 local xs = {}
             end
         ]],
@@ -268,7 +268,7 @@ describe("Pallene type checker", function()
 
     it("forbids non-empty array (without type annotation)", function()
         assert_error([[
-            function fn()
+            export function fn()
                 local xs = {10, 20, 30}
             end
         ]],
@@ -277,7 +277,7 @@ describe("Pallene type checker", function()
 
     it("forbids array initializers with a table part", function()
         assert_error([[
-            function fn()
+            export function fn()
                 local xs: {integer} = {10, 20, 30, x=17}
             end
         ]],
@@ -286,7 +286,7 @@ describe("Pallene type checker", function()
 
     it("forbids wrong type in array initializer", function()
         assert_error([[
-            function fn()
+            export function fn()
                 local xs: {integer} = {10, "hello"}
             end
         ]],
@@ -299,7 +299,7 @@ describe("Pallene type checker", function()
             assert_error([[
                 record Point x: float; y:float end
 
-                function f(): float
+                export function f(): float
                     local p ]].. typ ..[[ = ]].. code ..[[
                 end
             ]], err)
@@ -341,7 +341,7 @@ describe("Pallene type checker", function()
 
     it("forbids type hints that are not array, tables, or records", function()
         assert_error([[
-            function fn()
+            export function fn()
                 local p: string = { 10, 20, 30 }
             end
         ]],
@@ -350,7 +350,7 @@ describe("Pallene type checker", function()
 
     it("requires while statement conditions to be boolean", function()
         assert_error([[
-            function fn(x:integer): integer
+            export function fn(x:integer): integer
                 while x do
                     return 10
                 end
@@ -362,7 +362,7 @@ describe("Pallene type checker", function()
 
     it("requires repeat statement conditions to be boolean", function()
         assert_error([[
-            function fn(x:integer): integer
+            export function fn(x:integer): integer
                 repeat
                     return 10
                 until x
@@ -374,7 +374,7 @@ describe("Pallene type checker", function()
 
     it("requires if statement conditions to be boolean", function()
         assert_error([[
-            function fn(x:integer): integer
+            export function fn(x:integer): integer
                 if x then
                     return 10
                 else
@@ -387,7 +387,7 @@ describe("Pallene type checker", function()
 
     it("ensures numeric 'for' variable has number type", function()
         assert_error([[
-            function fn(x: integer, s: string): integer
+            export function fn(x: integer, s: string): integer
                 for i: string = "hello", 10, 2 do
                     x = x + i
                 end
@@ -399,7 +399,7 @@ describe("Pallene type checker", function()
 
     it("catches 'for' errors in the start expression", function()
         assert_error([[
-            function fn(x: integer, s: string): integer
+            export function fn(x: integer, s: string): integer
                 for i:integer = s, 10, 2 do
                     x = x + i
                 end
@@ -411,7 +411,7 @@ describe("Pallene type checker", function()
 
     it("catches 'for' errors in the limit expression", function()
         assert_error([[
-            function fn(x: integer, s: string): integer
+            export function fn(x: integer, s: string): integer
                 for i = 1, s, 2 do
                     x = x + i
                 end
@@ -423,7 +423,7 @@ describe("Pallene type checker", function()
 
     it("catches 'for' errors in the step expression", function()
         assert_error([[
-            function fn(x: integer, s: string): integer
+            export function fn(x: integer, s: string): integer
                 for i = 1, 10, s do
                     x = x + i
                 end
@@ -435,7 +435,7 @@ describe("Pallene type checker", function()
 
     it("detects too many return values", function()
         assert_error([[
-            function f(): ()
+            export function f(): ()
                 return 1
             end
         ]],
@@ -444,7 +444,7 @@ describe("Pallene type checker", function()
 
     it("detects too few return values", function()
         assert_error([[
-            function f(): integer
+            export function f(): integer
                 return
             end
         ]],
@@ -453,7 +453,7 @@ describe("Pallene type checker", function()
 
     it("detects when a function returns the wrong type", function()
         assert_error([[
-            function fn(): integer
+            export function fn(): integer
                 return "hello"
             end
         ]],
@@ -474,7 +474,7 @@ describe("Pallene type checker", function()
 
     it("detects attempts to call non-functions", function()
         assert_error([[
-            function fn(): integer
+            export function fn(): integer
                 local i: integer = 0
                 i()
             end
@@ -484,11 +484,11 @@ describe("Pallene type checker", function()
 
     it("detects wrong number of arguments to functions", function()
         assert_error([[
-            function f(x: integer, y: integer): integer
+            export function f(x: integer, y: integer): integer
                 return x + y
             end
 
-            function g(): integer
+            export function g(): integer
                 return f(1)
             end
         ]],
@@ -497,15 +497,15 @@ describe("Pallene type checker", function()
 
     it("detects wrong number of arguments when expanding a function", function()
         assert_error([[
-            function f(): (integer, integer)
+            export function f(): (integer, integer)
                 return 1, 2
             end
 
-            function g(x:integer, y:integer, z:integer): integer
+            export function g(x:integer, y:integer, z:integer): integer
                 return x + y
             end
 
-            function test(): integer
+            export function test(): integer
                 return g(f())
             end
         ]],
@@ -514,11 +514,11 @@ describe("Pallene type checker", function()
 
     it("detects wrong types of arguments to functions", function()
         assert_error([[
-            function f(x: integer, y: integer): integer
+            export function f(x: integer, y: integer): integer
                 return x + y
             end
 
-            function g(): integer
+            export function g(): integer
                 return f(1.0, 2.0)
             end
         ]],
@@ -530,7 +530,7 @@ describe("Pallene type checker", function()
             local err_msg = string.format(
                 "cannot concatenate with %s value", typ)
             local test_program = util.render([[
-                function fn(x : $typ) : string
+                export function fn(x : $typ) : string
                     return "hello " .. x
                 end
             ]], { typ = typ })
@@ -564,7 +564,7 @@ describe("Pallene type checker", function()
                         not (t1 == "float" and t2 == "integer")
                     then
                         optest("cannot compare $t1 and $t2 using $op", [[
-                            function fn(a: $t1, b: $t2): boolean
+                            export function fn(a: $t1, b: $t2): boolean
                                 return a $op b
                              end
                         ]], {
@@ -586,7 +586,7 @@ describe("Pallene type checker", function()
                     local dir, t1, t2 = test[1], test[2], test[3]
                     optest(
        "$dir hand side of '$op' has type $t", [[
-                        function fn(x: $t1, y: $t2) : boolean
+                        export function fn(x: $t1, y: $t2) : boolean
                             return x $op y
                         end
                     ]], { op = op, t = t, dir = dir, t1 = t1, t2=t2 })
@@ -605,7 +605,7 @@ describe("Pallene type checker", function()
                     local dir, t1, t2 = test[1], test[2], test[3]
                     optest(
         "$dir hand side of bitwise expression is a $t instead of an integer", [[
-                        function fn(a: $t1, b: $t2): integer
+                        export function fn(a: $t1, b: $t2): integer
                             return a $op b
                         end
                     ]], { op = op, t = t, dir = dir, t1 = t1, t2 = t2 })
@@ -624,7 +624,7 @@ describe("Pallene type checker", function()
                     local dir, t1, t2 = test[1], test[2], test[3]
                     optest(
         "$dir hand side of arithmetic expression is a $t instead of a number", [[
-                        function fn(a: $t1, b: $t2) : float
+                        export function fn(a: $t1, b: $t2) : float
                             return a $op b
                         end
                     ]], { op = op, t = t, dir = dir, t1 = t1, t2 = t2} )
@@ -638,7 +638,7 @@ describe("Pallene type checker", function()
             assert_error([[
                 record Point x: float; y:float end
 
-                function f(p: ]].. typ ..[[): float
+                export function f(p: ]].. typ ..[[): float
                     ]].. code ..[[
                 end
             ]], err)
@@ -675,7 +675,7 @@ describe("Pallene type checker", function()
             for _, t2 in ipairs(typs) do
                 if t1 ~= t2 then
                     optest("expected $t2 but found $t1 in cast expression", [[
-                        function fn(a: $t1) : $t2
+                        export function fn(a: $t1) : $t2
                             return a as $t2
                         end
                     ]], { t1 = t1, t2 = t2 })
@@ -686,10 +686,10 @@ describe("Pallene type checker", function()
 
     it("catches assignment to function", function ()
         assert_error([[
-            function f()
+            export function f()
             end
 
-            function g()
+            export function g()
                 f = g
             end
         ]],
@@ -698,10 +698,10 @@ describe("Pallene type checker", function()
 
     it("catches assignment to builtin (with correct type)", function ()
         assert_error([[
-            function f(x: string)
+            export function f(x: string)
             end
 
-            function g()
+            export function g()
                 io.write = f
             end
         ]],
@@ -710,10 +710,10 @@ describe("Pallene type checker", function()
 
     it("catches assignment to builtin (with wrong type)", function ()
         assert_error([[
-            function f(x: integer)
+            export function f(x: integer)
             end
 
-            function g()
+            export function g()
                 io.write = f
             end
         ]],
@@ -722,7 +722,7 @@ describe("Pallene type checker", function()
 
     it("typechecks io.write (error)", function()
         assert_error([[
-            function f()
+            export function f()
                 io.write(17)
             end
         ]],
@@ -731,7 +731,7 @@ describe("Pallene type checker", function()
 
     it("checks assignment variables to modules", function()
         assert_error([[
-            function f()
+            export function f()
                 local x = io
             end
         ]],
@@ -740,7 +740,7 @@ describe("Pallene type checker", function()
 
     it("checks assignment of modules", function()
         assert_error([[
-            function f()
+            export function f()
                 io = 1
             end
         ]],

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -55,12 +55,12 @@ describe("Scope analysis: ", function()
             "variable 'x' is not declared")
     end)
 
-    it("forbids multiple toplevel declarations with the same name", function()
+    it("forbids multiple toplevel declarations with the same name for exported functions", function()
         assert_error([[
-            local function f() end
-            local function f() end
+            export function f() end
+            export function f() end
         ]],
-            "duplicate toplevel declaration for 'f'")
+            "duplicate exported function 'f', previous one at line 1")
     end)
 
     it("forbids multiple toplevel variable declarations with the same name", function()

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -60,15 +60,16 @@ describe("Scope analysis: ", function()
             export function f() end
             export function f() end
         ]],
-            "duplicate exported function 'f', previous one at line 1")
+            "duplicate export 'f', previous one at line 1")
     end)
 
-    it("forbids multiple toplevel variable declarations with the same name", function()
-        assert_error([[
-            local a, a = 1, 2
-        ]],
-            "duplicate toplevel declaration for 'a'")
-    end)
+    -- Shouldn't this be removed?
+    -- it("forbids multiple toplevel variable declarations with the same name", function()
+    --     assert_error([[
+    --         local a, a = 1, 2
+    --     ]],
+    --         "duplicate toplevel declaration for 'a'")
+    -- end)
 
     it("ensure toplevel variables are not in scope in their initializers", function()
         assert_error([[

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -379,7 +379,7 @@ describe("Pallene coder /", function()
             local name, op, typ, rtyp = test[1], test[2], test[3], test[4]
 
             pallene_code[i] = util.render([[
-                function $name (x: $typ): $rtyp
+                export function $name (x: $typ): $rtyp
                     return $op x
                 end
             ]], {
@@ -516,7 +516,7 @@ describe("Pallene coder /", function()
                 test[1], test[2], test[3], test[4], test[5]
 
             pallene_code[i] = util.render([[
-                function $name (x: $typ1, y:$typ2): $rtyp
+                export function $name (x: $typ1, y:$typ2): $rtyp
                     return x ${op} y
                 end
             ]], {
@@ -551,15 +551,15 @@ describe("Pallene coder /", function()
 
     describe("Nil equality", function()
         setup(compile([[
-            function eq_nil(x: nil, y: nil): boolean
+            export function eq_nil(x: nil, y: nil): boolean
                 return x == y
             end
 
-            function ne_nil(x: nil, y: nil): boolean
+            export function ne_nil(x: nil, y: nil): boolean
                 return x ~= y
             end
 
-            function eq_any(x: any, y: any): boolean
+            export function eq_any(x: any, y: any): boolean
                 return x == y
             end
         ]]))
@@ -664,10 +664,11 @@ describe("Pallene coder /", function()
             local name, typ, value = test[1], test[2], test[3]
 
             pallene_code[i] = util.render([[
-                function from_${name}(x: ${typ}): any
+                export function from_${name}(x: ${typ}): any
                     return (x as any)
                 end
-                function to_${name}(x: any): ${typ}
+
+                export function to_${name}(x: any): ${typ}
                     return (x as ${typ})
                 end
             ]], {

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1611,6 +1611,62 @@ describe("Pallene coder /", function()
 
             ------
 
+            local a, a = 5, 3
+
+            ------
+
+            export function f(): integer
+                return 19
+            end
+
+            local function f(): integer
+                return 53
+            end
+
+            ------
+
+            export function g(): integer
+                return 83
+            end
+
+            local g : string = 'preets'
+
+            ------
+
+            export h : string = 'madyanam'
+
+            local function h(): integer
+                return 1216
+            end
+
+            ------
+
+            export i : string = 'baby'
+
+            local i : string = 'yoda'
+
+            ------
+
+            export function toplevel_local_f(): integer
+                return f()
+            end
+
+            export function toplevel_local_g_type(): string
+                return type(g)
+            end
+
+            export function toplevel_local_h_type(): string
+                return type(h)
+            end
+
+            export function toplevel_local_i(): string
+                return i
+            end
+
+            export function toplevel_local_a(): integer
+                return a
+            end
+
             export function local_type(): integer
                 local Point: Point = { x=1, y=2 }
                 return Point.x
@@ -1646,6 +1702,36 @@ describe("Pallene coder /", function()
                 return x
             end
         ]]))
+
+        it("exported functions that are locally shadowed should be visible ouside the module", function ()
+            run_test([[ assert('function' == type(test.g)) ]])
+            run_test([[ assert(19 == test.f()) ]])
+        end)
+
+        pending("exported variables that are locally shadowed should be visible outside the module", function ()
+            run_test([[ assert('baby' == test.i) ]])
+            run_test([[ assert('string' == type(test.h)) ]])
+        end)
+
+        it("local top-level variable shadows toplevel exported variable", function ()
+            run_test([[ assert('yoda' == test.toplevel_local_i()) ]])
+        end)
+
+        it("local top-level function shadows toplevel exported variable", function ()
+            run_test([[ assert('function' == test.toplevel_local_h_type()) ]])
+        end)
+
+        it("local top-level variable shadows toplevel exported function", function ()
+            run_test([[ assert('string' == test.toplevel_local_g_type()) ]])
+        end)
+
+        it("local top-level function shadows toplevel exported function", function ()
+            run_test([[ assert(53 == test.toplevel_local_f()) ]])
+        end)
+
+        it("local top-level variable is shadowed by the latest declaration", function ()
+            run_test([[ assert(3 == test.toplevel_local_a()) ]])
+        end)
 
         it("local variable doesn't shadow its type annotation", function()
             run_test([[ assert( 1 == test.local_type() ) ]])

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -43,7 +43,7 @@ describe("Pallene coder /", function()
 
     describe("Exported functions /", function()
         setup(compile([[
-                  function f(): integer return 10 end
+            export function f(): integer return 10 end
             local function g(): integer return 11 end
         ]]))
 
@@ -57,15 +57,15 @@ describe("Pallene coder /", function()
 
     describe("Literals /", function()
         setup(compile([[
-            function f_nil(): nil          return nil  end
-            function f_true(): boolean     return true end
-            function f_false(): boolean    return false end
-            function f_integer(): integer  return 17 end
-            function f_float(): float      return 3.14 end
-            function f_string(): string    return "Hello World" end
-            function pi(): float           return 3.141592653589793 end
-            function e(): float            return 2.718281828459045 end
-            function one_half(): float     return 1.0 / 2.0 end
+            export function f_nil(): nil          return nil  end
+            export function f_true(): boolean     return true end
+            export function f_false(): boolean    return false end
+            export function f_integer(): integer  return 17 end
+            export function f_float(): float      return 3.14 end
+            export function f_string(): string    return "Hello World" end
+            export function pi(): float           return 3.141592653589793 end
+            export function e(): float            return 2.718281828459045 end
+            export function one_half(): float     return 1.0 / 2.0 end
         ]]))
 
         it("nil", function()
@@ -112,11 +112,11 @@ describe("Pallene coder /", function()
 
     describe("Variables /", function()
         setup(compile([[
-            function fst(x:integer, y:integer): integer return x end
-            function snd(x:integer, y:integer): integer return y end
+            export function fst(x:integer, y:integer): integer return x end
+            export function snd(x:integer, y:integer): integer return y end
 
             local n = 0
-            function next_n(): integer
+            export function next_n(): integer
                 n = n + 1
                 return n
             end
@@ -140,37 +140,37 @@ describe("Pallene coder /", function()
 
     describe("Function calls /", function()
         setup(compile([[
-            function f0(): integer
+            export function f0(): integer
                 return 17
             end
 
-            function g0(): integer
+            export function g0(): integer
                 return f0()
             end
 
             -----------
 
-            function f1(x:integer): integer
+            export function f1(x:integer): integer
                 return x
             end
 
-            function g1(x:integer): integer
+            export function g1(x:integer): integer
                 return f1(x)
             end
 
             -----------
 
-            function f2(x:integer, y:integer): integer
+            export function f2(x:integer, y:integer): integer
                 return x+y
             end
 
-            function g2(x:integer, y:integer): integer
+            export function g2(x:integer, y:integer): integer
                 return f2(x, y)
             end
 
             -----------
 
-            function gcd(a:integer, b:integer): integer
+            export function gcd(a:integer, b:integer): integer
                 if b == 0 then
                    return a
                 else
@@ -180,7 +180,7 @@ describe("Pallene coder /", function()
 
             -----------
 
-            function even(x: integer): boolean
+            export function even(x: integer): boolean
                 if x == 0 then
                     return true
                 else
@@ -188,7 +188,7 @@ describe("Pallene coder /", function()
                 end
             end
 
-            function odd(x: integer): boolean
+            export function odd(x: integer): boolean
                 if x == 0 then
                     return false
                 else
@@ -198,17 +198,17 @@ describe("Pallene coder /", function()
 
             -----------
 
-            function skip_a() end
-            function skip_b() skip_a(); skip_a() end
+            export function skip_a() end
+            export function skip_b() skip_a(); skip_a() end
 
             -----------
 
-            function ignore_return(): integer
+            export function ignore_return(): integer
                 even(1)
                 return 17
             end
 
-            function ignore_return_builtin(): integer
+            export function ignore_return_builtin(): integer
                 math.sqrt(1.0)
                 return 18
             end
@@ -289,16 +289,16 @@ describe("Pallene coder /", function()
 
     describe("First class functions /", function()
         setup(compile([[
-            function inc(x:integer): integer   return x + 1   end
-            function dec(x:integer): integer   return x - 1   end
+            export function inc(x:integer): integer   return x + 1   end
+            export function dec(x:integer): integer   return x - 1   end
 
-            function get_inc(): integer->integer
+            export function get_inc(): integer->integer
                 return inc
             end
 
             --------
 
-            function call(
+            export function call(
                 f : integer -> integer,
                 x : integer
             ) :  integer
@@ -309,15 +309,15 @@ describe("Pallene coder /", function()
 
             local f: integer->integer = inc
 
-            function setf(g:integer->integer): ()
+            export function setf(g:integer->integer): ()
                 f = g
             end
 
-            function getf(): integer->integer
+            export function getf(): integer->integer
                 return f
             end
 
-            function callf(x:integer): integer
+            export function callf(x:integer): integer
                 return f(x)
             end
         ]]))
@@ -592,7 +592,7 @@ describe("Pallene coder /", function()
                 y: float
             end
 
-            function points(): {Point}
+            export function points(): {Point}
                 return {
                     { x = 1.0, y = 2.0 },
                     { x = 1.0, y = 2.0 },
@@ -600,11 +600,11 @@ describe("Pallene coder /", function()
                 }
             end
 
-            function eq_point(p: Point, q: Point): boolean
+            export function eq_point(p: Point, q: Point): boolean
                 return p == q
             end
 
-            function ne_point(p: Point, q: Point): boolean
+            export function ne_point(p: Point, q: Point): boolean
                 return p ~= q
             end
         ]]))
@@ -651,7 +651,7 @@ describe("Pallene coder /", function()
         local record_decls = [[
             record Empty
             end
-            function new_empty(): Empty
+            export function new_empty(): Empty
                 return {}
             end
         ]]
@@ -719,7 +719,7 @@ describe("Pallene coder /", function()
 
     describe("Statements /", function()
         setup(compile([[
-            function stat_blocks(): integer
+            export function stat_blocks(): integer
                 local a = 1
                 local b = 2
                 do
@@ -730,7 +730,7 @@ describe("Pallene coder /", function()
                 return a + b
             end
 
-            function sign(x: integer) : integer
+            export function sign(x: integer) : integer
                 if x < 0 then
                     return -1
                 elseif x == 0 then
@@ -740,14 +740,14 @@ describe("Pallene coder /", function()
                 end
             end
 
-            function abs(x: integer) : integer
+            export function abs(x: integer) : integer
                 if x >= 0 then
                     return x
                 end
                 return -x
             end
 
-            function factorial_while(n: integer): integer
+            export function factorial_while(n: integer): integer
                 local r = 1
                 while n > 0 do
                     r = r * n
@@ -756,7 +756,7 @@ describe("Pallene coder /", function()
                 return r
             end
 
-            function factorial_int_for_inc(n: integer): integer
+            export function factorial_int_for_inc(n: integer): integer
                 local res = 1
                 for i = 1, n do
                     res = res * i
@@ -764,7 +764,7 @@ describe("Pallene coder /", function()
                 return res
             end
 
-            function factorial_int_for_dec(n: integer): integer
+            export function factorial_int_for_dec(n: integer): integer
                 local res = 1
                 for i = n, 1, -1 do
                     res = res * i
@@ -772,7 +772,7 @@ describe("Pallene coder /", function()
                 return res
             end
 
-            function factorial_float_for_inc(n: float): float
+            export function factorial_float_for_inc(n: float): float
                 local res = 1.0
                 for i = 1.0, n do
                     res = res * i
@@ -780,7 +780,7 @@ describe("Pallene coder /", function()
                 return res
             end
 
-            function factorial_float_for_dec(n: float): float
+            export function factorial_float_for_dec(n: float): float
                 local res = 1.0
                 for i = n, 1.0, -1.0 do
                     res = res * i
@@ -788,7 +788,7 @@ describe("Pallene coder /", function()
                 return res
             end
 
-            function repeat_until(): integer
+            export function repeat_until(): integer
                 local x = 0
                 repeat
                     x = x + 1
@@ -797,17 +797,17 @@ describe("Pallene coder /", function()
                 return x
             end
 
-            function break_while() : integer
+            export function break_while() : integer
                 while true do break end
                 return 17
             end
 
-            function break_repeat() : integer
+            export function break_repeat() : integer
                 repeat break until false
                 return 17
             end
 
-            function break_for(): integer
+            export function break_for(): integer
                 local x = 0
                 for i = 1, 10 do
                     x = x + i
@@ -816,7 +816,7 @@ describe("Pallene coder /", function()
                 return x
             end
 
-            function nested_break(x:boolean): integer
+            export function nested_break(x:boolean): integer
                 while true do
                     while true do
                         break
@@ -892,35 +892,35 @@ describe("Pallene coder /", function()
 
     describe("Arrays /", function()
         setup(compile([[
-            function newarr(): {integer}
+            export function newarr(): {integer}
                 return {10,20,30}
             end
 
-            function len(xs:{integer}): integer
+            export function len(xs:{integer}): integer
                 return #xs
             end
 
-            function geti(arr: {integer}, i: integer): integer
+            export function geti(arr: {integer}, i: integer): integer
                 return arr[i]
             end
 
-            function seti(arr: {integer}, i: integer, v: integer)
+            export function seti(arr: {integer}, i: integer, v: integer)
                 arr[i] = v
             end
 
-            function insert(xs: {any}, v:any): ()
+            export function insert(xs: {any}, v:any): ()
                 xs[#xs + 1] = v
             end
 
-            function remove(xs: {any}): ()
+            export function remove(xs: {any}): ()
                 xs[#xs] = nil
             end
 
-            function getany(xs: {any}, i:integer): any
+            export function getany(xs: {any}, i:integer): any
                 return xs[i]
             end
 
-            function getnil(xs: {nil}, i: integer): nil
+            export function getnil(xs: {nil}, i: integer): nil
                 return xs[i]
             end
         ]]))
@@ -1069,43 +1069,43 @@ describe("Pallene coder /", function()
         setup(compile([[
             typealias point = {x: integer, y: integer}
 
-            function newpoint(): point
+            export function newpoint(): point
                 return {x = 10, y = 20}
             end
 
-            function getx(p: point): integer
+            export function getx(p: point): integer
                 return p.x
             end
 
-            function gety(p: point): integer
+            export function gety(p: point): integer
                 return p.y
             end
 
-            function setx(p: point, v: integer)
+            export function setx(p: point, v: integer)
                 p.x = v
             end
 
-            function sety(p: point, v: integer)
+            export function sety(p: point, v: integer)
                 p.y = v
             end
 
-            function getany(t: {x: any}): any
+            export function getany(t: {x: any}): any
                 return t.x
             end
 
-            function setany(t: {x: any}, v: any)
+            export function setany(t: {x: any}, v: any)
                 t.x = v
             end
 
-            function getnil(t: {x: nil}): nil
+            export function getnil(t: {x: nil}): nil
                 return t.x
             end
 
-            function setnil(t: {x: nil})
+            export function setnil(t: {x: nil})
                 t.x = nil
             end
 
-            function getmax(t: {]].. maxlenfield ..[[: integer}): integer
+            export function getmax(t: {]].. maxlenfield ..[[: integer}): integer
                 return t.]].. maxlenfield ..[[
             end
         ]]))
@@ -1190,7 +1190,7 @@ describe("Pallene coder /", function()
 
     describe("Strings", function()
         setup(compile([[
-            function len(s:string): integer
+            export function len(s:string): integer
                 return #s
             end
         ]]))
@@ -1207,9 +1207,9 @@ describe("Pallene coder /", function()
             typealias Float = float
             typealias FLOAT = float
 
-            function Float2float(x: Float): float return x end
-            function float2Float(x: float): Float return x end
-            function Float2FLOAT(x: Float): FLOAT return x end
+            export function Float2float(x: Float): float return x end
+            export function float2Float(x: float): Float return x end
+            export function Float2FLOAT(x: Float): FLOAT return x end
 
             record point
                 x: Float
@@ -1218,15 +1218,15 @@ describe("Pallene coder /", function()
             typealias Point = point
             typealias Points = {Point}
 
-            function newPoint(x: Float): Point
+            export function newPoint(x: Float): Point
                 return {x = x}
             end
 
-            function get(p: Point): FLOAT
+            export function get(p: Point): FLOAT
                 return p.x
             end
 
-            function addPoint(ps: Points, p: Point)
+            export function addPoint(ps: Points, p: Point)
                 ps[#ps + 1] = p
             end
         ]]))
@@ -1263,23 +1263,23 @@ describe("Pallene coder /", function()
                 y: {integer}
             end
 
-            function make_foo(x: integer, y: {integer}): Foo
+            export function make_foo(x: integer, y: {integer}): Foo
                 return { x = x, y = y }
             end
 
-            function get_x(foo: Foo): integer
+            export function get_x(foo: Foo): integer
                 return foo.x
             end
 
-            function set_x(foo: Foo, x: integer)
+            export function set_x(foo: Foo, x: integer)
                 foo.x = x
             end
 
-            function get_y(foo: Foo): {integer}
+            export function get_y(foo: Foo): {integer}
                 return foo.y
             end
 
-            function set_y(foo: Foo, y: {integer})
+            export function set_y(foo: Foo, y: {integer})
                 foo.y = y
             end
 
@@ -1287,7 +1287,7 @@ describe("Pallene coder /", function()
                 x: integer
             end
 
-            function make_prim(x: integer): Prim
+            export function make_prim(x: integer): Prim
                 return { x = x }
             end
 
@@ -1295,14 +1295,14 @@ describe("Pallene coder /", function()
                 x: {integer}
             end
 
-            function make_gc(x: {integer}): Gc
+            export function make_gc(x: {integer}): Gc
                 return { x = x }
             end
 
             record Empty
             end
 
-            function make_empty(): Empty
+            export function make_empty(): Empty
                 return {}
             end
         ]]))
@@ -1377,7 +1377,7 @@ describe("Pallene coder /", function()
 
     describe("I/O", function()
         setup(compile([[
-            function write(s:string)
+            export function write(s:string)
                 io.write(s)
             end
         ]]))
@@ -1392,7 +1392,7 @@ describe("Pallene coder /", function()
 
     describe("tofloat builtin", function()
         setup(compile([[
-            function itof(x:integer): float
+            export function itof(x:integer): float
                 return tofloat(x)
             end
         ]]))
@@ -1409,7 +1409,7 @@ describe("Pallene coder /", function()
 
     describe("math.sqrt builtin", function()
         setup(compile([[
-            function square_root(x: float): float
+            export function square_root(x: float): float
                 return math.sqrt(x)
             end
         ]]))
@@ -1441,7 +1441,7 @@ describe("Pallene coder /", function()
 
     describe("string.char builtin", function()
         setup(compile([[
-            function chr(x: integer): string
+            export function chr(x: integer): string
                 return string_.char(x)
             end
         ]]))
@@ -1475,7 +1475,7 @@ describe("Pallene coder /", function()
 
     describe("string.sub builtin", function()
         setup(compile([[
-            function sub(s: string, i: integer, j: integer): string
+            export function sub(s: string, i: integer, j: integer): string
                 return string_.sub(s, i, j)
             end
         ]]))
@@ -1494,23 +1494,23 @@ describe("Pallene coder /", function()
 
     describe("any", function()
         setup(compile([[
-            function id(x:any): any
+            export function id(x:any): any
                 return x
             end
 
-            function call(f:any->any, x:any): any
+            export function call(f:any->any, x:any): any
                 return f(x)
             end
 
-            function read(xs:{any}, i:integer): any
+            export function read(xs:{any}, i:integer): any
                 return xs[i]
             end
 
-            function write(xs:{any}, i:integer, x:any): ()
+            export function write(xs:{any}, i:integer, x:any): ()
                 xs[i] = x
             end
 
-            function if_any(x:any): boolean
+            export function if_any(x:any): boolean
                 if x then
                     return true
                 else
@@ -1518,7 +1518,7 @@ describe("Pallene coder /", function()
                 end
             end
 
-            function while_any(x:any): integer
+            export function while_any(x:any): integer
                 local out = 0
                 while x do
                     out = out + 1
@@ -1527,7 +1527,7 @@ describe("Pallene coder /", function()
                 return out
             end
 
-            function repeat_any(x:any): integer
+            export function repeat_any(x:any): integer
                 local out = 0
                 repeat
                     out = out + 1
@@ -1610,17 +1610,17 @@ describe("Pallene coder /", function()
 
             ------
 
-            function local_type(): integer
+            export function local_type(): integer
                 local Point: Point = { x=1, y=2 }
                 return Point.x
             end
 
-            function local_initializer(): integer
+            export function local_initializer(): integer
                 local x = x + 1
                 return x
             end
 
-            function for_type_annotation(): integer
+            export function for_type_annotation(): integer
                 local res = 0
                 for y:y = 1, 10 do
                     res = res + y
@@ -1628,7 +1628,7 @@ describe("Pallene coder /", function()
                 return res
             end
 
-            function for_initializer(): integer
+            export function for_initializer(): integer
                 local res = 0
                 for x = x + 1, x + 100, x-7 do
                     res = res + 1
@@ -1636,12 +1636,12 @@ describe("Pallene coder /", function()
                 return res
             end
 
-            function tofloat_shadowing(x:integer) : float
+            export function tofloat_shadowing(x:integer) : float
                 local tofloat = 1.0
                 return (x + tofloat)
             end
 
-            function duplicate_parameter(x: integer, x:integer) : integer
+            export function duplicate_parameter(x: integer, x:integer) : integer
                 return x
             end
         ]]))
@@ -1673,7 +1673,7 @@ describe("Pallene coder /", function()
 
     describe("Non-constant toplevel initializers", function()
         setup(compile([[
-            function f(): integer
+            export function f(): integer
                 return 10
             end
 
@@ -1683,23 +1683,23 @@ describe("Pallene coder /", function()
             local x4: {integer} = { x1 }
             local x5: {x: integer} = { x = x1 }
 
-            function get_x1(): integer
+            export function get_x1(): integer
                 return x1
             end
 
-            function get_x2(): integer
+            export function get_x2(): integer
                 return x2
             end
 
-            function get_x3(): integer
+            export function get_x3(): integer
                 return x3
             end
 
-            function get_x4(): {integer}
+            export function get_x4(): {integer}
                 return x4
             end
 
-            function get_x5(): {x: integer}
+            export function get_x5(): {x: integer}
                 return x5
             end
         ]]))
@@ -1720,7 +1720,7 @@ describe("Pallene coder /", function()
 
     describe("Nested for loops", function()
         setup(compile([[
-            function mul(n: integer, m:integer) : integer
+            export function mul(n: integer, m:integer) : integer
                 local ret = 0
                 for i = 1, n do
                     for j = 1, m do
@@ -1751,7 +1751,7 @@ describe("Pallene coder /", function()
                 return counter
             end
 
-            function next(): integer
+            export function next(): integer
                 x = inc()
                 return counter
             end
@@ -1768,7 +1768,7 @@ describe("Pallene coder /", function()
 
     describe("Uninitialized variables", function()
         setup(compile([[
-            function sign(x: integer): integer
+            export function sign(x: integer): integer
                 local ret: integer
                 if     x  < 0 then
                     ret = -1
@@ -1780,7 +1780,7 @@ describe("Pallene coder /", function()
                 return ret
             end
 
-            function non_breaking_loop(): integer
+            export function non_breaking_loop(): integer
                 local i = 1
                 while true do
                     if i == 42 then return i end
@@ -1788,7 +1788,7 @@ describe("Pallene coder /", function()
                 end
             end
 
-            function initialize_inside_loop(): integer
+            export function initialize_inside_loop(): integer
                 local x: integer
                 repeat
                     x = 17
@@ -1820,7 +1820,7 @@ describe("Pallene coder /", function()
 
     describe("For loop integer overflow", function()
         setup(compile([[
-            function loop(A: integer, B: integer, C: integer): {integer}
+            export function loop(A: integer, B: integer, C: integer): {integer}
                 local xs: {integer} = {}
                 for i = A, B, C do
                     xs[#xs+1] = i
@@ -1880,21 +1880,21 @@ describe("Pallene coder /", function()
                 y: integer
             end
 
-            function new_rpoint(x:integer, y:integer): RPoint
+            export function new_rpoint(x:integer, y:integer): RPoint
                 return {x = x, y = y}
             end
 
-            function get_rpoint_fields(p:RPoint): (integer, integer)
+            export function get_rpoint_fields(p:RPoint): (integer, integer)
                 return p.x, p.y
             end
 
             local gi, ga: {integer} = 1, {}
-            function assign_global(): (integer, {integer})
+            export function assign_global(): (integer, {integer})
                 gi, ga[gi] = gi+1, 20
                 return gi, ga
             end
 
-            function assign_local(): (integer, {integer})
+            export function assign_local(): (integer, {integer})
                 local li: integer = 1
                 local la: {integer} = {}
 
@@ -1902,56 +1902,56 @@ describe("Pallene coder /", function()
                 return li, la
             end
 
-            function assign_bracket(): (integer, integer)
+            export function assign_bracket(): (integer, integer)
                 local a: {integer} = {10, 20}
 
                 a[1], a[2] = a[2], a[1]
                 return a[1], a[2]
             end
 
-            function swap(): (integer, integer)
+            export function swap(): (integer, integer)
                 local x, y = 10, 20
                 x, y = y, x
                 return x, y
             end
 
-            function swap_point(): TPoint
+            export function swap_point(): TPoint
                 local p:TPoint = { x = 10, y = 20 }
                 p.x, p.y = p.y, p.x
                 return p
             end
 
-            function assign_tables_1(a:{integer}, b:{integer}, c:integer): ({integer}, {integer})
+            export function assign_tables_1(a:{integer}, b:{integer}, c:integer): ({integer}, {integer})
                 a, a[1] = b, c
                 return a, b
             end
 
-            function assign_tables_2(a:{integer}, b:{integer}, c:integer): ({integer}, {integer})
+            export function assign_tables_2(a:{integer}, b:{integer}, c:integer): ({integer}, {integer})
                 a[1], a = c, b
                 return a, b
             end
 
-            function assign_dots_1(a:TPoint, b:TPoint, c:integer, d:integer): (TPoint, TPoint)
+            export function assign_dots_1(a:TPoint, b:TPoint, c:integer, d:integer): (TPoint, TPoint)
                 a, a.x, a.y = b, c, d
                 return a, b
             end
 
-            function assign_dots_2(a:TPoint, b:TPoint, c:integer, d:integer): (TPoint, TPoint)
+            export function assign_dots_2(a:TPoint, b:TPoint, c:integer, d:integer): (TPoint, TPoint)
                 a.x, a.y, a = c, d, b
                 return a, b
             end
 
-            function assign_recs_1(a:RPoint, b:RPoint, c:integer, d:integer): (RPoint, RPoint)
+            export function assign_recs_1(a:RPoint, b:RPoint, c:integer, d:integer): (RPoint, RPoint)
                 a, a.x, a.y = b, c, d
                 return a, b
             end
 
-            function assign_recs_2(a:RPoint, b:RPoint, c:integer, d:integer): (RPoint, RPoint)
+            export function assign_recs_2(a:RPoint, b:RPoint, c:integer, d:integer): (RPoint, RPoint)
                 a.x, a.y, a = c, d, b
                 return a, b
             end
 
-            function assign_same_var(): integer
+            export function assign_same_var(): integer
                 local a:integer
                 a, a, a = 10, 20, 30
                 return a
@@ -2094,43 +2094,43 @@ describe("Pallene coder /", function()
 
     describe("Multiple returns", function()
         setup(compile([[
-            function f(): (integer, integer, integer)
+            export function f(): (integer, integer, integer)
                 return 10, 20, 30
             end
 
-            function g(x:integer, y:integer, z:integer): integer
+            export function g(x:integer, y:integer, z:integer): integer
                 return x + y + z
             end
 
-            function func_as_param(): integer
+            export function func_as_param(): integer
                 local a = g(f())
                 return a
             end
 
-            function func_as_return(): (integer, integer, integer)
+            export function func_as_return(): (integer, integer, integer)
                 return f()
             end
 
-            function func_as_first_return(): (integer, integer)
+            export function func_as_first_return(): (integer, integer)
                 return f(), 42
             end
 
-            function func_as_only_exp(): integer
+            export function func_as_only_exp(): integer
                 local a, b, c = f()
                 return a + b + c
             end
 
-            function func_inside_paren(): integer
+            export function func_inside_paren(): integer
                 return (f())
             end
 
-            function assign_same_var_1(): integer
+            export function assign_same_var_1(): integer
                 local x: integer
                 x, x, x = f()
                 return x
             end
 
-            function assign_same_var_2(): integer
+            export function assign_same_var_2(): integer
                 local x: integer
                 local y: integer
                 x, y, y = f()

--- a/spec/lexer_spec.lua
+++ b/spec/lexer_spec.lua
@@ -69,12 +69,14 @@ describe("Pallene lexer", function()
 
     it("can lex some keywords", function()
         assert_lex("and", {"AND"}, {})
+        assert_lex("export", {"EXPORT"}, {})
     end)
 
     it("can lex keywords that contain other keywords", function()
         assert_lex("if",     {"IF"},     {})
         assert_lex("else",   {"ELSE"},   {})
         assert_lex("elseif", {"ELSEIF"}, {})
+        assert_lex("export", {"EXPORT"}, {})
     end)
 
     it("does not generate semantic values for keywords", function()

--- a/spec/pallenec_spec.lua
+++ b/spec/pallenec_spec.lua
@@ -3,7 +3,7 @@ local util = require "pallene.util"
 describe("pallenec", function()
     before_each(function()
         util.set_file_contents("__test__.pln", [[
-            function f(x:integer): integer
+            export function f(x:integer): integer
                 return x + 17
             end
         ]])

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -89,7 +89,7 @@ end
 
 local function expression_test_program(s)
     return (util.render([[
-        function foo(): nil
+        export function foo(): nil
             x = ${EXPR}
         end
     ]], { EXPR = s }))
@@ -113,7 +113,7 @@ end
 
 local function statements_test_program(s)
     return (util.render([[
-        function foo(): nil
+        export function foo(): nil
             ${STATS}
         end
     ]], { STATS = s }))
@@ -859,12 +859,12 @@ describe("Pallene parser", function()
 
     it("does not allow identifiers that are type names", function()
         assert_program_syntax_error([[
-            function integer()
+            export function integer()
             end
         ]], "Expected a function name after 'function'.")
 
         assert_program_syntax_error([[
-            function f()
+            export function f()
                 local integer: integer = 10
             end
         ]], "Expected variable declaration after 'local'.")
@@ -878,34 +878,34 @@ describe("Pallene parser", function()
     it("uses specific error labels for some errors", function()
 
         assert_program_syntax_error([[
-            function () : int
+            export function () : int
             end
         ]], "Expected a function name after 'function'.")
 
         assert_program_syntax_error([[
-            function foo : int
+            export function foo : int
             end
         ]], "Expected '(' for the parameter list.")
 
         assert_program_syntax_error([[
-            function foo ( : int
+            export function foo ( : int
             end
         ]], "Expected ')' to close the parameter list.")
 
         assert_program_syntax_error([[
-            function foo () :
+            export function foo () :
                 local x = 3
             end
         ]], "Expected a type in function declaration.")
 
         assert_program_syntax_error([[
-            function foo () : int
+            export function foo () : int
               local x = 3
               return x
         ]], "Expected 'end' to close the function body.")
 
         assert_program_syntax_error([[
-            function foo(x, y) : int
+            export function foo(x, y) : int
             end
         ]], "Expected ':' after parameter name.")
 
@@ -955,12 +955,12 @@ describe("Pallene parser", function()
         ]], "Expected the name of a module after 'import'.")
 
         assert_program_syntax_error([[
-            function foo (a:int, ) : int
+            export function foo (a:int, ) : int
             end
         ]], "Expected a variable name after ','.")
 
         assert_program_syntax_error([[
-            function foo (a: ) : int
+            export function foo (a: ) : int
             end
         ]], "Expected a type name after ':'.")
 
@@ -1000,7 +1000,7 @@ describe("Pallene parser", function()
         ]], "Expected a type name after ':'.")
 
         assert_program_syntax_error([[
-            function f ( x : int) : string
+            export function f ( x : int) : string
                 do
                 return "42"
         ]], "Expected 'end' to close block.")
@@ -1168,7 +1168,7 @@ describe("Pallene parser", function()
 
     it("catches break statements outside loops", function()
         assert_program_syntax_error([[
-            function fn()
+            export function fn()
                 break
             end
         ]], "break statement outside loop")
@@ -1176,7 +1176,7 @@ describe("Pallene parser", function()
 
     it("catches break statements outside loops but inside other statements", function()
         assert_program_syntax_error([[
-            function fn(x:boolean)
+            export function fn(x:boolean)
                 do
                     if x then
                         break

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -236,7 +236,7 @@ describe("Pallene parser", function()
 
     it("allows ommiting the optional return type annotation", function ()
         assert_program_ast([[
-            function foo()
+            export function foo()
             end
             local function bar()
             end

--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -24,14 +24,14 @@ describe("Uninitialized variable analysis: ", function()
 
     it("empty function", function()
         assert_error([[
-            function fn(): integer
+            export function fn(): integer
             end
         ]], missing_return)
     end)
 
     it("missing return in elseif", function()
         assert_error([[
-            function getval(a:integer): integer
+            export function getval(a:integer): integer
                 if a == 1 then
                     return 10
                 elseif a == 2 then
@@ -44,7 +44,7 @@ describe("Uninitialized variable analysis: ", function()
 
     it("missing return in deep elseif", function()
         assert_error([[
-            function getval(a:integer): integer
+            export function getval(a:integer): integer
                 if a == 1 then
                     return 10
                 elseif a == 2 then
@@ -64,7 +64,7 @@ describe("Uninitialized variable analysis: ", function()
 
     it("catches use of uninitialized variable", function()
         assert_error([[
-            function foo(): integer
+            export function foo(): integer
                 local x:integer
                 return x
             end
@@ -73,7 +73,7 @@ describe("Uninitialized variable analysis: ", function()
 
     it("assumes that loops might not execute", function()
         assert_error([[
-            function foo(cond: boolean): integer
+            export function foo(cond: boolean): integer
                 local x: integer
                 while cond do
                     x = 0


### PR DESCRIPTION
This pull request implements the `export` modifier which allows top-level functions and variables to be exported from a Pallene module.