### PR TITLE
Updated the translator to prevent redundant spaces before assignment …

### DIFF
--- a/benchmarks/binsearch/lua.lua
+++ b/benchmarks/binsearch/lua.lua
@@ -1,7 +1,7 @@
 local binsearch, test;
 function binsearch(t, x)
     -- lo <= x <= hi
-local lo = 1
+    local lo = 1
     local hi = #t
 
     local steps = 0

--- a/benchmarks/fasta/lua.lua
+++ b/benchmarks/fasta/lua.lua
@@ -60,8 +60,8 @@ function random_fasta(id, desc, frequencies, n)
         local total = 0.0
         for i = 1, nitems do
             local o = frequencies[i]
-            local c = o[1] 
-            local p = o[2] 
+            local c = o[1]
+            local p = o[2]
             total = total + p
             letters[i] = c
             probs[i]   = total

--- a/benchmarks/fasta/pallene.pln
+++ b/benchmarks/fasta/pallene.pln
@@ -55,7 +55,7 @@ export function random_fasta(id: string, desc: string, frequencies: {{any}}, n: 
     -- Prepare the cummulative probability table
     local nitems  = #frequencies
     local letters: {string} = {}
-    local probs: {float}  = {}
+    local probs: {float} = {}
     do
         local total = 0.0
         for i = 1, nitems do

--- a/benchmarks/spectralnorm/lua.lua
+++ b/benchmarks/spectralnorm/lua.lua
@@ -41,7 +41,7 @@ end
 
 function Approximate(N)
     -- Create unit vector
-local u = {}
+    local u = {}
     for i = 1, N do
         u[i] = 1.0
     end

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -506,7 +506,7 @@ local i, p;
 
 
 i = 1
-p = { x = i , y = i }
+p = { x = i, y = i }
 ]])
     end)
 
@@ -518,7 +518,7 @@ local j: integer = i as integer
 ]],
 [[
 local i, j;i = 1
-j = i 
+j = i
 ]])
     end)
 
@@ -531,8 +531,8 @@ local k: integer = (j as integer) + 1
 ]],
 [[
 local i, j, k;i = 1
-j = i 
-k = (j ) + 1
+j = i
+k = (j) + 1
 ]])
     end)
 
@@ -572,7 +572,7 @@ local k, f;k = 1
 
 function f()
     if true then
-        local j = k 
+        local j = k
     end
 end
 ]])
@@ -624,7 +624,7 @@ function f()
     if false then
         -- Nothing
     elseif true then
-        local j = k 
+        local j = k
     end
 end
 ]])
@@ -650,7 +650,7 @@ function f()
     if false then
         -- Nothing
     else
-        local j = k 
+        local j = k
     end
 end
 ]])
@@ -673,7 +673,7 @@ local k, f;k = 1
 function f()
     repeat
         -- Nothing
-    until k 
+    until k
 end
 ]])
     end)
@@ -694,7 +694,7 @@ local k, f;k = 1
 
 function f()
     repeat
-        local j = k 
+        local j = k
     until true
 end
 ]])
@@ -715,7 +715,7 @@ end
 local k, f;k = 1
 
 function f()
-    for j = k , k + 10, k do
+    for j = k, k + 10, k do
         -- Nothing
     end
 end
@@ -738,7 +738,7 @@ local k, f;k = 1
 
 function f()
     for j = 1, 10 do
-        local m = k 
+        local m = k
     end
 end
 ]])
@@ -757,7 +757,7 @@ end
 local k, f;k = 1
 
 function f()
-    k, k = k , k 
+    k, k = k, k
 end
 ]])
     end)
@@ -775,7 +775,7 @@ end
 local k, f;k = 1
 
 function f()
-    k = ((k ) )
+    k = ((k))
 end
 ]])
     end)
@@ -793,7 +793,7 @@ end
 local k, f;k = 1
 
 function f()
-    local j = k 
+    local j = k
 end
 ]])
     end)
@@ -811,7 +811,7 @@ end
 local k, f;k = "Madyanam"
 
 function f()
-    io.write(k )
+    io.write(k)
 end
 ]])
     end)
@@ -831,7 +831,7 @@ local name1, name2, get_names;name1 = "Anushka"
 name2 = "Samuel"
 
 function get_names()
-    return name1 , name2 
+    return name1, name2
 end
 ]])
     end)


### PR DESCRIPTION
…and as operator.

Added a utility method to the translator: `add_partial`. It ensures that the partials inserted are
not empty. This constraint is required by the translator when removing redundant spaces.