### PR TITLE
Export variables from Pallene module

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -376,6 +376,40 @@ export name: string = "Hello"
 You can export on top-level components from a Pallene module.
 Further, it is an error to export the same name twice.
 
+
+When variables are exported from a module, only the initial values are exported.
+Therefore, any changes made to the variable from within the module after the export, will not be reflected outside.
+You could over come this limitation (or perhaps a feature), using tables.
+For example, if the exported value is a table then the contents of the table may change and that will be seen outside.
+But if you are exporting a string or number variable, any subsequent changes will remain unseen outside the module.
+
+This is an intended behavior.
+In fact, it is analogous to what happens if you define a Lua module like this:
+```lua
+local x = 10
+
+local function f()
+    return x
+end
+
+return { x = x, f = f }
+```
+
+In Lua you can also create modules in a way that lets the variables be monkey-patched.
+```
+local m = {}
+
+m.x = 10
+
+function m.f()
+    return m.x
+end
+
+return m
+```
+
+But we do not use this pattern in Pallene because it is harder to optimize function calls if they can be monkey-patched.
+
 ## The Complete Syntax of Pallene
 
 Here is the complete syntax of Pallene in extended BNF.

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1640,6 +1640,19 @@ function Coder:generate_luaopen_function()
         }))
     end
 
+    for _, g_id in ipairs(self.module.exported_globals) do
+        local name = self.module.globals[g_id].name
+        table.insert(init_exports, util.render([[
+            lua_pushstring(L, ${name});
+            lua_getiuservalue(L, globals, $ix);
+            lua_settable(L, export_table);
+            /**/
+        ]], {
+            name = C.string(name),
+            ix = C.integer(self.upvalue_of_global[g_id]),
+        }))
+    end
+
     return (util.render([[
         int ${name}(lua_State *L)
         {

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -492,7 +492,7 @@ function Coder:init_closures()
     for f_id in pairs(self.upvalue_of_function) do
         table.insert(f_ids, f_id)
     end
-    for _, f_id in ipairs(self.module.exports) do
+    for _, f_id in ipairs(self.module.exported_functions) do
         table.insert(f_ids, f_id)
     end
     table.sort(f_ids) -- For determinism
@@ -1627,7 +1627,7 @@ function Coder:generate_luaopen_function()
 
 
     local init_exports = {}
-    for _, f_id in ipairs(self.module.exports) do
+    for _, f_id in ipairs(self.module.exported_functions) do
         local name = self.module.functions[f_id].name
         table.insert(init_exports, util.render([[
             lua_pushstring(L, ${name});

--- a/pallene/constant_propagation.lua
+++ b/pallene/constant_propagation.lua
@@ -84,15 +84,24 @@ function constant_propagation.run(module)
     -- 3) Find out which constant globals should be propagated, and which unused constant globals
     -- should be simply eliminated.
 
+    local is_exported = {}
+    for _, g_id in ipairs(module.exported_globals) do
+        is_exported[g_id] = true
+    end
+
     local n_new_globals = 0
     local new_global_id = {} -- { g_id => g_id? }
     for i = 1, n_globals do
-        if constant_initializer[i] and (n_reads[i] == 0 or n_writes[i] == 1) then
+        if constant_initializer[i] and not is_exported[i] and (n_reads[i] == 0 or n_writes[i] == 1) then
             new_global_id[i] = false
         else
             n_new_globals = n_new_globals + 1
             new_global_id[i] = n_new_globals
         end
+    end
+
+    for i, g_id in ipairs(module.exported_globals) do
+        module.exported_globals[i] = assert(new_global_id[g_id])
     end
 
     -- 4) Propagate the constant globals, and rename the existing ones accordingly

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -16,7 +16,7 @@ local typedecl = require "pallene.typedecl"
 -- There is no expression-level nesting. an ir.Value can only be a variable name or a literal
 -- constant. Nested subexpressions are converted into multiple commands, using temporary variables.
 --
--- There is stil some statement-level nesting, with if.Cmd.Loop, ir.Cmd.If, etc. We think that
+-- There is still some statement-level nesting, with if.Cmd.Loop, ir.Cmd.If, etc. We think that
 -- structured control flow is easier to reason about then an unstructured control flow graph built
 -- around basic blocks and gotos.
 
@@ -28,10 +28,11 @@ end
 
 function ir.Module()
     return {
-        record_types = {}, -- list of Type
-        functions    = {}, -- list of ir.Function
-        globals      = {}, -- list of ir.VarDecl
-        exports      = {}, -- list of function ids
+        record_types       = {}, -- list of Type
+        functions          = {}, -- list of ir.Function
+        globals            = {}, -- list of ir.VarDecl
+        exported_functions = {}, -- list of function ids
+        exported_globals   = {}, -- list of variable ids
     }
 end
 
@@ -71,8 +72,12 @@ function ir.add_global(module, name, typ)
     return #module.globals
 end
 
-function ir.add_export(module, f_id)
-    table.insert(module.exports, f_id)
+function ir.add_exported_function(module, f_id)
+    table.insert(module.exported_functions, f_id)
+end
+
+function ir.add_exported_global(module, g_id)
+    table.insert(module.exported_globals, g_id)
 end
 
 --

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -105,7 +105,12 @@ function ToIR:convert_toplevel(prog_ast)
         if     tag == "ast.Toplevel.Func" then
             local f_id = self.fun_id_of_decl[tl_node.decl]
             if not tl_node.is_local then
-                ir.add_export(self.module, f_id)
+                ir.add_exported_function(self.module, f_id)
+            end
+        elseif tag == "ast.Toplevel.Var" then
+            local g_id = self.glb_id_of_decl[tl_node.decl]
+            if not tl_node.is_local then
+                ir.add_exported_global(self.module, g_id)
             end
         end
     end

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -108,9 +108,11 @@ function ToIR:convert_toplevel(prog_ast)
                 ir.add_exported_function(self.module, f_id)
             end
         elseif tag == "ast.Toplevel.Var" then
-            local g_id = self.glb_id_of_decl[tl_node.decl]
             if not tl_node.is_local then
-                ir.add_exported_global(self.module, g_id)
+                for _, decl in ipairs(tl_node.decls) do
+                    local g_id = self.glb_id_of_decl[decl]
+                    ir.add_exported_global(self.module, g_id)
+                end
             end
         end
     end

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -63,7 +63,7 @@ describe("Scope analysis: ", function()
             "duplicate export 'f', previous one at line 1")
     end)
 
-    pending("forbids multiple toplevel declarations with the same name for exported function and variable", function()
+    it("forbids multiple toplevel declarations with the same name for exported function and variable", function()
         assert_error([[
             export function f() end
             export f = 1

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1708,7 +1708,7 @@ describe("Pallene coder /", function()
             run_test([[ assert(19 == test.f()) ]])
         end)
 
-        pending("exported variables that are locally shadowed should be visible outside the module", function ()
+        it("exported variables that are locally shadowed should be visible outside the module", function ()
             run_test([[ assert('baby' == test.i) ]])
             run_test([[ assert('string' == type(test.h)) ]])
         end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1597,8 +1597,19 @@ describe("Pallene coder /", function()
         end)
     end)
 
-    describe("Corner cases of scoping", function()
+    describe("Corner cases of exporting variables", function ()
+        setup(compile([[
+            local z = 10
+            export x = 2000
+            local x = 300
+        ]]))
 
+        it("ensure that when globals are optimized away, the variables being exported are the right ones", function ()
+            run_test([[ assert(2000 == test.x) ]])
+        end)
+    end)
+
+    describe("Corner cases of scoping", function()
         setup(compile([[
             record Point
                 x: integer
@@ -1644,6 +1655,14 @@ describe("Pallene coder /", function()
             export i : string = 'baby'
 
             local i : string = 'yoda'
+
+            ------
+
+            local j : integer = 5319
+
+            ------
+
+            export k : string = "How you doin'?"
 
             ------
 
@@ -1702,6 +1721,14 @@ describe("Pallene coder /", function()
                 return x
             end
         ]]))
+
+        it("ensure that local variables are not exported", function ()
+            run_test([[ assert(nil == test.j) ]])
+        end)
+
+        it("ensure that exported variables are not optimized out", function ()
+            run_test([[ assert("How you doin'?" == test.k) ]])
+        end)
 
         it("exported functions that are locally shadowed should be visible ouside the module", function ()
             run_test([[ assert('function' == type(test.g)) ]])


### PR DESCRIPTION
This pull request implements the export mechanism for top-level variables.

Here's a tentative list of the tasks that this pull request tries to achieve:
1. Rename the `exports` field to `exported_functions`.
2. Add the `exported_globals` field to the IR module table.
3. Modify `to_ir.lua` to appropriately initialize the `exported_globals` field
4. Modify `coder.lua` to export the required global variables in the `luaopen` function.
5. Write appropriate test cases.