### PR TITLE
Get rid of the tofloat builtin

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -46,16 +46,31 @@ There is also a catch-all type `any`, which can refer to any Lua or Pallene valu
 
 ### Primitive types
 
-Pallene's primitive types are the same as Lua's:
+Pallene's primitive types are similat to Lua's:
 
 - `nil`
 - `boolean`
 - `integer`
 - `float`
 
-There is no type `number`, since `integer` and `float` are separate types in Pallene.
-Also, there is no automatic coercion between them.
-For example, `local x: float = 0` is a type error; you should use `0.0` instead.
+### Integers and floats
+
+In Pallene there are separate typed for `integer` and `float` instead of a single `number` type.
+There are no automatic coercions between the two types, meaning that code such as the following is a type error in Pallene:
+
+```
+local x: float = 0 -- Type error. Should use 0.0 instead.
+```
+
+That said, most arithmetic operators still work if one of the parameters is an integer and the other is a float.
+If you just want to convert an integer to float, the recommended idiom is to multiply it by 1.0.
+(Adding 0.0 also works but GCC produces worse code for that.)
+
+```
+local i: integer = 10
+local x: float = i + 3.4
+local y: float = i * 1.0
+```
 
 ### Strings
 

--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -72,7 +72,8 @@ declare_type("Exp", {
     Binop      = {"loc", "lhs", "op", "rhs"},
     Cast       = {"loc", "exp", "target", "target_end_loc"},
     Paren      = {"loc", "exp"},
-    ExtraRet   = {"loc", "call_exp", "i"}, -- See checker.lua
+    ExtraRet   = {"loc", "call_exp", "i"}, -- Inserted by checker.lua
+    ToFloat    = {"loc", "exp"},           -- Inserted by checker.lua
 })
 
 declare_type("Field", {

--- a/pallene/builtins.lua
+++ b/pallene/builtins.lua
@@ -9,8 +9,7 @@ local T = types.T
 local builtins = {}
 
 builtins.functions = {
-    tofloat = T.Function({ T.Integer() }, { T.Float() }),
-    type = T.Function({ T.Any() }, { T.String() }),
+    ["type"] = T.Function({ T.Any() }, { T.String() }),
     ["io.write"] = T.Function({ T.String() }, {}),
     ["math.sqrt"] = T.Function({ T.Float() }, { T.Float() }),
     ["string_.char"] = T.Function({ T.Integer() }, { T.String() }),

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1085,6 +1085,12 @@ gen_cmd["Concat"] = function(self, cmd, _func)
     }))
 end
 
+gen_cmd["ToFloat"] = function(self, cmd, _func)
+    local dst = self:c_var(cmd.dst)
+    local v = self:c_value(cmd.src)
+    return util.render([[ $dst = (lua_Number) $v; ]], { dst = dst, v = v })
+end
+
 gen_cmd["ToDyn"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
     local src = self:c_value(cmd.src)
@@ -1355,12 +1361,6 @@ gen_cmd["BuiltinStringSub"] = function(self, cmd, _func)
     local j   = self:c_value(cmd.srcs[3])
     return util.render([[ $dst = pallene_string_sub(L, $str, $i, $j); ]], {
         dst = dst, str = str, i = i, j = j })
-end
-
-gen_cmd["BuiltinToFloat"] = function(self, cmd, _func)
-    local dst = self:c_var(cmd.dsts[1])
-    local v = self:c_value(cmd.srcs[1])
-    return util.render([[ $dst = (lua_Number) $v; ]], { dst = dst, v = v })
 end
 
 gen_cmd["BuiltinType"] = function(self, cmd, _func)

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -123,6 +123,7 @@ local ir_cmd_constructors = {
     Unop       = {"loc", "dst", "op", "src"},
     Binop      = {"loc", "dst", "op", "src1", "src2"},
     Concat     = {"loc", "dst", "srcs"},
+    ToFloat    = {"loc", "dst", "src"},
 
     --- Dynamic Value
     ToDyn      = {"loc", "src_typ", "dst", "src"},
@@ -157,7 +158,6 @@ local ir_cmd_constructors = {
     BuiltinMathSqrt   = {"loc", "dsts", "srcs"},
     BuiltinStringChar = {"loc", "dsts", "srcs"},
     BuiltinStringSub  = {"loc", "dsts", "srcs"},
-    BuiltinToFloat    = {"loc", "dsts", "srcs"},
     BuiltinType       = {"loc", "dsts", "srcs"},
 
     --

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -642,9 +642,6 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 assert(#xs == 3)
                 table.insert(cmds, ir.Cmd.BuiltinStringSub(loc, dsts, xs))
                 table.insert(cmds, ir.Cmd.CheckGC())
-            elseif bname == "tofloat" then
-                assert(#xs == 1)
-                table.insert(cmds, ir.Cmd.BuiltinToFloat(loc, dsts, xs))
             elseif bname == "type" then
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinType(loc, dsts, xs))
@@ -767,6 +764,10 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 error("impossible")
             end
         end
+
+    elseif tag == "ast.Exp.ToFloat" then
+        local v = self:exp_to_value(cmds, exp.exp)
+        table.insert(cmds, ir.Cmd.ToFloat(loc, dst, v))
 
     else
         use_exp_to_value = true

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -143,6 +143,8 @@ function Translator:translate_exp(exp)
         self:translate_exp(exp.exp)
     elseif tag == "ast.Exp.ExtraRet" then
         -- Since `ExtraRet` is imaginary, we ignore it.
+    elseif tag == "ast.Exp.ToFloat" then
+        self:translate_exp(exp.exp)
     else
         error(tag .. " impossible")
     end

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1396,23 +1396,6 @@ describe("Pallene coder /", function()
         end)
     end)
 
-    describe("tofloat builtin", function()
-        compile([[
-            export function itof(x:integer): float
-                return tofloat(x)
-            end
-        ]])
-
-        it("works", function()
-            run_test([[
-                local x_i = 1
-                local x_f = test.itof(x_i)
-                assert("float" == math.type(x_f))
-                assert(1.0 == x_f)
-            ]])
-        end)
-    end)
-
     describe("math.sqrt builtin", function()
         compile([[
             export function square_root(x: float): float
@@ -1665,11 +1648,6 @@ describe("Pallene coder /", function()
                 return res
             end
 
-            export function tofloat_shadowing(x:integer) : float
-                local tofloat = 1.0
-                return (x + tofloat)
-            end
-
             export function duplicate_parameter(x: integer, x:integer) : integer
                 return x
             end
@@ -1693,10 +1671,6 @@ describe("Pallene coder /", function()
 
         it("for loop variable scope doesn't shadow its initializers", function()
             run_test([[ assert( 34 == test.for_initializer() ) ]])
-        end)
-
-        it("tofloat in coercions doesn't get shadowed", function()
-            run_test([[ assert( 21.0 == test.tofloat_shadowing(20) ) ]])
         end)
 
         it("allows functions with repeated argument names", function()


### PR DESCRIPTION
Encourage multiplying by `1.0` instead of using a special `tofloat` builtin. Closes #296.

The tofloat builtin is the only builtin operator that existed in Pallene but not on Lua. This meant
that it was one corner case where erasing the type annotations from Pallene did not result in a
valid Lua program. Since this builtin function is not strictly necessary, I think the best thing to
do is to just get rid of it.

The recommended idiom is to multiply by `1.0` because the C compiler can optimize that as a no-op.
Adding `0.0` also should work however GCC is not able to optimize that as a no-op. I think the
reason it doesn't do so is that `x + 0.0 == x` is not valid for negative zero: `-0.0 + 0.0 == 0.0`.
However, the identity should be valid for any floating point number that was originally an integer.
Clang can optimize that, at least.