### PR TITLE
Lua 5.4 rockspec

### DIFF
--- a/pallene-dev-1.rockspec
+++ b/pallene-dev-1.rockspec
@@ -11,7 +11,7 @@ Compiler for the Pallene programming language.]],
    license = "MIT"
 }
 dependencies = {
-   "lua ~> 5.3",
+   "lua >= 5.3",
    "lpeglabel >= 1.5.0",
    "inspect >= 3.1.0",
    "argparse >= 0.7.0",

--- a/pallene-dev-1.rockspec
+++ b/pallene-dev-1.rockspec
@@ -4,10 +4,9 @@ source = {
    url = "git+https://github.com/pallene-lang/pallene"
 }
 description = {
-   summary = "Initial prototype of the Pallene compiler",
+   summary = "Pallene compiler",
    detailed = [[
-      Initial prototype of the Pallene compiler.
-   ]],
+Compiler for the Pallene programming language.]],
    homepage = "http://github.com/pallene-lang/pallene",
    license = "MIT"
 }


### PR DESCRIPTION
I tested running the Pallene compiler using Lua 5.4 as the system version of Lua and it seemed to work. Therefore, I am updating the rockspeck to be more optimistic. If this breaks with Lua 5.5 we can always revisit it later.

Closes #258.