### PR TITLE
Cast of cast

### DIFF
--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -125,18 +125,18 @@ function defs.elseif_(pos, exp, block)
     return { pos = pos, exp = exp, block = block }
 end
 
-function defs.fold_binop_left(pos, matches)
-    local lhs = matches[1]
-    for i = 2, #matches, 2 do
-        local op  = matches[i]
-        local rhs = matches[i+1]
-        lhs = ast.Exp.Binop(pos, lhs, op, rhs)
+function defs.fold_binop_left(exp, matches)
+    for i = 1, #matches, 3 do
+        local pos = matches[i]
+        local op  = matches[i+1]
+        local rhs = matches[i+2]
+        exp = ast.Exp.Binop(pos, exp, op, rhs)
     end
-    return lhs
+    return exp
 end
 
 -- Should this go on a separate constant propagation pass?
-function defs.binop_concat(pos, lhs, op, rhs)
+function defs.binop_concat(lhs, pos, op, rhs)
     if op then
         if rhs._tag == "ast.Exp.Concat" then
             table.insert(rhs.exps, 1, lhs)
@@ -156,7 +156,7 @@ function defs.binop_concat(pos, lhs, op, rhs)
     end
 end
 
-function defs.binop_right(pos, lhs, op, rhs)
+function defs.binop_right(lhs, pos, op, rhs)
     if op then
         return ast.Exp.Binop(pos, lhs, op, rhs)
     else
@@ -164,16 +164,19 @@ function defs.binop_right(pos, lhs, op, rhs)
     end
 end
 
-function defs.fold_unops(pos, unops, exp)
-    for i = #unops, 1, -1 do
-        local op = unops[i]
+function defs.fold_unops(matches, exp)
+    for i = #matches, 1, -2 do
+        local op  = matches[i]
+        local pos = matches[i-1]
         exp = ast.Exp.Unop(pos, op, exp)
     end
     return exp
 end
 
-function defs.fold_casts(pos, exp, types)
-    for _, typ in ipairs(types) do
+function defs.fold_casts(exp, matches)
+    for i = 1, #matches, 2 do
+        local pos = matches[i]
+        local typ = matches[i+1]
         exp = ast.Exp.Cast(pos, exp, typ)
     end
     return exp
@@ -365,19 +368,19 @@ local grammar = re.compile([[
     op12            <- ( POW -> '^' )
 
     exp             <- e1
-    e1              <- (P  {| e2  (op1  e2^OpExp)* |})           -> fold_binop_left
-    e2              <- (P  {| e3  (op2  e3^OpExp)* |})           -> fold_binop_left
-    e3              <- (P  {| e4  (op3  e4^OpExp)* |})           -> fold_binop_left
-    e4              <- (P  {| e5  (op4  e5^OpExp)* |})           -> fold_binop_left
-    e5              <- (P  {| e6  (op5  e6^OpExp)* |})           -> fold_binop_left
-    e6              <- (P  {| e7  (op6  e7^OpExp)* |})           -> fold_binop_left
-    e7              <- (P  {| e8  (op7  e8^OpExp)* |})           -> fold_binop_left
-    e8              <- (P     e9  (op8  e8^OpExp)?)              -> binop_concat
-    e9              <- (P  {| e10 (op9  e10^OpExp)* |})          -> fold_binop_left
-    e10             <- (P  {| e11 (op10 e11^OpExp)* |})          -> fold_binop_left
-    e11             <- (P  {| unop* |}  e12)                     -> fold_unops
-    e12             <- (P  e13 (op12 e11^OpExp)?)                -> binop_right
-    e13             <- (P  simpleexp {| (AS type^CastType)* |})  -> fold_casts
+    e1              <- (e2  {| (P op1  e2^OpExp)*  |})           -> fold_binop_left
+    e2              <- (e3  {| (P op2  e3^OpExp)*  |})           -> fold_binop_left
+    e3              <- (e4  {| (P op3  e4^OpExp)*  |})           -> fold_binop_left
+    e4              <- (e5  {| (P op4  e5^OpExp)*  |})           -> fold_binop_left
+    e5              <- (e6  {| (P op5  e6^OpExp)*  |})           -> fold_binop_left
+    e6              <- (e7  {| (P op6  e7^OpExp)*  |})           -> fold_binop_left
+    e7              <- (e8  {| (P op7  e8^OpExp)*  |})           -> fold_binop_left
+    e8              <- (e9  (P op8  e8^OpExp)?)                  -> binop_concat
+    e9              <- (e10 {| (P op9  e10^OpExp)* |})           -> fold_binop_left
+    e10             <- (e11 {| (P op10 e11^OpExp)* |})           -> fold_binop_left
+    e11             <- ({| (P unop)* |}  e12)                    -> fold_unops
+    e12             <- (e13 (P op12 e11^OpExp)?)                 -> binop_right
+    e13             <- (simpleexp {| (P AS type^CastType)* |})   -> fold_casts
 
     suffixedexp     <- (prefixexp {| expsuffix* |})              -> fold_suffixes
 

--- a/pallene/syntax_errors.lua
+++ b/pallene/syntax_errors.lua
@@ -174,7 +174,7 @@ local errors = {
 
     AssignNotToVar = "Expected a valid lvalue in the left side of assignment but found a regular expression.",
 
-    CastMissingType = "Expected a type for the cast expression.",
+    CastType = "Expected a type for the cast expression.",
 
     LocalOrExportRequiredFunction = "Expected 'local' or 'export' modifier in function definition.",
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -907,6 +907,16 @@ describe("Pallene parser", function()
                 _tag = "ast.Exp.Cast",
                 exp = { _tag = "ast.Exp.Var" },
                 target = { _tag = "ast.Type.Integer" } }})
+
+        assert_expression_ast([[ 1 as integer as any ]],
+            { _tag = "ast.Exp.Cast",
+                target = { _tag = "ast.Type.Any" },
+                exp = {
+                    _tag = "ast.Exp.Cast",
+                    target = { _tag = "ast.Type.Integer" },
+                    exp = {
+                        _tag = "ast.Exp.Integer"
+                    }}})
     end)
 
     it("does not allow parentheses in the LHS of an assignment", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -886,14 +886,27 @@ describe("Pallene parser", function()
     end)
 
     it("can parse cast expressions", function()
+
         assert_expression_ast([[ foo as integer ]],
-            { _tag = "ast.Exp.Cast", exp = { _tag = "ast.Exp.Var" }, target = { _tag = "ast.Type.Integer" } })
+            { _tag = "ast.Exp.Cast",
+                exp = { _tag = "ast.Exp.Var" },
+                target = { _tag = "ast.Type.Integer" } })
+
         assert_expression_ast([[ a.b[1].c as integer ]],
-            { _tag = "ast.Exp.Cast", exp = { _tag = "ast.Exp.Var" }, target = { _tag = "ast.Type.Integer" } })
+            { _tag = "ast.Exp.Cast",
+                exp = { _tag = "ast.Exp.Var" },
+                target = { _tag = "ast.Type.Integer" } })
+
         assert_expression_ast([[ foo as { integer } ]],
-            { _tag = "ast.Exp.Cast", exp = { _tag = "ast.Exp.Var" }, target = { _tag = "ast.Type.Array" } })
+            { _tag = "ast.Exp.Cast",
+                exp = { _tag = "ast.Exp.Var" },
+                target = { _tag = "ast.Type.Array" } })
+
         assert_expression_ast([[ 2 + foo as integer ]],
-            { rhs = { _tag = "ast.Exp.Cast", exp = { _tag = "ast.Exp.Var" }, target = { _tag = "ast.Type.Integer" } }})
+            { rhs = {
+                _tag = "ast.Exp.Cast",
+                exp = { _tag = "ast.Exp.Var" },
+                target = { _tag = "ast.Type.Integer" } }})
     end)
 
     it("does not allow parentheses in the LHS of an assignment", function()


### PR DESCRIPTION
Now it is possible to write casts of casts such as `x as integer as any`. Previously it was a syntax error. Fixes #283.

---------------

Edit: This PR also changes the AST locations of unary operators, binary operators, and the cast operator. Now, the AST location points to the operator instead of pointing to the left subexpression.