### PR TITLE
The translator now uses gsub() to retain whitespace characters.

### DIFF
--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -24,19 +24,9 @@ end
 function Translator:add_whitespace(input, start_index, stop_index)
     self:add_previous(input, start_index - 1)
 
-    local p = start_index
-    local q = start_index
-    while q <= stop_index do
-        if input:sub(q, q) == "\n" then
-            local partial = string.rep(" ", q - p)
-            table.insert(self.partials, partial)
-            table.insert(self.partials, "\n")
-            p = q + 1
-        end
-        q = q + 1
-    end
-    local final_partial = string.rep(" ", q - p)
-    table.insert(self.partials, final_partial)
+    local region = input:sub(start_index, stop_index)
+    local partial = region:gsub("%S", " ")
+    table.insert(self.partials, partial)
 
     self.last_index = stop_index + 1
 end
@@ -47,10 +37,12 @@ function translator.translate(input, prog_ast)
     for _, node in ipairs(prog_ast) do
         if node._tag == "ast.Toplevel.Var" then
             for _, decl in ipairs(node.decls) do
-                local start = decl.col_loc.pos
-                local stop = decl.end_loc.pos
-
-                instance:add_whitespace(input, start, stop - 1)
+                if decl.type then
+                    -- Remove the colon but retain any adjacent comment to the right.
+                    instance:add_whitespace(input, decl.col_loc.pos, decl.col_loc.pos)
+                    -- Remove the type annotation but exclude the next token.
+                    instance:add_whitespace(input, decl.type.loc.pos, decl.end_loc.pos - 1)
+                end
             end
         end
     end


### PR DESCRIPTION
The general idea is to use `string.sub` to get the substring we want to replace with whitespace.
After which, we call `string.gsub` on the substring with `%S` to replace all non-whitespace
characters with space. Whitespace characters including newlines stay unchanged.

As of now, comments before the actual type annotation begins are retained. See the snippet
below:
```
local i : -- This comment is retained.
{
   -- This comment will be erased.
   integer
} = { 1, 2, 3 }
```
This is possible because we have access to enough offsets to retain such comments.
However, comments that appear within type annotations are erased. We could think
of a workaround later if it turns out that preserving those comments is important
in practice.

The most important thing is preserving newlines because that means error messages
point to the right place. Preserving comments is a nice thing to do but is not
essential because you still have the original Pallene file with all the comments.