### PR TITLE
Added test cases for inputs with errors during translation

### DIFF
--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -125,6 +125,18 @@ end
 --    compile("c", "so", "foo.c)      --> outputs "foo.so"
 --
 
+function driver.translate(input_file_name, input)
+    local prog_ast, errs = driver.compile_internal(input_file_name, input, "checker")
+
+    if not prog_ast then
+        return false, errs
+    end
+
+    local translation = translator.translate(input, prog_ast)
+
+    return translation, {}
+end
+
 local function compile_pln_to_lua(input_ext, output_ext, input_file_name, base_name)
     assert(input_ext == "pln")
 
@@ -133,14 +145,12 @@ local function compile_pln_to_lua(input_ext, output_ext, input_file_name, base_n
         return false, { err }
     end
 
-    local prog_ast, errs = driver.compile_internal(input_file_name, input, "checker")
-    if not prog_ast then
+    local translation, errs = driver.translate(input_file_name, input)
+    if not translation then
         return false, errs
     end
 
-    local translation = translator.translate(input, prog_ast)
     assert(util.set_file_contents(base_name .. "." .. output_ext, translation))
-
     return true, {}
 end
 

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -134,16 +134,11 @@ local function compile_pln_to_lua(input_ext, output_ext, input_file_name, base_n
     end
 
     local prog_ast, errs = driver.compile_internal(input_file_name, input, "checker")
-
     if not prog_ast then
         return false, errs
     end
 
     local translation = translator.translate(input, prog_ast)
-
-    if not translation then
-        return false, errs
-    end
 
     assert(util.set_file_contents(base_name .. "." .. output_ext, translation))
     return true, {}

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -125,18 +125,6 @@ end
 --    compile("c", "so", "foo.c)      --> outputs "foo.so"
 --
 
-function driver.translate(input_file_name, input)
-    local prog_ast, errs = driver.compile_internal(input_file_name, input, "checker")
-
-    if not prog_ast then
-        return false, errs
-    end
-
-    local translation = translator.translate(input, prog_ast)
-
-    return translation, {}
-end
-
 local function compile_pln_to_lua(input_ext, output_ext, input_file_name, base_name)
     assert(input_ext == "pln")
 
@@ -145,7 +133,14 @@ local function compile_pln_to_lua(input_ext, output_ext, input_file_name, base_n
         return false, { err }
     end
 
-    local translation, errs = driver.translate(input_file_name, input)
+    local prog_ast, errs = driver.compile_internal(input_file_name, input, "checker")
+
+    if not prog_ast then
+        return false, errs
+    end
+
+    local translation = translator.translate(input, prog_ast)
+
     if not translation then
         return false, errs
     end

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -230,12 +230,15 @@ end
 local grammar = re.compile([[
 
     program         <-  SKIP*
-                        {| ( toplevelfunc
+                        {|
+                           ( toplevelfunc
                            / toplevelvar
                            / typealias
                            / toplevelrecord
                            / import
-                           / FUNCTION %{LocalOrExportRequired})* |} !.
+                           / FUNCTION %{LocalOrExportRequiredFunction}
+                           / NAME (ASSIGN / COMMA) %{LocalOrExportRequiredVariable} )*
+                        |} !.
 
     toplevelfunc    <- (P  export_or_local FUNCTION NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -234,7 +234,8 @@ local grammar = re.compile([[
                            / toplevelvar
                            / typealias
                            / toplevelrecord
-                           / import )* |} !.
+                           / import
+                           / FUNCTION %{LocalOrExportRequired})* |} !.
 
     toplevelfunc    <- (P  export_or_local FUNCTION NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -250,7 +250,8 @@ local grammar = re.compile([[
                            END^EndRecord)                        -> ToplevelRecord
 
     export_or_local <- LOCAL -> to_true
-                     / EXPORT -> to_false
+                    / EXPORT -> to_false
+
 
     import          <- (P  LOCAL NAME^NameImport ASSIGN^AssignImport
                            IMPORT^ImportImport

--- a/pallene/syntax_errors.lua
+++ b/pallene/syntax_errors.lua
@@ -175,6 +175,8 @@ local errors = {
     AssignNotToVar = "Expected a valid lvalue in the left side of assignment but found a regular expression.",
 
     CastMissingType = "Expected a type for the cast expression.",
+
+    LocalOrExportRequired = "Expected 'local' or 'export' modifier in function definition."
 }
 
 syntax_errors.errors = errors

--- a/pallene/syntax_errors.lua
+++ b/pallene/syntax_errors.lua
@@ -176,7 +176,9 @@ local errors = {
 
     CastMissingType = "Expected a type for the cast expression.",
 
-    LocalOrExportRequired = "Expected 'local' or 'export' modifier in function definition."
+    LocalOrExportRequiredFunction = "Expected 'local' or 'export' modifier in function definition.",
+
+    LocalOrExportRequiredVariable = "Expected 'local' or 'export' modifier in variable declaration."
 }
 
 syntax_errors.errors = errors

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -167,6 +167,39 @@ describe("Pallene parser", function()
         assert_program_syntax_error([[ x=17 ]], "Syntax Error")
     end)
 
+    it("cannot define function without export or local modifier", function()
+        assert_program_syntax_error([[
+            function f() : integer
+                return 5319
+            end
+        ]],
+        "Expected 'local' or 'export' modifier in function definition.")
+    end)
+
+    it("last function without export or local modifier", function()
+        assert_program_syntax_error([[
+            export function a()
+            end
+
+            function f() : integer
+                return 5319
+            end
+        ]],
+        "Expected 'local' or 'export' modifier in function definition.")
+    end)
+
+    it("first function without export or local modifier", function()
+        assert_program_syntax_error([[
+            function a()
+            end
+
+            export function f() : integer
+                return 5319
+            end
+        ]],
+        "Expected 'local' or 'export' modifier in function definition.")
+    end)
+
     it("can parse toplevel function declarations", function()
         assert_program_ast([[
             local function fA() : float

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -164,7 +164,8 @@ describe("Pallene parser", function()
     end)
 
     it("does not allow global variables", function()
-        assert_program_syntax_error([[ x=17 ]], "Syntax Error")
+        assert_program_syntax_error([[ x=17 ]],
+            "Expected 'local' or 'export' modifier in variable declaration.")
     end)
 
     it("cannot define function without export or local modifier", function()
@@ -198,6 +199,20 @@ describe("Pallene parser", function()
             end
         ]],
         "Expected 'local' or 'export' modifier in function definition.")
+    end)
+
+    it("toplevel variable declaration without export or local modifier", function()
+        assert_program_syntax_error([[
+            a,m="s","r"
+        ]],
+        "Expected 'local' or 'export' modifier in variable declaration.")
+    end)
+
+    it("toplevel variable declaration without export or local modifier (without comma)", function()
+        assert_program_syntax_error([[
+            a="s"
+        ]],
+        "Expected 'local' or 'export' modifier in variable declaration.")
     end)
 
     it("can parse toplevel function declarations", function()


### PR DESCRIPTION
The translator spec was updated to ensure that input with syntax and semantic errors are properly reported when `--emit-lua` is specified. It should be noted that the test spec does not actually invoke the compiler with the flag, instead it invokes an internal
function to simulate it.