### PR TITLE
Updated the test specs to avoid creating "__test__.pln".

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -2,7 +2,7 @@ local driver = require 'pallene.driver'
 local util = require 'pallene.util'
 
 local function run_checker(code)
-    assert(util.set_file_contents("__test__.pln", code))
+    -- "__test__.pln" does not exist on disk. The name is only used for error messages.
     local module, errs = driver.compile_internal("__test__.pln", code, "checker")
     return module, table.concat(errs, "\n")
 end
@@ -14,10 +14,6 @@ local function assert_error(code, expected_err)
 end
 
 describe("Scope analysis: ", function()
-
-    teardown(function()
-        os.remove("__test__.pln")
-    end)
 
     it("forbids variables from being used before they are defined", function()
         assert_error([[
@@ -136,10 +132,6 @@ describe("Scope analysis: ", function()
 end)
 
 describe("Pallene type checker", function()
-
-    teardown(function()
-        os.remove("__test__.pln")
-    end)
 
     it('catches incompatible function type assignments', function()
         assert_error([[

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -34,7 +34,6 @@ end
 --
 
 local function parse(code)
-    assert(util.set_file_contents("__test__.pln", code))
     return driver.compile_internal("__test__.pln", code, "ast")
 end
 
@@ -149,7 +148,6 @@ describe("Pallene parser", function()
 
     teardown(function()
         assert:set_parameter("TableFormatLevel", ORIGINAL_FORMAT_LEVEL)
-        os.remove("__test__.pln")
     end)
 
     it("can parse programs starting with whitespace or comments", function()

--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -1,8 +1,6 @@
 local driver = require 'pallene.driver'
-local util = require 'pallene.util'
 
 local function run_uninitialized(code)
-    assert(util.set_file_contents("__test__.pln", code))
     local module, errs = driver.compile_internal("__test__.pln", code, "uninitialized")
     return module, table.concat(errs, "\n")
 end
@@ -17,10 +15,6 @@ local missing_return =
     "control reaches end of function with non-empty return type"
 
 describe("Uninitialized variable analysis: ", function()
-
-    teardown(function()
-        os.remove("__test__.pln")
-    end)
 
     it("empty function", function()
         assert_error([[


### PR DESCRIPTION
Since `compile_internal` now accepts the Pallene code, the utility functions in the spec files were
updated to take advantage of this. In other words, a temporary file does not have to be created for
each test thus reducing the overall time taken for running the tests.