### PR TITLE
Use -O0 to run tests

### DIFF
--- a/test-project
+++ b/test-project
@@ -6,5 +6,5 @@
 # you need to press Ctrl-C multiple times and one of those Ctrl-C's will likely kill the busted
 # process itself, meaning that the "teardown" routines are not run. On the other hand, with
 # --no-keep-going we only need to press Ctrl-C once and busted usually gets to exit gracefully.
-
+export CFLAGS=-O0
 busted --no-keep-going "$@"


### PR DESCRIPTION
This shaves about 1 second from the coder_spec, from 6.8s down to 5.5s on my machine.
Not amazing, but it is a decent change. Closes #252.