### PR TITLE
Don't crash if we use the -O0 flag

### DIFF
--- a/pallenec
+++ b/pallenec
@@ -30,7 +30,7 @@ p:mutex(
 -- NOTE: *For C compiler only* this option may be overridden  using the CFLAGS environment variable.
 p:option("-O", "Optimization level")
     :args(1):convert(tonumber)
-    :choices({0, 1, 2, 3})
+    :choices({"0", "1", "2", "3"})
     :default(2)
 
 


### PR DESCRIPTION
In a previous commit, I removed the quotes from a place that actually needed the quotes. Oops!
In the current form, argparse will always reject the argument to -O, because strings are not
numbers.