### PR TITLE
Update the translator to translate the remaining constructs

### DIFF
--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -25,8 +25,8 @@ declare_type("Type", {
 })
 
 declare_type("Toplevel", {
-    Func      = {"loc", "is_local", "mod_end_loc", "decl", "value", "rt_col_loc", "rt_end_loc"},
-    Var       = {"loc", "is_local", "mod_end_loc", "decls", "values"},
+    Func      = {"loc", "is_local", "decl", "value", "rt_col_loc", "rt_end_loc"},
+    Var       = {"loc", "is_local", "decls", "values"},
     Typealias = {"loc", "name", "type", "end_loc"},
     Record    = {"loc", "name", "field_decls", "end_loc"},
     Import    = {"loc", "local_name", "mod_name"},

--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -26,7 +26,7 @@ declare_type("Type", {
 
 declare_type("Toplevel", {
     Func      = {"loc", "is_local", "mod_end_loc", "decl", "value", "rt_col_loc", "rt_end_loc"},
-    Var       = {"loc", "is_local", "decls", "values"},
+    Var       = {"loc", "is_local", "mod_end_loc", "decls", "values"},
     Typealias = {"loc", "name", "type", "end_loc"},
     Record    = {"loc", "name", "field_decls", "end_loc"},
     Import    = {"loc", "local_name", "mod_name"},

--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -25,7 +25,7 @@ declare_type("Type", {
 })
 
 declare_type("Toplevel", {
-    Func      = {"loc", "is_local", "decl", "value", "rt_col_loc", "rt_end_loc"},
+    Func      = {"loc", "is_local", "mod_end_loc", "decl", "value", "rt_col_loc", "rt_end_loc"},
     Var       = {"loc", "is_local", "decls", "values"},
     Typealias = {"loc", "name", "type", "end_loc"},
     Record    = {"loc", "name", "field_decls", "end_loc"},

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -245,7 +245,7 @@ local grammar = re.compile([[
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            P rettypeopt P block END^EndFunc)         -> toplevel_func
 
-    toplevelvar     <- (P  export_or_local decllist ASSIGN^AssignVar
+    toplevelvar     <- (P  export_or_local P decllist ASSIGN^AssignVar
                            !IMPORT explist1^ExpVarDec)           -> ToplevelVar
 
     typealias       <- (P  TYPEALIAS NAME^NameTypeAlias ASSIGN^AssignTypeAlias

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -77,7 +77,7 @@ function defs.opt_list(x)
     end
 end
 
-function defs.toplevel_func(loc, is_local, mod_end_loc, name, params, rt_col_loc, ret_types,
+function defs.toplevel_func(loc, is_local, name, params, rt_col_loc, ret_types,
     rt_end_loc, block)
     local arg_types = {}
     for i, decl in ipairs(params) do
@@ -85,7 +85,7 @@ function defs.toplevel_func(loc, is_local, mod_end_loc, name, params, rt_col_loc
     end
     local func_typ = ast.Type.Function(loc, arg_types, ret_types)
     return ast.Toplevel.Func(
-        loc, is_local, mod_end_loc,
+        loc, is_local,
         ast.Decl.Decl(loc, name, false, func_typ, false),
         ast.Exp.Lambda(loc, params, block), rt_col_loc, rt_end_loc)
 end
@@ -241,11 +241,11 @@ local grammar = re.compile([[
                            / NAME (ASSIGN / COMMA) %{LocalOrExportRequiredVariable} )*
                         |} !.
 
-    toplevelfunc    <- (P  export_or_local P FUNCTION NAME^NameFunc
+    toplevelfunc    <- (P  export_or_local FUNCTION NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            P rettypeopt P block END^EndFunc)         -> toplevel_func
 
-    toplevelvar     <- (P  export_or_local P decllist ASSIGN^AssignVar
+    toplevelvar     <- (P  export_or_local decllist ASSIGN^AssignVar
                            !IMPORT explist1^ExpVarDec)           -> ToplevelVar
 
     typealias       <- (P  TYPEALIAS NAME^NameTypeAlias ASSIGN^AssignTypeAlias

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -77,14 +77,15 @@ function defs.opt_list(x)
     end
 end
 
-function defs.toplevel_func(loc, is_local, name, params, rt_col_loc, ret_types, rt_end_loc, block)
+function defs.toplevel_func(loc, is_local, mod_end_loc, name, params, rt_col_loc, ret_types,
+    rt_end_loc, block)
     local arg_types = {}
     for i, decl in ipairs(params) do
         arg_types[i] = decl.type
     end
     local func_typ = ast.Type.Function(loc, arg_types, ret_types)
     return ast.Toplevel.Func(
-        loc, is_local,
+        loc, is_local, mod_end_loc,
         ast.Decl.Decl(loc, name, false, func_typ, false),
         ast.Exp.Lambda(loc, params, block), rt_col_loc, rt_end_loc)
 end
@@ -240,7 +241,7 @@ local grammar = re.compile([[
                            / NAME (ASSIGN / COMMA) %{LocalOrExportRequiredVariable} )*
                         |} !.
 
-    toplevelfunc    <- (P  export_or_local FUNCTION NAME^NameFunc
+    toplevelfunc    <- (P  export_or_local P FUNCTION NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            P rettypeopt P block END^EndFunc)         -> toplevel_func
 

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -31,6 +31,8 @@ local Translator = util.Class()
 function Translator:init()
     self.last_index = 1
     self.partials = {}
+    self.exports = {}
+    self.input = false
     return self
 end
 
@@ -46,15 +48,15 @@ function Translator:add_whitespace(input, start_index, stop_index)
     assert(start_index <= stop_index+1)
     self:add_previous(input, start_index - 1)
 
-    local region = input:sub(start_index, stop_index)
+    local region = self.input:sub(start_index, stop_index)
     local partial = region:gsub("%S", " ")
     table.insert(self.partials, partial)
 
     self.last_index = stop_index + 1
 end
 
-function Translator:add_local(input, start_index, stop_index)
-    self:add_previous(input, start_index - 1)
+function Translator:add_local(start_index, stop_index)
+    self:add_previous(start_index - 1)
     -- The export keyword is six characters long, whereas the local keyword is five characters
     -- long. Therefore, we pad the keyword with a space. We could add the space to the left, too.
     -- But it seems more "natural" on the right.
@@ -63,10 +65,10 @@ function Translator:add_local(input, start_index, stop_index)
     self.last_index = stop_index
 end
 
-function Translator:add_exports(exports)
-    if #exports > 0 then
+function Translator:add_exports()
+    if #self.exports > 0 then
         table.insert(self.partials, "\nreturn {\n")
-        for _, export in ipairs(exports) do
+        for _, export in ipairs(self.exports) do
             local pair = string.format("    %s = %s,\n", export, export)
             table.insert(self.partials, pair)
         end
@@ -74,72 +76,79 @@ function Translator:add_exports(exports)
     end
 end
 
+function Translator:translate_tl_variables(node)
+    -- Add the variables to the export sequence if they are declared with the `export`
+    -- modifier.
+    if not node.is_local then
+        self:add_local(node.loc.pos, node.mod_end_loc.pos - 1)
+        for _, decl in ipairs(node.decls) do
+            table.insert(self.exports, decl.name)
+        end
+    end
+
+    for _, decl in ipairs(node.decls) do
+        if decl.type then
+            -- Remove the colon but retain any adjacent comment to the right.
+            self:add_whitespace(decl.col_loc.pos, decl.col_loc.pos)
+            -- Remove the type annotation but exclude the next token.
+            self:add_whitespace(decl.type.loc.pos, decl.end_loc.pos - 1)
+        end
+    end
+end
+
+function Translator:translate_tl_function(node)
+    if not node.is_local then
+        self:add_local(node.loc.pos, node.mod_end_loc.pos - 1)
+        table.insert(self.exports, node.decl.name)
+    end
+
+    -- Remove type annotations from function parameters.
+    for _, arg_decl in ipairs(node.value.arg_decls) do
+        -- Type annotations are mandatory for function parameters.
+        -- Remove the colon but retain any adjacent comment to the right.
+        self:add_whitespace(arg_decl.col_loc.pos, arg_decl.col_loc.pos)
+        -- Remove the type annotation but exclude the next token.
+        self:add_whitespace(arg_decl.type.loc.pos, arg_decl.end_loc.pos - 1)
+    end
+
+    -- Remove type annotations from the return type, which is optional. However, `rt_col_loc`
+    -- and `rt_end_loc` are always set. Therefore, it is safe to replace without any checks.
+    self:add_whitespace(node.rt_col_loc.pos, node.rt_end_loc.pos - 1)
+
+    -- Remove type annotations from local declarations.
+    for _, statement in ipairs(node.value.body.stats) do
+        if statement._tag == "ast.Stat.Decl" then
+            for _, decl in ipairs(statement.decls) do
+                if decl.type then
+                    -- Remove the colon but retain any adjacent comment to the right.
+                    self:add_whitespace(decl.col_loc.pos, decl.col_loc.pos)
+                    -- Remove the type annotation but exclude the next token.
+                    self:add_whitespace(decl.type.loc.pos, decl.end_loc.pos - 1)
+                end
+            end
+        end
+    end
+end
+
 function translator.translate(input, prog_ast)
     local instance = Translator:new()
-    local exports = {}
+    instance.input = input
 
     for _, node in ipairs(prog_ast) do
         if node._tag == "ast.Toplevel.Var" then
-            -- Add the variables to the export sequence if they are declared with the `export`
-            -- modifier.
-            if not node.is_local then
-                instance:add_local(input, node.loc.pos, node.mod_end_loc.pos - 1)
-                for _, decl in ipairs(node.decls) do
-                    table.insert(exports, decl.name)
-                end
-            end
-
-            for _, decl in ipairs(node.decls) do
-                if decl.type then
-                    -- Remove the colon but retain any adjacent comment to the right.
-                    instance:add_whitespace(input, decl.col_loc.pos, decl.col_loc.pos)
-                    -- Remove the type annotation but exclude the next token.
-                    instance:add_whitespace(input, decl.type.loc.pos, decl.end_loc.pos - 1)
-                end
-            end
+            instance:translate_tl_variables(node)
         elseif node._tag == "ast.Toplevel.Func" then
-            if not node.is_local then
-                instance:add_local(input, node.loc.pos, node.mod_end_loc.pos - 1)
-                table.insert(exports, node.decl.name)
-            end
-
-            -- Remove type annotations from function parameters.
-            for _, arg_decl in ipairs(node.value.arg_decls) do
-                -- Type annotations are mandatory for function parameters.
-                -- Remove the colon but retain any adjacent comment to the right.
-                instance:add_whitespace(input, arg_decl.col_loc.pos, arg_decl.col_loc.pos)
-                -- Remove the type annotation but exclude the next token.
-                instance:add_whitespace(input, arg_decl.type.loc.pos, arg_decl.end_loc.pos - 1)
-            end
-
-            -- Remove type annotations from the return type, which is optional. However, `rt_col_loc`
-            -- and `rt_end_loc` are always set. Therefore, it is safe to replace without any checks.
-            instance:add_whitespace(input, node.rt_col_loc.pos, node.rt_end_loc.pos - 1)
-
-            -- Remove type annotations from local declarations.
-            for _, statement in ipairs(node.value.body.stats) do
-                if statement._tag == "ast.Stat.Decl" then
-                    for _, decl in ipairs(statement.decls) do
-                        if decl.type then
-                            -- Remove the colon but retain any adjacent comment to the right.
-                            instance:add_whitespace(input, decl.col_loc.pos, decl.col_loc.pos)
-                            -- Remove the type annotation but exclude the next token.
-                            instance:add_whitespace(input, decl.type.loc.pos, decl.end_loc.pos - 1)
-                        end
-                    end
-                end
-            end
+            instance:translate_tl_function(node)
         elseif node._tag == "ast.Toplevel.Typealias" then
             -- Remove the type alias but exclude the next token.
-            instance:add_whitespace(input, node.loc.pos, node.end_loc.pos - 1)
+            instance:add_whitespace(node.loc.pos, node.end_loc.pos - 1)
         elseif node._tag == "ast.Toplevel.Record" then
             -- Remove the record but exclude the next token.
-            instance:add_whitespace(input, node.loc.pos, node.end_loc.pos - 1)
+            instance:add_whitespace(node.loc.pos, node.end_loc.pos - 1)
         end
     end
     -- Whatever characters that were not included in the partials should be added.
-    instance:add_previous(input, #input)
-
+    instance:add_previous(#input)
     instance:add_exports(exports)
 
     return table.concat(instance.partials, "")

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -67,9 +67,18 @@ end
 function translator.translate(input, prog_ast)
     local instance = Translator:new()
     local exports = {}
+    print(require("inspect")(prog_ast))
 
     for _, node in ipairs(prog_ast) do
         if node._tag == "ast.Toplevel.Var" then
+            -- Add the variables to the export sequence if they are declared with the `export`
+            -- modifier.
+            if not node.is_local then
+                for _, decl in ipairs(node.decls) do
+                    table.insert(exports, decl.name)
+                end
+            end
+
             for _, decl in ipairs(node.decls) do
                 if decl.type then
                     -- Remove the colon but retain any adjacent comment to the right.

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -28,25 +28,25 @@ local translator = {}
 
 local Translator = util.Class()
 
-function Translator:init()
-    self.last_index = 1
-    self.partials = {}
-    self.exports = {}
-    self.input = false
+function Translator:init(input)
+    self.input = input -- string
+    self.last_index = 1 -- integer
+    self.partials = {} -- list of strings
+    self.exports = {} -- list of strings
     return self
 end
 
-function Translator:add_previous(input, stop_index)
+function Translator:add_previous(stop_index)
     assert(self.last_index <= stop_index + 1)
-    local partial = input:sub(self.last_index, stop_index)
+    local partial = self.input:sub(self.last_index, stop_index)
     table.insert(self.partials, partial)
     self.last_index = stop_index + 1
 end
 
-function Translator:add_whitespace(input, start_index, stop_index)
+function Translator:add_whitespace(start_index, stop_index)
     assert(self.last_index <= start_index)
     assert(start_index <= stop_index+1)
-    self:add_previous(input, start_index - 1)
+    self:add_previous(start_index - 1)
 
     local region = self.input:sub(start_index, stop_index)
     local partial = region:gsub("%S", " ")
@@ -55,14 +55,14 @@ function Translator:add_whitespace(input, start_index, stop_index)
     self.last_index = stop_index + 1
 end
 
-function Translator:add_local(start_index, stop_index)
+function Translator:add_local(start_index)
     self:add_previous(start_index - 1)
     -- The export keyword is six characters long, whereas the local keyword is five characters
     -- long. Therefore, we pad the keyword with a space. We could add the space to the left, too.
     -- But it seems more "natural" on the right.
     table.insert(self.partials, "local ")
 
-    self.last_index = stop_index
+    self.last_index = self.last_index + 6
 end
 
 function Translator:add_exports()
@@ -76,7 +76,7 @@ function Translator:add_exports()
     end
 end
 
-function Translator:translate_var_decl(decl)
+function Translator:translate_decl(decl)
     if decl.type then
         -- Remove the colon but retain any adjacent comment to the right.
         self:add_whitespace(decl.col_loc.pos, decl.col_loc.pos)
@@ -85,70 +85,70 @@ function Translator:translate_var_decl(decl)
     end
 end
 
-function Translator:translate_tl_variables(node)
-    -- Add the variables to the export sequence if they are declared with the `export`
-    -- modifier.
-    if not node.is_local then
-        self:add_local(node.loc.pos, node.mod_end_loc.pos - 1)
-        for _, decl in ipairs(node.decls) do
-            table.insert(self.exports, decl.name)
+function Translator:translate_stat(stat)
+    if stat._tag == "ast.Stat.Decl" then
+        for _, decl in ipairs(stat.decls) do
+            self:translate_decl(decl)
         end
-    end
-
-    for _, decl in ipairs(node.decls) do
-        self:translate_var_decl(decl)
+    elseif stat._tag == "ast.Stat.For" then
+        self:translate_decl(stat.decl)
+    elseif stat._tag == "ast.Stat.Block" then
+        for _, s in ipairs(stat.stats) do
+            self:translate_stat(s)
+        end
     end
 end
 
-function Translator:translate_tl_function(node)
-    if not node.is_local then
-        self:add_local(node.loc.pos, node.mod_end_loc.pos - 1)
-        table.insert(self.exports, node.decl.name)
-    end
-
-    -- Remove type annotations from function parameters.
-    for _, arg_decl in ipairs(node.value.arg_decls) do
-        self:translate_var_decl(arg_decl)
-    end
-
-    -- Remove type annotations from the return type, which is optional. However, `rt_col_loc`
-    -- and `rt_end_loc` are always set. Therefore, it is safe to replace without any checks.
-    self:add_whitespace(node.rt_col_loc.pos, node.rt_end_loc.pos - 1)
-
-    -- Remove type annotations from local declarations.
-    for _, statement in ipairs(node.value.body.stats) do
-        if statement._tag == "ast.Stat.Decl" then
-            for _, decl in ipairs(statement.decls) do
-                self:translate_var_decl(decl)
+function Translator:translate_toplevel(node)
+    if node._tag == "ast.Toplevel.Var" then
+        -- Add the variables to the export sequence if they are declared with the `export`
+        -- modifier.
+        if not node.is_local then
+            self:add_local(node.loc.pos)
+            for _, decl in ipairs(node.decls) do
+                table.insert(self.exports, decl.name)
             end
-        elseif statement._tag == "ast.Stat.For" then
-            self:translate_var_decl(statement.decl)
         end
+
+        for _, decl in ipairs(node.decls) do
+            self:translate_decl(decl)
+        end
+    elseif node._tag == "ast.Toplevel.Func" then
+        if not node.is_local then
+            self:add_local(node.loc.pos)
+            table.insert(self.exports, node.decl.name)
+        end
+
+        -- Remove type annotations from function parameters.
+        for _, arg_decl in ipairs(node.value.arg_decls) do
+            self:translate_decl(arg_decl)
+        end
+
+        -- Remove type annotations from the return type, which is optional. However, `rt_col_loc`
+        -- and `rt_end_loc` are always set. Therefore, it is safe to replace without any checks.
+        self:add_whitespace(node.rt_col_loc.pos, node.rt_end_loc.pos - 1)
+
+        self:translate_stat(node.value.body)
+    elseif node._tag == "ast.Toplevel.Typealias" then
+        -- Remove the type alias but exclude the next token.
+        self:add_whitespace(node.loc.pos, node.end_loc.pos - 1)
+    elseif node._tag == "ast.Toplevel.Record" then
+        -- Remove the record but exclude the next token.
+        self:add_whitespace(node.loc.pos, node.end_loc.pos - 1)
     end
 end
 
 function translator.translate(input, prog_ast)
-    local instance = Translator:new()
-    instance.input = input
+    local instance = Translator.new(input)
 
     for _, node in ipairs(prog_ast) do
-        if node._tag == "ast.Toplevel.Var" then
-            instance:translate_tl_variables(node)
-        elseif node._tag == "ast.Toplevel.Func" then
-            instance:translate_tl_function(node)
-        elseif node._tag == "ast.Toplevel.Typealias" then
-            -- Remove the type alias but exclude the next token.
-            instance:add_whitespace(node.loc.pos, node.end_loc.pos - 1)
-        elseif node._tag == "ast.Toplevel.Record" then
-            -- Remove the record but exclude the next token.
-            instance:add_whitespace(node.loc.pos, node.end_loc.pos - 1)
-        end
+        instance:translate_toplevel(node)
     end
     -- Whatever characters that were not included in the partials should be added.
     instance:add_previous(#input)
     instance:add_exports()
 
-    return table.concat(instance.partials, "")
+    return table.concat(instance.partials)
 end
 
 return translator

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -146,7 +146,7 @@ function translator.translate(input, prog_ast)
     end
     -- Whatever characters that were not included in the partials should be added.
     instance:add_previous(#input)
-    instance:add_exports(exports)
+    instance:add_exports()
 
     return table.concat(instance.partials, "")
 end

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -320,6 +320,67 @@ describe("Pallene to Lua translator", function ()
         ]])
     end)
 
+    it("Generate return statement for exported variable", function ()
+        assert_translation(
+            "export i : integer = 0",
+
+            "local  i           = 0\n" ..
+            "return {\n" ..
+            "    i = i,\n" ..
+            "}\n")
+    end)
+
+    it("Generate return statement for exported function", function ()
+        assert_translation(
+            "export function f() end",
+            "local  function f() end\nreturn {\n    f = f,\n}\n")
+    end)
+
+    it("Generate the same return statement for both exported functions and variables", function ()
+        assert_translation(
+            "export i : integer = 0\n" ..
+            "\n" ..
+            "export function f()\n" ..
+            "end",
+
+            "local  i           = 0\n" ..
+            "\n" ..
+            "local  function f()\n" ..
+            "end\n" ..
+            "return {\n" ..
+            "    i = i,\n" ..
+            "    f = f,\n" ..
+            "}\n")
+    end)
+
+    it("Do not include local symbols in the module return statement", function ()
+        assert_translation(
+            "export i : integer = 0\n" ..
+            "\n" ..
+            "export function a()\n" ..
+            "end\n" ..
+            "\n" ..
+            "local function s()\n" ..
+            "end\n" ..
+            "\n" ..
+            "local j : { integer } = { 1, 2, 3 }",
+
+            "local  i           = 0\n" ..
+            "\n" ..
+            "local  function a()\n" ..
+            "end\n" ..
+            "\n" ..
+            "local function s()\n" ..
+            "end\n" ..
+            "\n" ..
+            "local j               = { 1, 2, 3 }" ..
+            "\n" ..
+            "return {\n" ..
+            "    i = i,\n" ..
+            "    a = a,\n" ..
+            "}\n")
+    end)
+
     pending("Mutually recursive functions (infinite)", function ()
         assert_translation([[
             local function a()

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -404,31 +404,29 @@ describe("Pallene to Lua translator", function ()
         ]])
     end)
 
-    pending("Remove type annotations", function ()
+    it("Remove any type annotation", function ()
         assert_translation([[
             local xs: {any} = {10, "hello", 3.14}
 
-            function f(x: any, y: any): integer
-                return (x as integer) + (y as integer)
+            local function f(x: any, y: any): any
             end
         ]],
         [[
-            local xs = { 10, "hello", 3.14 }
+            local xs        = {10, "hello", 3.14}
 
-            function f(x, y)
-                return x + y
+            local function f(x     , y     )     
             end
         ]])
     end)
 
-    pending("Remove function shapes", function ()
+    it("Remove function shapes", function ()
         assert_translation([[
             local function invoke(x: (integer, integer) -> (float, float)): (float, float)
                 return x(1, 2)
             end
         ]],
         [[
-            local function invoke(x)
+            local function invoke(x                                      )                
                 return x(1, 2)
             end
         ]])
@@ -447,20 +445,7 @@ describe("Pallene to Lua translator", function ()
         ]])
     end)
 
-    pending("Remove type aliases", function ()
-        assert_translation([[
-            typealias point = {
-                x: integer,
-                y: integer
-            }
-            local p: point = { x = 10, y = 20 }
-        ]],
-        [[
-            local p = { x = 10, y = 20 }
-        ]])
-    end)
-
-    pending("Keep the strings quotes as is", function ()
+    it("Keep the strings quotes as is", function ()
         assert_translation([[
             local function print_hello()
                 io.write('Hello, ')
@@ -475,94 +460,59 @@ describe("Pallene to Lua translator", function ()
         ]])
     end)
 
-    pending("Remove return type annotations", function ()
+    it("Remove return type annotations", function ()
         assert_translation([[
-            local function get_numbers() : { integer, integer }
+            local function get_numbers() : ( integer, integer )
                 return 53, 519
             end
         ]],
         [[
-            local function get_numbers()
+            local function get_numbers()                       
                 return 53, 519
             end
         ]])
     end)
 
-    pending("Remove parameter and return type annotations", function ()
+    it("Remove parameter and return type annotations", function ()
         assert_translation([[
             local function add(x: integer, y: integer) : integer
                 return x + y
             end
         ]],
         [[
-            local function add(x, y)
+            local function add(x         , y         )          
                 return x + y
             end
         ]])
     end)
 
-    pending("Remove local variable type annotations.", function ()
+    it("Remove local variable type annotations.", function ()
         assert_translation([[
-            local function add()
+            local function f()
                 local x: integer = 10
                 local y: integer = 20
                 local z: integer = x + y
             end
         ]],
         [[
-            local function add()
-                local x = 10
-                local y = 20
-                local z = x + y
+            local function f()
+                local x          = 10
+                local y          = 20
+                local z          = x + y
             end
         ]])
     end)
 
-    pending("Exported functions will be made local, but added to the table returned.", function ()
+    it("Expressions are copied as is", function ()
         assert_translation([[
-            export function add(x: integer, y: integer) : integer
-                return x + y
-            end
-        ]],
-        [[
-            --
-            local function add(x, y)
-                return x + y
-            end
-
-            return {
-                add = add
-            }
-        ]])
-    end)
-
-    pending("Exported variables will be made local, but added to the table returned.", function ()
-        assert_translation([[
-            export x : integer = 83
-        ]],
-        [[
-            local x = 83
-
-            return {
-                x = x
-            }
-        ]])
-    end)
-
-    pending("Expressions are copied as is", function ()
-        assert_translation([[
-            export function expression()
-                local x = (1 + 2) * (100 / 30) or true
+            local function expression()
+                local x = (1 + 2) * (100 / 30)
             end
         ]],
         [[
             local function expression()
-                local x = (1 + 2) * (100 / 30) or true
+                local x = (1 + 2) * (100 / 30)
             end
-
-            return {
-                expression = expression
-            }
         ]])
     end)
 
@@ -577,7 +527,7 @@ describe("Pallene to Lua translator", function ()
         ]],
         [[
             local function count()
-                local i = 1
+                local i           = 1
                 while i <= 10 do
                     i = i + 1
                 end
@@ -587,26 +537,24 @@ describe("Pallene to Lua translator", function ()
 
     it("Do Statement", function ()
         assert_translation([[
-            local function example()
+            local function f()
                 local i : integer = 10
                 do
                     local i : integer = 20
                 end
-                return i
             end
         ]],
         [[
-            local function example()
-                local i = 10
+            local function f()
+                local i           = 10
                 do
-                    local i = 20
+                    local i           = 20
                 end
-                return i
             end
         ]])
     end)
 
-    pending("If statement", function ()
+    it("If statement", function ()
         assert_translation([[
             local function is_even(n: integer): boolean
                 if (n % 2) == 0 then
@@ -617,7 +565,7 @@ describe("Pallene to Lua translator", function ()
             end
         ]],
         [[
-            local function is_even(n)
+            local function is_even(n         )         
                 if (n % 2) == 0 then
                     return true
                 else
@@ -627,18 +575,16 @@ describe("Pallene to Lua translator", function ()
         ]])
     end)
 
-    pending("For statement", function ()
+    it("For statement", function ()
         assert_translation([[
-            local function print_strings(strings: {string})
-                for s : string in strings do
-                    io.write(s .. '\n')
+            local function f()
+                for i : integer = 1, 10 do
                 end
             end
         ]],
         [[
-            local function print_strings(strings)
-                for s in strings do
-                    io.write(s .. '\n')
+            local function f()
+                for i           = 1, 10 do
                 end
             end
         ]])

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -566,7 +566,7 @@ describe("Pallene to Lua translator", function ()
         ]])
     end)
 
-    pending("While statements", function ()
+    it("While statements", function ()
         assert_translation([[
             local function count()
                 local i : integer = 1
@@ -585,7 +585,7 @@ describe("Pallene to Lua translator", function ()
         ]])
     end)
 
-    pending("Do Statement", function ()
+    it("Do Statement", function ()
         assert_translation([[
             local function example()
                 local i : integer = 10


### PR DESCRIPTION
The following tasks were achieved in this PR:
 * Update the test cases to enable or add new tests.
 * Refactor the translator to remove redundant code.
 * Remove type annotation from for parameter.
 * Generate a return statement at the end to export symbols.
 * Convert exported symbols to local symbols to prevent globals symbols from being created.