### PR TITLE
Minor luaopen cleanup

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -645,8 +645,10 @@ function Coder:init_upvalues()
             for _, v in ipairs(ir.get_srcs(cmd)) do
                 if v._tag == "ir.Value.Function" then
                     local f_id = v.id
-                    table.insert(self.upvalues, coder.Upvalue.Function(f_id))
-                    self.upvalue_of_function[f_id] = #self.upvalues
+                    if not self.upvalue_of_function[f_id] then
+                        table.insert(self.upvalues, coder.Upvalue.Function(f_id))
+                        self.upvalue_of_function[f_id] = #self.upvalues
+                    end
                 end
             end
         end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -70,10 +70,6 @@ function Coder:init(module, modname)
     self.gc = {} -- (see gc.compute_stack_slots)
     self.max_lua_call_stack_usage = {} -- func => integer
     self:init_gc()
-
-    self.closures = {}      -- list of f_id
-    self.closure_index = {} -- fid => index in closures lis
-    self:init_closures()
 end
 
 --
@@ -484,27 +480,6 @@ end
 --
 -- The first upvalue should be the module's global userdata object.
 
-
--- Computes a list of function ids that need a Lua entry point
-function Coder:init_closures()
-    local f_ids = {}
-    table.insert(f_ids, 1) -- $init function
-    for f_id in pairs(self.upvalue_of_function) do
-        table.insert(f_ids, f_id)
-    end
-    for _, f_id in ipairs(self.module.exported_functions) do
-        table.insert(f_ids, f_id)
-    end
-    table.sort(f_ids) -- For determinism
-
-    for _, f_id in ipairs(f_ids) do
-        if not self.closure_index[f_id] then
-            table.insert(self.closures, f_id)
-            self.closure_index[f_id] = #self.closures
-        end
-    end
-end
-
 function Coder:lua_entry_point_name(f_id)
     return string.format("function_%02d_lua", f_id)
 end
@@ -640,17 +615,28 @@ function Coder:init_upvalues()
     end
 
     -- Functions
+
+    local closures = {}
+    table.insert(closures, 1) -- $init
     for _, func in ipairs(self.module.functions) do
         for cmd in ir.iter(func.body) do
             for _, v in ipairs(ir.get_srcs(cmd)) do
                 if v._tag == "ir.Value.Function" then
-                    local f_id = v.id
-                    if not self.upvalue_of_function[f_id] then
-                        table.insert(self.upvalues, coder.Upvalue.Function(f_id))
-                        self.upvalue_of_function[f_id] = #self.upvalues
-                    end
+                    table.insert(closures, v.id)
                 end
             end
+        end
+    end
+    for _, f_id in ipairs(self.module.exported_functions) do
+        table.insert(closures, f_id)
+    end
+
+    table.sort(closures) -- For determinism
+
+    for _, f_id in ipairs(closures) do
+        if not self.upvalue_of_function[f_id] then
+            table.insert(self.upvalues, coder.Upvalue.Function(f_id))
+            self.upvalue_of_function[f_id] = #self.upvalues
         end
     end
 
@@ -1564,8 +1550,10 @@ function Coder:generate_module()
     end
 
     table.insert(out, section_comment("Exports"))
-    for _, f_id in ipairs(self.closures) do
-        table.insert(out, self:lua_entry_point_definition(f_id))
+    for f_id = 1, #self.module.functions do
+        if self.upvalue_of_function[f_id] then
+            table.insert(out, self:lua_entry_point_definition(f_id))
+        end
     end
     table.insert(out, self:generate_luaopen_function())
 
@@ -1573,21 +1561,6 @@ function Coder:generate_module()
 end
 
 function Coder:generate_luaopen_function()
-
-    local init_closures = {}
-    for ix, f_id in ipairs(self.closures) do
-        local entry_point = self:lua_entry_point_name(f_id)
-        table.insert(init_closures, util.render([[
-            lua_pushvalue(L, globals);
-            lua_pushcclosure(L, ${entry_point}, 1);
-            lua_seti(L, closures, $ix);
-            /**/
-        ]], {
-            entry_point = entry_point,
-            ix = C.integer(ix),
-        }))
-    end
-
 
     local init_upvalues = {}
     for ix, upv in ipairs(self.upvalues) do
@@ -1606,9 +1579,12 @@ function Coder:generate_luaopen_function()
                     }))
             elseif tag == "coder.Upvalue.Function" then
                 table.insert(init_upvalues, util.render([[
-                    lua_geti(L, closures, $ix); ]], {
-                        ix = C.integer(self.closure_index[upv.f_id])
-                    }))
+                    lua_pushvalue(L, globals);
+                    lua_pushcclosure(L, ${entry_point}, 1);
+                ]], {
+                    entry_point = self:lua_entry_point_name(upv.f_id),
+                    ix = C.integer(self.upvalue_of_function[upv.f_id]),
+                }))
             else
                 error("impossible")
             end
@@ -1621,11 +1597,14 @@ function Coder:generate_luaopen_function()
             }))
         end
     end
-    table.insert(init_upvalues, [[
+
+    table.insert(init_upvalues, util.render([[
         // Run toplevel statements & initialize globals
-        lua_geti(L, closures, 1);
+        lua_getiuservalue(L, globals, $ix);
         lua_call(L, 0, 0);
-    ]])
+    ]], {
+        ix = C.integer(assert(self.upvalue_of_function[1])),
+    }))
 
 
     local init_exports = {}
@@ -1633,12 +1612,12 @@ function Coder:generate_luaopen_function()
         local name = self.module.functions[f_id].name
         table.insert(init_exports, util.render([[
             lua_pushstring(L, ${name});
-            lua_geti(L, closures, $ix);
+            lua_getiuservalue(L, globals, $ix);
             lua_settable(L, export_table);
             /**/
         ]], {
             name = C.string(name),
-            ix = C.integer(self.closure_index[f_id]),
+            ix = C.integer(self.upvalue_of_function[f_id]),
         }))
     end
 
@@ -1667,19 +1646,8 @@ function Coder:generate_luaopen_function()
 
             /**/
 
-            lua_createtable(L, $n_closures, 0);
-            int closures = lua_gettop(L);
-
-            /**/
-
             lua_newtable(L);
             int export_table = lua_gettop(L);
-
-            /**/
-            /* Closures */
-            /**/
-
-            ${init_closures}
 
             /**/
             /* Global values */
@@ -1700,9 +1668,7 @@ function Coder:generate_luaopen_function()
         }
     ]], {
         name = "luaopen_" .. self.modname,
-        n_closures = C.integer(#self.closures),
         n_upvalues = C.integer(#self.upvalues),
-        init_closures = table.concat(init_closures, "\n"),
         init_upvalues = table.concat(init_upvalues, "\n"),
         init_exports  = table.concat(init_exports, "\n"),
     }))


### PR DESCRIPTION
This set of patches streamlines the generated `luaopen` function a little bit by getting rid of the`closures` array.

Instead of initializing the closures in a separate step, initialize them in the same place where we initialize the other kinds of module-level constants (strings and metatables). This simplifies the coder and also makes exporting functions work more similarly to exporting of other values.

The small price we pay is that if a function is exported but not used as a first-class value it will now use an upvalue slot while it previously would not. Thankfully it does not lead to memory leaks because those function closures would already be kept alive by the exports table. It does cause an insignificant amount of memory bloat though. That said, if we really want to optimize that then perhaps the right way to do it would be to implement closures that are safe-for-space instead of special casing the creation of function values in the luaopen.

----------------

Example program:

```lua
local x: integer = 0

export function inc(): integer
    io.write("hello")
    x = x + 1
    return x
end
```

Before:

```c
int luaopen_foo(lua_State *L)
{
    luaL_checkversion(L);
    	
    lua_newuserdatauv(L, 0, 2);
    int globals = lua_gettop(L);
    	
    lua_createtable(L, 2, 0);
    int closures = lua_gettop(L);
    	
    lua_newtable(L);
    int export_table = lua_gettop(L);
    	
    /* Closures */
    	
    lua_pushvalue(L, globals);
    lua_pushcclosure(L, function_01_lua, 1);
    lua_seti(L, closures, 1);
    	
    lua_pushvalue(L, globals);
    lua_pushcclosure(L, function_02_lua, 1);
    lua_seti(L, closures, 2);
    	
    /* Global values */
    	
    lua_pushstring(L, "hello");
    lua_setiuservalue(L, globals, 1);
    	
    // Run toplevel statements & initialize globals
    lua_geti(L, closures, 1);
    lua_call(L, 0, 0);
    	
    /* Exports */
    	
    lua_pushstring(L, "inc");
    lua_geti(L, closures, 2);
    lua_settable(L, export_table);
    	
    lua_pushvalue(L, export_table);
    return 1;
}
```

After:

```c
int luaopen_foo(lua_State *L)
{
    luaL_checkversion(L);
    	
    /* Constants */
    	
    lua_newuserdatauv(L, 0, 3);
    int globals = lua_gettop(L);
    	
    lua_pushstring(L, "hello");
    lua_setiuservalue(L, globals, 1);
    	
    lua_pushvalue(L, globals);
    lua_pushcclosure(L, function_02_lua, 1);
    lua_setiuservalue(L, globals, 2);
    	
    /* Variables & Initializers */
    	
    lua_pushvalue(L, globals);
    lua_pushcclosure(L, function_01_lua, 1);
    lua_call(L, 0, 0);
    	
    /* Exports */
    	
    lua_newtable(L);
    int export_table = lua_gettop(L);
    	
    lua_pushstring(L, "inc");
    lua_getiuservalue(L, globals, 2);
    lua_settable(L, export_table);
    	
    lua_pushvalue(L, export_table);
    return 1;
}
```