### PR TITLE
Parse '..' as a binary operator.

### DIFF
--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -67,7 +67,6 @@ declare_type("Exp", {
     CallMethod = {"loc", "exp", "method", "args"},
     Var        = {"loc", "var"},
     Unop       = {"loc", "op", "exp"},
-    Concat     = {"loc", "exps"},
     Binop      = {"loc", "lhs", "op", "rhs"},
     Cast       = {"loc", "exp", "target", "target_end_loc"},
     Paren      = {"loc", "exp"},

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -642,15 +642,7 @@ function Parser:SubExp(limit)
 
         local op   = self:e()
         local bexp = self:SubExp(is_right_associative[op.name] and prec-1 or prec)
-        if op.name == ".." then
-            if bexp._tag == "ast.Exp.Concat" then
-                exp = ast.Exp.Concat(op.loc, {exp, table.unpack(bexp.exps) })
-            else
-                exp = ast.Exp.Concat(op.loc, {exp, bexp})
-            end
-        else
-            exp = ast.Exp.Binop(op.loc, exp, op.name, bexp)
-        end
+        exp = ast.Exp.Binop(op.loc, exp, op.name, bexp)
     end
 
     return exp

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -740,6 +740,17 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 ir.Cmd.Seq({}),
                 ir.Cmd.Seq(rhs_cmds)))
 
+        elseif op == ".." then
+            -- Flatten (a .. (b .. (c .. d))) into (a .. b .. c .. d)
+            local xs = {}
+            while exp._tag == "ast.Exp.Binop" and exp.op == ".." do
+                table.insert(xs, self:exp_to_value(cmds, exp.lhs))
+                exp = exp.rhs
+            end
+            table.insert(xs, self:exp_to_value(cmds, exp))
+
+            table.insert(cmds, ir.Cmd.Concat(loc, dst, xs))
+
         else
             local irop = type_specific_binop(op, exp.lhs._type, exp.rhs._type)
             local v1 = self:exp_to_value(cmds, exp.lhs)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -648,11 +648,11 @@ describe("Pallene parser", function()
         -- concatenation is right associative
         -- and has less precedence than prefix operators
         assert_expression_ast([[-x .. -y .. -z]],
-            { _tag = "ast.Exp.Concat", exps = {
-                { op = "-", exp = { var = { name = "x" } } },
-                { op = "-", exp = { var = { name = "y" } } },
-                { op = "-", exp = { var = { name = "z" } } },
-            } })
+            { _tag = "ast.Exp.Binop", op = "..",
+                lhs = { op = "-", exp = { var = { name = "x" } } },
+                rhs = { _tag = "ast.Exp.Binop", op = "..",
+                    lhs = { op = "-", exp = { var = { name = "y" } } },
+                    rhs = { op = "-", exp = { var = { name = "z" } } }, } })
 
         -- exponentiation is also right associative
         -- but it has a higher precedence than prefix operators


### PR DESCRIPTION
The transformation where we treat '..' as a variadic operator is an optimization. Therefore, the
appropriate place for it is in the translation from AST to IR, not in the parser itself.