### PR TITLE
Simplify the "erase preceding spaces" logic in translator

### DIFF
--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -95,7 +95,8 @@ end
 -- inclusive.
 function Parser:region_begin()
     if self.region_depth == 0 then
-        table.insert(self.type_regions, { self.next.loc.pos, false })
+        local pos = (self.prev and self.prev.end_pos + 1 or 1)
+        table.insert(self.type_regions, { pos, false })
     end
     self.region_depth = self.region_depth + 1
 end

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -44,14 +44,8 @@ end
 function Translator:add_previous(stop_index)
     assert(self.last_index <= stop_index + 1)
     local partial = self.input:sub(self.last_index, stop_index)
-    self:add_partial(partial)
+    table.insert(self.partials, partial)
     self.last_index = stop_index + 1
-end
-
-function Translator:add_partial(partial)
-    if partial ~= "" then
-        table.insert(self.partials, partial)
-    end
 end
 
 function Translator:erase_region(start_index, stop_index)
@@ -59,29 +53,21 @@ function Translator:erase_region(start_index, stop_index)
     assert(start_index <= stop_index + 1)
     self:add_previous(start_index - 1)
 
-    if #self.partials > 0 then
-        local last_partial = self.partials[#self.partials]
-        local space_index = last_partial:find(" +$")
-        if space_index then
-            self.partials[#self.partials] = last_partial:sub(1, space_index - 1)
-        end
-    end
-
     local region = self.input:sub(start_index, stop_index)
     local partial = region:gsub("[^\n\r]", "")
-    self:add_partial(partial)
+    table.insert(self.partials, partial)
 
     self.last_index = stop_index + 1
 end
 
 function Translator:add_exports()
     if #self.exports > 0 then
-        self:add_partial("\nreturn {\n")
+        table.insert(self.partials, "\nreturn {\n")
         for _, export in ipairs(self.exports) do
             local pair = string.format("    %s = %s,\n", export, export)
-            self:add_partial(pair)
+            table.insert(self.partials, pair)
         end
-        self:add_partial("}\n")
+        table.insert(self.partials, "}\n")
     end
 end
 
@@ -136,7 +122,7 @@ function translator.translate(input, prog_ast)
 
         -- Preserve the comments inside the current region.
         while j <= #comments and comments[j][2] <= end_index do
-            assert(start_index < comments[j][1])
+            assert(start_index <= comments[j][1])
             instance:erase_region(start_index, comments[j][1] - 1)
             start_index = comments[j][2] + 1
             j = j + 1


### PR DESCRIPTION
After lunch I had an idea that lets us simplify the code from the last PR a little bit...

If we include the preceding spaces in the region to be erased then we don't need to look at the
previous partials and we don't need to worry about the previous partial being empty.