### PR TITLE
Don't set exps[i] to false in Stat.Decl

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -973,13 +973,13 @@ end
 function Checker:check_initializer_exp(decl, exp, err_fmt, ...)
     if decl.type then
         decl._type = self:from_ast_type(decl.type)
-        if exp then
+        if exp ~= nil then
             return self:check_exp_verify(exp, decl._type, err_fmt, ...)
         else
-            return false
+            return nil
         end
     else
-        if exp then
+        if exp ~= nil then
             local e = self:check_exp_synthesize(exp)
             decl._type = e._type
             return e


### PR DESCRIPTION
In the checker, when a variable declaration did not have an initializer, we would set the
initializer to `false`. While this is more explicit, it is a bit confusing because it is different
from what the parser returns ans also because someone iterating over stat.exps needs to check if the
exp is not false.

The choice is to either document this behavior in checker.lua or to get rid of it. I think it
getting rid of it is the simplest solution.