### PR TITLE
Allow primitive type names to be used as identifiers

### DIFF
--- a/benchmarks/fasta/pallene.pln
+++ b/benchmarks/fasta/pallene.pln
@@ -29,12 +29,12 @@ export function repeat_fasta(id: string, desc: string, alu: string, n: integer)
     local start = 0 -- (This index is 0-based bacause of the % operator)
     for _ = 1, lines do
         local stop = start + WIDTH
-        io.write(string_sub(aluwrap, start+1, stop))
+        io.write(string.sub(aluwrap, start+1, stop))
         io.write("\n")
         start = stop % alusize
     end
     if last_line > 0 then
-        io.write(string_sub(aluwrap, start+1, start + last_line))
+        io.write(string.sub(aluwrap, start+1, start + last_line))
         io.write("\n")
     end
 end

--- a/benchmarks/mandelbrot/pallene.pln
+++ b/benchmarks/mandelbrot/pallene.pln
@@ -28,7 +28,7 @@ export function mandelbrot(N: integer)
             nbits = nbits + 1
 
             if nbits == 8 then
-                io.write(string_char(bits))
+                io.write(string.char(bits))
                 bits  = 0
                 nbits = 0
             end
@@ -36,7 +36,7 @@ export function mandelbrot(N: integer)
 
         if nbits > 0 then
             bits  = bits << (8 - nbits)
-            io.write(string_char(bits))
+            io.write(string.char(bits))
             bits  = 0
             nbits = 0
         end

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -75,9 +75,13 @@ local y: float = i * 1.0
 ### Strings
 
 Pallene also has a `string` type, for Lua strings.
-The syntax for string literals is the same as in Lua.
+The syntax for string literals is the same as in Lua
+You can use single quotes, double quotes, or `[[`.
 
-Currently, the only supported operations for Pallene strings are concatenation with the `..` operator and printing strings to stdout with `io.write`.
+The primitive operators that operate on strings are the concatenation operator `..`,  the length operator `#`, and the comparison operators (`==`, `~=`, `<`, `>`, `<=`, `>=`).
+
+Pallene also implements some functions from the `string` library.
+Currently we implement `string.char` and `string.sub`  but more may be implemented in the future.
 
 ### Arrays
 

--- a/pallene/Lexer.lua
+++ b/pallene/Lexer.lua
@@ -48,7 +48,7 @@ local is_keyword = {}
 do
     local strs = [[
         and break do else elseif end for false function goto if in local nil not or repeat return
-        then true until while   any as boolean export float string import integer record typealias
+        then true until while   as export import record typealias
     ]]
     for s in string.gmatch(strs, "%S+") do
         is_keyword[s] = true

--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -17,11 +17,6 @@ declare_type("Program", {
 
 declare_type("Type", {
     Nil      = {"loc"},
-    Boolean  = {"loc"},
-    Integer  = {"loc"},
-    Float    = {"loc"},
-    String   = {"loc"},
-    Any      = {"loc"},
     Name     = {"loc", "name"},
     Array    = {"loc", "subtype"},
     Table    = {"loc", "fields"},

--- a/pallene/builtins.lua
+++ b/pallene/builtins.lua
@@ -12,14 +12,14 @@ builtins.functions = {
     ["type"] = T.Function({ T.Any() }, { T.String() }),
     ["io.write"] = T.Function({ T.String() }, {}),
     ["math.sqrt"] = T.Function({ T.Float() }, { T.Float() }),
-    ["string_.char"] = T.Function({ T.Integer() }, { T.String() }),
-    ["string_.sub"] = T.Function({ T.String(), T.Integer(), T.Integer() }, { T.String() })
+    ["string.char"] = T.Function({ T.Integer() }, { T.String() }),
+    ["string.sub"] = T.Function({ T.String(), T.Integer(), T.Integer() }, { T.String() })
 }
 
 builtins.modules = {
     io = true,
     math = true,
-    string_ = true
+    string = true
 }
 
 return builtins

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -540,10 +540,15 @@ function Checker:check_var(var)
         end
 
     elseif tag == "ast.Var.Dot" then
-        if var.exp._tag == "ast.Exp.Var" and
-           var.exp.var._tag == "ast.Var.Name" and
-           builtins.modules[var.exp.var.name] then
-            local module_name = var.exp.var.name
+        local mod_cname
+        if var.exp._tag == "ast.Exp.Var" and var.exp.var._tag == "ast.Var.Name" then
+            mod_cname = self.symbol_table:find_symbol(var.exp.var.name)
+        else
+            mod_cname = false
+        end
+
+        if mod_cname and mod_cname._tag == "checker.Name.Module" then
+            local module_name = mod_cname.name
             local function_name = var.name
             local internal_name = module_name .. "." .. function_name
 
@@ -574,6 +579,7 @@ function Checker:check_var(var)
             end
             var._type = field_type
         end
+
     elseif tag == "ast.Var.Bracket" then
         var.t = self:check_exp_synthesize(var.t)
         local arr_type = var.t._type

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -269,26 +269,6 @@ function Parser:SimpleType()
         local tok = self:e()
         return ast.Type.Nil(tok.loc)
 
-    elseif self:peek("boolean") then
-        local tok = self:e()
-        return ast.Type.Boolean(tok.loc)
-
-    elseif self:peek("integer") then
-        local tok = self:e()
-        return ast.Type.Integer(tok.loc)
-
-    elseif self:peek("float") then
-        local tok = self:e()
-        return ast.Type.Float(tok.loc)
-
-    elseif self:peek("string") then
-        local tok = self:e()
-        return ast.Type.String(tok.loc)
-
-    elseif self:peek("any") then
-        local tok = self:e()
-        return ast.Type.Any(tok.loc)
-
     elseif self:peek("NAME") then
         local tok = self:e()
         return ast.Type.Name(tok.loc, tok.value)

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -634,11 +634,11 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             elseif bname == "math.sqrt" then
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinMathSqrt(loc, dsts, xs))
-            elseif bname == "string_.char" then
+            elseif bname == "string.char" then
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinStringChar(loc, dsts, xs))
                 table.insert(cmds, ir.Cmd.CheckGC())
-            elseif bname == "string_.sub" then
+            elseif bname == "string.sub" then
                 assert(#xs == 3)
                 table.insert(cmds, ir.Cmd.BuiltinStringSub(loc, dsts, xs))
                 table.insert(cmds, ir.Cmd.CheckGC())

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -86,8 +86,6 @@ function Translator:add_exports()
 end
 
 function Translator:add_forward_declarations(prog_ast)
-    table.insert(self.partials, "local string_ = string;")
-
     local names = {}
     for _, node in ipairs(prog_ast.tls) do
         -- Build the exports and forward declaration table.

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -1390,7 +1390,7 @@ function execution_tests.run(compile, backend, describe, it, assert)
     describe("string.char builtin", function()
         compile([[
             export function chr(x: integer): string
-                return string_.char(x)
+                return string.char(x)
             end
         ]])
 
@@ -1424,7 +1424,7 @@ function execution_tests.run(compile, backend, describe, it, assert)
     describe("string.sub builtin", function()
         compile([[
             export function sub(s: string, i: integer, j: integer): string
-                return string_.sub(s, i, j)
+                return string.sub(s, i, j)
             end
         ]])
 
@@ -1610,6 +1610,8 @@ function execution_tests.run(compile, backend, describe, it, assert)
             export function duplicate_parameter(x: integer, x:integer) : integer
                 return x
             end
+
+            export integer: integer = 12
         ]])
 
         it("ensure that local variables are not exported", function ()
@@ -1634,6 +1636,10 @@ function execution_tests.run(compile, backend, describe, it, assert)
 
         it("allows functions with repeated argument names", function()
             run_test([[ assert( 20 == test.duplicate_parameter(10, 20) )]])
+        end)
+
+        it("allows identifiers named like builtin types", function()
+            run_test([[ assert( 12 == test.integer) ]])
         end)
     end)
 

--- a/spec/lexer_spec.lua
+++ b/spec/lexer_spec.lua
@@ -264,7 +264,7 @@ describe("Pallene lexer", function()
 
     it("can lex some programs", function()
         assert_lex("local x: float = 10.0",
-            {"local", "NAME", ":", "float", "=", "NUMBER"},
-            {"x", 10.0})
+            {"local", "NAME", ":", "NAME", "=", "NUMBER"},
+            {"x", "float", 10.0})
     end)
 end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -233,7 +233,7 @@ describe("Pallene parser", function()
                     type = {
                         arg_types = {},
                         ret_types = {
-                            { _tag = "ast.Type.Float" }, }, } },
+                            { _tag = "ast.Type.Name", name = "float" }, }, } },
                 value = {
                     _tag = "ast.Exp.Lambda",
                     arg_decls  = {},
@@ -252,9 +252,9 @@ describe("Pallene parser", function()
                     name = "fB",
                     type = {
                         arg_types = {
-                            { _tag = "ast.Type.Integer" }, },
+                            { _tag = "ast.Type.Name", name = "integer" }, },
                         ret_types = {
-                            { _tag = "ast.Type.Float" }, }, } },
+                            { _tag = "ast.Type.Name", name = "float" }, }, } },
                 value = {
                     _tag = "ast.Exp.Lambda",
                     arg_decls = { { name = "x" } },
@@ -273,10 +273,10 @@ describe("Pallene parser", function()
                     name = "fC",
                     type = {
                         arg_types = {
-                            { _tag = "ast.Type.Integer" },
-                            { _tag = "ast.Type.Integer" }, },
+                            { _tag = "ast.Type.Name", name = "integer" },
+                            { _tag = "ast.Type.Name", name = "integer" }, },
                         ret_types = {
-                            { _tag = "ast.Type.Float" }, }, } },
+                            { _tag = "ast.Type.Name", name = "float" }, }, } },
                 value = {
                     _tag = "ast.Exp.Lambda",
                     arg_decls = { { name = "x" }, { name = "y" } },
@@ -359,13 +359,13 @@ describe("Pallene parser", function()
         assert_type_ast("{ x: float }",
             { _tag = "ast.Type.Table",
               fields = {
-                { name = "x", type = { _tag = "ast.Type.Float" } } } })
+                { name = "x", type = { _tag = "ast.Type.Name", name = "float" } } } })
 
         assert_type_ast("{ x: float, y: integer }",
             { _tag = "ast.Type.Table",
               fields = {
-                { name = "x", type = { _tag = "ast.Type.Float" } },
-                { name = "y", type = { _tag = "ast.Type.Integer" } } } })
+                { name = "x", type = { _tag = "ast.Type.Name", name = "float" } },
+                { name = "y", type = { _tag = "ast.Type.Name", name = "integer" } } } })
 
         assert_type_ast("{ a: {integer} }",
             { _tag = "ast.Type.Table",
@@ -770,8 +770,8 @@ describe("Pallene parser", function()
             { _tag = "ast.Toplevel.Record",
               name = "Point",
               field_decls = {
-                { name = "x", type = { _tag = "ast.Type.Float" } },
-                { name = "y", type = { _tag = "ast.Type.Float" } } } },
+                { name = "x", type = { _tag = "ast.Type.Name", name = "float" } },
+                { name = "y", type = { _tag = "ast.Type.Name", name = "float" } } } },
         })
 
         assert_program_ast([[
@@ -880,12 +880,12 @@ describe("Pallene parser", function()
         assert_expression_ast([[ foo as integer ]],
             { _tag = "ast.Exp.Cast",
                 exp = { _tag = "ast.Exp.Var" },
-                target = { _tag = "ast.Type.Integer" } })
+                target = { _tag = "ast.Type.Name", name = "integer" } })
 
         assert_expression_ast([[ a.b[1].c as integer ]],
             { _tag = "ast.Exp.Cast",
                 exp = { _tag = "ast.Exp.Var" },
-                target = { _tag = "ast.Type.Integer" } })
+                target = { _tag = "ast.Type.Name", name = "integer" } })
 
         assert_expression_ast([[ foo as { integer } ]],
             { _tag = "ast.Exp.Cast",
@@ -896,14 +896,14 @@ describe("Pallene parser", function()
             { rhs = {
                 _tag = "ast.Exp.Cast",
                 exp = { _tag = "ast.Exp.Var" },
-                target = { _tag = "ast.Type.Integer" } }})
+                target = { _tag = "ast.Type.Name", name = "integer" } }})
 
         assert_expression_ast([[ 1 as integer as any ]],
             { _tag = "ast.Exp.Cast",
-                target = { _tag = "ast.Type.Any" },
+                target = { _tag = "ast.Type.Name", name = "any" },
                 exp = {
                     _tag = "ast.Exp.Cast",
-                    target = { _tag = "ast.Type.Integer" },
+                    target = { _tag = "ast.Type.Name", name = "integer" },
                     exp = {
                         _tag = "ast.Exp.Integer"
                     }}})
@@ -914,24 +914,6 @@ describe("Pallene parser", function()
             "Expected a name before '('")
         assert_statements_syntax_error([[ (x) = 42 ]],
             "This expression is not an lvalue")
-    end)
-
-    it("does not allow identifiers that are type names", function()
-        assert_program_syntax_error([[
-            export function integer()
-            end
-        ]], "Expected a name before 'integer'")
-
-        assert_program_syntax_error([[
-            export function f()
-                local integer: integer = 10
-            end
-        ]], "Expected a name before 'integer'")
-    end)
-
-    it("doesn't allow using a primitive type as a record", function()
-        assert_expression_syntax_error("integer.new(10)",
-            "Unexpected 'integer'")
     end)
 
     it("uses specific error labels for some errors", function()

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -15,7 +15,7 @@ end
 local function assert_translation(pallene_code, expected)
     compile(pallene_code)
     local contents = util.get_file_contents("__test__.lua")
-    assert.are.same("local string_ = string;" .. expected, contents)
+    assert.are.same(expected, contents)
 end
 
 local function assert_translation_error(pallene_code, expected)


### PR DESCRIPTION
And also allow string.char and string.sub, getting rid of the string_ workaround. Fixes #240.

The first part of this patch is that most builtin types are no longer a keyword, meaning that they can now be used in variable names. The only exception is `nil`, which was already a keyword in Lua.

The next change that we did is that we got rid of the string_ workaround. The solution we chose was to add the `string` name in the scope as a module name, but still have it count as the String() type if it is used as a type name. Currently this workaround is just for the string type / module but in theory we could extend it to other types in the future if there is a desire to have modules that export a type with the same name as the module name.