### PR TITLE
Clarify syntax error for expected ')'

### DIFF
--- a/pallene/syntax_errors.lua
+++ b/pallene/syntax_errors.lua
@@ -37,7 +37,7 @@ local errors = {
 
     LParPList = "Expected '(' for the parameter list.",
 
-    RParPList = "Expected ')' to close the parameter list.",
+    RParPList = "Missing ')' or unexpected token before ')' in parameter list.",
 
     TypeFunc = "Expected a type in function declaration.",
 
@@ -72,7 +72,7 @@ local errors = {
 
     StringLParImport = "Expected the name of a module after '('.",
 
-    RParImport = "Expected ')' to close import declaration.",
+    RParImport = "Missing ')' or unexpected token before ')' in import declaration.",
 
     StringImport = "Expected the name of a module after 'import'.",
 
@@ -88,7 +88,7 @@ local errors = {
 
     TypelistType = "Expected type after ','.",
 
-    RParenTypelist = "Expected ')' to close type list.",
+    RParenTypelist = "Missing ')' or unexpected token before ')' in type list.",
 
     TypeReturnTypes = "Expected return types after `->` to finish the function type.",
 
@@ -158,15 +158,15 @@ local errors = {
 
     ExpSimpleExp = "Expected an expression after '('.",
 
-    RParSimpleExp = "Expected ')'to match '('.",
+    RParSimpleExp = "Missing ')' to match '(' or unexpected token before the ')'.",
 
-    RParFuncArgs = "Expected ')' to match '('.",
+    RParFuncArgs = "Missing ')' or unexpected token before ')' in function call.",
 
     ExpExpList = "Expected an expression after ','.",
 
     VarVarList = "Expected an assignable after ','.",
 
-    RCurlyInitList = "Expected '{' to match '}'.",
+    RCurlyInitList = "Missing '}' or unexpected token before '}' in table constructor.",
 
     ExpFieldList = "Expected an expression after ',' or ';'.",
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -936,7 +936,7 @@ describe("Pallene parser", function()
         assert_program_syntax_error([[
             export function foo ( : int
             end
-        ]], "Expected ')' to close the parameter list.")
+        ]], "Missing ')' or unexpected token before ')' in parameter list.")
 
         assert_program_syntax_error([[
             export function foo () :
@@ -994,7 +994,7 @@ describe("Pallene parser", function()
 
         assert_program_syntax_error([[
             local bola = import ('bola'
-        ]], "Expected ')' to close import declaration.")
+        ]], "Missing ')' or unexpected token before ')' in import declaration.")
 
         assert_program_syntax_error([[
             local bola = import
@@ -1028,7 +1028,7 @@ describe("Pallene parser", function()
             "Expected type after ','")
 
         assert_type_syntax_error([[ (a, b -> b  ]],
-            "Expected ')' to close type list")
+            "Missing ')' or unexpected token before ')' in type list.")
 
         assert_type_syntax_error([[ (a, b) -> = nil ]],
             "Expected return types after `->` to finish the function type")
@@ -1194,16 +1194,16 @@ describe("Pallene parser", function()
             "Expected an expression after '('.")
 
         assert_expression_syntax_error([[ (42 ]],
-            "Expected ')'to match '('.")
+             "Missing ')' to match '(' or unexpected token before the ')'.")
 
         assert_expression_syntax_error([[ f(42 ]],
-            "Expected ')' to match '('.")
+             "Missing ')' or unexpected token before ')' in function call.")
 
         assert_expression_syntax_error([[ f(42,) ]],
             "Expected an expression after ','.")
 
         assert_expression_syntax_error([[ y{42 ]],
-            "Expected '{' to match '}'.")
+             "Missing '}' or unexpected token before '}' in table constructor.")
 
         assert_expression_syntax_error([[ y{42,,} ]],
             "Expected an expression after ',' or ';'.")


### PR DESCRIPTION
Sometimes we get a syntax error because there is an unexpected token before the ')'. In those cases,
it might not be accurate to complain that the ')' is missing or that the parenthesis are unmatched.

For example, the following function call is parsed as a function name followed by an empty parameter
list followed by an unexpected while token. The ')' is there, but we got a syntax error before we
reached it.

   f(while)