### PR TITLE
Updated the translator to retain comments inside type annotations.

### DIFF
--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -12,7 +12,7 @@ local function declare_type(type_name, cons)
 end
 
 declare_type("Program", {
-    Program = {"tls", "regions", "comment_regions"}
+    Program = {"tls", "type_regions", "comment_regions"}
 })
 
 declare_type("Type", {

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -122,30 +122,34 @@ function translator.translate(input, prog_ast)
     local instance = Translator.new(input)
     instance:add_forward_declarations(prog_ast)
 
-    local j = 1 -- The index of the current comment region.
+    -- Erase all type regions, while preserving comments
+    -- As a sanity check, assert that the comment regions are either inside or outside the type
+    -- regions, not crossing the boundaries.
+    local j = 1
+    local comments = prog_ast.comment_regions
     for _, region in ipairs(prog_ast.regions) do
         local start_index = region[1]
+        local end_index   = region[2]
 
-        -- Ignore the comments before the current region.
-        while j <= #prog_ast.comment_regions and start_index > prog_ast.comment_regions[j][1] do
+        -- Skip over the comments before the current region.
+        while j <= #comments and comments[j][2] < start_index do
             j = j + 1
         end
 
-        -- Multiple comment regions can span within a single region.
-        while j <= #prog_ast.comment_regions do
-            local comment = prog_ast.comment_regions[j]
-            -- Ensure that the current comment does not appear before the current region.
-            assert(start_index <= comment[1])
-            -- Determine if the comment appears within the current region.
-            if comment[2] <= region[2] then
-                instance:erase_region(start_index, comment[1] - 1)
-                start_index = comment[2] + 1
-                j = j + 1
-            else
-                break
-            end
+        -- Preserve the comments inside the current region
+        while j <= #comments and comments[j][2] <= end_index do
+            assert(start_index < comments[j][1])
+            instance:erase_region(start_index, comments[j][1] - 1)
+            start_index = comments[j][2] + 1
+            j = j + 1
         end
-        instance:erase_region(start_index, region[2])
+
+        -- Ensure that the next comment is outside the current region
+        if j <= #comments then
+            assert(end_index < comments[j][1])
+        end
+
+        instance:erase_region(start_index, end_index)
     end
 
     -- Whatever characters that were not included in the partials should be added.

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -127,7 +127,7 @@ function translator.translate(input, prog_ast)
     -- regions, not crossing the boundaries.
     local j = 1
     local comments = prog_ast.comment_regions
-    for _, region in ipairs(prog_ast.regions) do
+    for _, region in ipairs(prog_ast.type_regions) do
         local start_index = region[1]
         local end_index   = region[2]
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -49,7 +49,7 @@ local function assert_program_ast(program_str, expected_tls)
     local expected_ast = {
         _tag = "ast.Program.Program",
         tls = expected_tls,
-        regions = {},
+        type_regions = {},
         comment_regions = {}
     }
     local prog_ast = assert_parses_successfuly(program_str)

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -160,12 +160,29 @@ local xs: -- This is a comment.
     integer = 10
 ]],
 [[
-local xs;xs
+local xs;xs-- This is a comment.
  = 10
 ]])
     end)
 
-    pending("Keep comments that appear inside in a top-level variable type annotation", function ()
+    it("Keep comments that appear outside type annotations", function ()
+        assert_translation([[
+-- Knock knock
+local x: { -- Who's there?
+    integer -- Baby Yoda
+} = { 5, 3, 19 } -- Baby Yoda who?
+-- Baby Yoda one for me. XD
+]],
+[[
+local x;-- Knock knock
+x-- Who's there?
+-- Baby Yoda
+ = { 5, 3, 19 } -- Baby Yoda who?
+-- Baby Yoda one for me. XD
+]])
+    end)
+
+    it("Keep comments that appear inside in a top-level variable type annotation", function ()
         assert_translation(
 [[
 local xs: { -- This is a comment.
@@ -173,9 +190,9 @@ local xs: { -- This is a comment.
 } = { 5, 3, 19 }
 ]],
 [[
-local xs    -- This is a comment.
-            -- This is another comment.
-    = { 5, 3, 19 }
+local xs;xs-- This is a comment.
+-- This is another comment.
+ = { 5, 3, 19 }
 ]])
     end)
 


### PR DESCRIPTION
In some cases multiple comments can span within a type annotation. Therefore, the translator repeatedly
tries to find comments within a region. The translator spec was updated to validate this feature.