### PR TITLE
Fix to #225, added better error reporting for internal compiler errors.

### DIFF
--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -100,7 +100,7 @@ function ast.toplevel_names(tl_node)
     elseif tag == "ast.Toplevel.Builtin" then
         table.insert(names, tl_node.name)
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
     return names
 end

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -124,7 +124,7 @@ declare_type("Name", {
 })
 
 function Checker:add_type(name, typ)
-    assert(string.match(typ._tag, "^types%.T%."))
+    assert(typedecl.tag_matches(typ._tag, "types.T."))
     self.symbol_table:add_symbol(name, checker.Name.Type(typ))
 end
 

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -218,7 +218,7 @@ function Checker:from_ast_type(ast_typ)
         return types.T.Function(p_types, ret_types)
 
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 end
 
@@ -360,7 +360,7 @@ function Checker:check_program(prog_ast)
                     self:add_type(tl_node.name, typ)
 
                 else
-                    error("impossible")
+                    typedecl.tag_error(tag)
                 end
             end
 
@@ -455,7 +455,7 @@ function Checker:check_stat(stat)
             elseif loop_type._tag == "types.T.Float" then
                 stat.step = ast.Exp.Float(stat.limit.loc, 1.0)
             else
-                error("impossible")
+                typedecl.tag_error(loop_type._tag, "incorrect loop step type.")
             end
         end
 
@@ -515,7 +515,7 @@ function Checker:check_stat(stat)
         -- ok
 
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 
     return stat
@@ -547,7 +547,7 @@ function Checker:check_var(var)
                 "cannot reference module name '%s' without dot notation",
                 var.name)
         else
-            error("impossible")
+            typedecl.tag_error(cname._tag)
         end
 
     elseif tag == "ast.Var.Dot" then
@@ -603,7 +603,7 @@ function Checker:check_var(var)
         var._type = arr_type.elem
 
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
     return var
 end
@@ -618,8 +618,10 @@ function Checker:coerce_numeric_exp_to_float(exp)
         return exp
     elseif tag == "types.T.Integer" then
         return self:check_exp_synthesize(ast.Exp.ToFloat(exp.loc, exp))
+    elseif typedecl.tag_is_type(tag) then
+        typedecl.tag_error(tag, "this type cannot be coerced to float.")
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 end
 
@@ -687,7 +689,7 @@ function Checker:check_exp_synthesize(exp)
             check_type_is_condition(exp.exp, "'not' operator")
             exp._type = types.T.Boolean()
         else
-            error("impossible")
+            typedecl.tag_error(tag, string.format("unknown unary operator '%s'.", op))
         end
 
     elseif tag == "ast.Exp.Binop" then
@@ -797,7 +799,7 @@ function Checker:check_exp_synthesize(exp)
             exp._type = types.T.Integer()
 
         else
-            error("impossible")
+            typedecl.tag_error(tag, string.format("unknown binary operator '%s'.", op))
         end
 
     elseif tag == "ast.Exp.CallFunc" then
@@ -865,7 +867,7 @@ function Checker:check_exp_synthesize(exp)
         exp._type = types.T.Float()
 
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 
     return exp
@@ -898,7 +900,7 @@ function Checker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
                         field.exp, expected_type.elem,
                         "array initializer")
                 else
-                    error("impossible")
+                    typedecl.tag_error(ftag)
                 end
             end
 
@@ -928,7 +930,7 @@ function Checker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
                         field.exp, field_type,
                         "table initializer")
                 else
-                    error("impossible")
+                    typedecl.tag_error(ftag)
                 end
             end
 

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -618,7 +618,7 @@ function Checker:coerce_numeric_exp_to_float(exp)
         return exp
     elseif tag == "types.T.Integer" then
         return self:check_exp_synthesize(ast.Exp.ToFloat(exp.loc, exp))
-    elseif typedecl.tag_is_type(tag) then
+    elseif typedecl.tag_matches(tag, "types.T") then
         typedecl.tag_error(tag, "this type cannot be coerced to float.")
     else
         typedecl.tag_error(tag)

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -455,7 +455,7 @@ function Checker:check_stat(stat)
             elseif loop_type._tag == "types.T.Float" then
                 stat.step = ast.Exp.Float(stat.limit.loc, 1.0)
             else
-                typedecl.tag_error(loop_type._tag, "incorrect loop step type.")
+                typedecl.tag_error(loop_type._tag, "loop type is not a number.")
             end
         end
 
@@ -799,7 +799,7 @@ function Checker:check_exp_synthesize(exp)
             exp._type = types.T.Integer()
 
         else
-            typedecl.tag_error(tag, string.format("unknown binary operator '%s'.", op))
+            typedecl.tag_error(op)
         end
 
     elseif tag == "ast.Exp.CallFunc" then

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -39,7 +39,7 @@ local function ctype(typ)
     elseif tag == "types.T.Table"    then return "Table *"
     elseif tag == "types.T.Record"   then return "Udata *"
     elseif tag == "types.T.Any"      then return "TValue"
-    elseif typedecl.tag_is_type(tag) then
+    elseif typedecl.tag_matches(tag, "types.T") then
         typedecl.tag_error(tag, "unable to get corresponding c type.")
     else typedecl.tag_error(tag)
     end
@@ -119,7 +119,7 @@ local function set_stack_slot(typ, dst_slot, value)
     elseif tag == "types.T.Table"    then tmpl = "sethvalue(L, $dst, $src);"
     elseif tag == "types.T.Record"   then tmpl = "setuvalue(L, $dst, $src);"
     elseif tag == "types.T.Any"      then tmpl = "setobj(L, $dst, &$src);"
-    elseif not typedecl.tag_is_type(tag) then
+    elseif not typedecl.tag_matches(tag, "types.T") then
         typedecl.tag_error(tag, "not a type.")
     else
         typedecl.tag_error(tag)

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1510,7 +1510,7 @@ gen_cmd["CheckGC"] = function(self, cmd, func)
 end
 
 function Coder:generate_cmd(func, cmd)
-    local name = assert(string.match(cmd._tag, "^ir%.Cmd%.(.*)$"))
+    local name = assert(typedecl.tag_matches(cmd._tag, "ir.Cmd."))
     local f = assert(gen_cmd[name], "impossible")
     local out = f(self, cmd, func)
 

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -39,9 +39,7 @@ local function ctype(typ)
     elseif tag == "types.T.Table"    then return "Table *"
     elseif tag == "types.T.Record"   then return "Udata *"
     elseif tag == "types.T.Any"      then return "TValue"
-    elseif typedecl.tag_matches(tag, "types.T") then
-        typedecl.tag_error(tag, "unable to get corresponding c type.")
-    else typedecl.tag_error(tag)
+    else   typedecl.tag_error(tag)
     end
 end
 
@@ -119,10 +117,7 @@ local function set_stack_slot(typ, dst_slot, value)
     elseif tag == "types.T.Table"    then tmpl = "sethvalue(L, $dst, $src);"
     elseif tag == "types.T.Record"   then tmpl = "setuvalue(L, $dst, $src);"
     elseif tag == "types.T.Any"      then tmpl = "setobj(L, $dst, &$src);"
-    elseif not typedecl.tag_matches(tag, "types.T") then
-        typedecl.tag_error(tag, "not a type.")
-    else
-        typedecl.tag_error(tag)
+    else typedecl.tag_error(tag)
     end
 
     return (util.render(tmpl, { dst = dst_slot, src = value }))
@@ -171,7 +166,7 @@ local function pallene_type_tag(typ)
     elseif tag == "types.T.Array"    then return "LUA_TTABLE"
     elseif tag == "types.T.Table"    then return "LUA_TTABLE"
     elseif tag == "types.T.Record"   then return "LUA_TUSERDATA"
-    elseif tag == "types.T.Any"      then typedecl.tag_error(tag, "value is not a tag")
+    elseif tag == "types.T.Any"      then typedecl.tag_error(tag, "'Any' is not a Lua type tag.")
     else typedecl.tag_error(tag)
     end
 end
@@ -333,7 +328,7 @@ function Coder:c_value(value)
     elseif typedecl.tag_matches(tag, "ir.Value") then
         typedecl.tag_error(tag, "unable to get C expression for this value type.")
     else
-        typedecl.tag_error(tag, "not a value.")
+        typedecl.tag_error(tag)
     end
 end
 

--- a/pallene/constant_propagation.lua
+++ b/pallene/constant_propagation.lua
@@ -4,6 +4,7 @@
 -- SPDX-License-Identifier: MIT
 
 local ir = require "pallene.ir"
+local typedecl = require "pallene.typedecl"
 
 local constant_propagation = {}
 
@@ -17,7 +18,7 @@ local function is_constant_value(v)
     elseif tag == "ir.Value.LocalVar" then return false
     elseif tag == "ir.Value.Function" then return true
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 end
 

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -215,7 +215,7 @@ local function Cmd(cmd)
     elseif tag == "ir.Cmd.CallStatic" then rhs = Call(Fun(cmd.f_id),  Vals(cmd.srcs))
     elseif tag == "ir.Cmd.CallDyn"    then rhs = Call(Val(cmd.src_f), Vals(cmd.srcs))
     else
-        local tagname = assert(string.match(cmd._tag, "^ir.Cmd.(.*)"))
+        local tagname = assert(typedecl.tag_matches(cmd._tag, "ir.Cmd."))
         rhs = Call(tagname, Vals(ir.get_srcs(cmd)))
     end
 

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -6,6 +6,7 @@
 local C = require "pallene.C"
 local ir = require "pallene.ir"
 local util = require "pallene.util"
+local typedecl = require "pallene.typedecl"
 
 --
 -- Generates a human-readable representation of the IR.
@@ -41,7 +42,7 @@ local function Val(val)
     elseif tag == "ir.Value.LocalVar" then return Var(val.id)
     elseif tag == "ir.Value.Function" then return Fun(val.id)
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 end
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -497,7 +497,7 @@ function ToIR:exp_to_value(cmds, exp, _recursive)
                 return ir.Value.Function(id)
 
             elseif cname._tag == "checker.Name.Builtin" then
-                typedecl.tag_error(cname._tag, "not implemented")
+                error("not implemented")
 
             else
                 typedecl.tag_error(cname._tag)
@@ -651,7 +651,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinTostring(loc, dsts, xs))
             else
-                typedecl.tag_error(cname._tag, "unknown builtin function.")
+                typedecl.tag_error(bname)
             end
 
         elseif cname and cname._tag == "checker.Name.Function" then
@@ -780,8 +780,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             elseif src_typ._tag == "types.T.Any" then
                 table.insert(cmds, ir.Cmd.FromDyn(loc, dst_typ, dst, v))
             else
-                typedecl.tag_error(tag,
-                    string.format("error casting from type '%s' to '%s'",
+                error(string.format("error casting from type '%s' to '%s'",
                         types.tostring(src_typ), types.tostring(dst_typ)))
             end
         end

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -93,7 +93,7 @@ function ToIR:convert_toplevel(prog_ast)
             self.rec_id_of_typ[typ] = ir.add_record_type(self.module, typ)
 
         else
-            error("impossible")
+            typedecl.tag_error(tag)
         end
     end
 
@@ -248,7 +248,7 @@ function ToIR:convert_stat(cmds, stat)
                     local id = self.glb_id_of_decl[cname.decl]
                     table.insert(lhss, to_ir.LHS.Global(id))
                 else
-                    error("impossible")
+                    typedecl.tag_error(cname._tag)
                 end
 
             elseif var._tag == "ast.Var.Bracket" then
@@ -266,12 +266,14 @@ function ToIR:convert_stat(cmds, stat)
                 elseif ttag == "types.T.Record" then
                     local typ = var.exp._type
                     table.insert(lhss, to_ir.LHS.Record(typ, t, var.name))
+                elseif typedecl.tag_is_type(ttag) then
+                    typedecl.tag_error(ttag, "type not indexable.")
                 else
-                    error("impossible")
+                    typedecl.tag_error(ttag)
                 end
 
             else
-                error("impossible")
+                typedecl.tag_error(var._tag)
             end
         end
 
@@ -326,7 +328,7 @@ function ToIR:convert_stat(cmds, stat)
                 elseif ltag == "to_ir.LHS.Record" then
                     cmd = ir.Cmd.SetField(loc, lhs.typ, lhs.rec, lhs.field, val)
                 else
-                    error("impossible")
+                    typedecl.tag_error(ltag)
                 end
                 table.insert(cmds, cmd)
             end
@@ -355,7 +357,7 @@ function ToIR:convert_stat(cmds, stat)
         table.insert(cmds, ir.Cmd.Break())
 
     else
-        error("impossible")
+        typedecl.type_error(tag)
     end
 end
 
@@ -495,10 +497,10 @@ function ToIR:exp_to_value(cmds, exp, _recursive)
                 return ir.Value.Function(id)
 
             elseif cname._tag == "checker.Name.Builtin" then
-                error("not implemented")
+                typedecl.tag_error(cname._tag, "not implemented")
 
             else
-                error("impossible")
+                typedecl.tag_error(cname._tag)
             end
         else
             -- Fallthrough to default
@@ -577,7 +579,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 table.insert(cmds, ir.Cmd.SetField(exp.loc, typ, dv, field_name, vv))
             end
         else
-            error("impossible")
+            typedecl.tag_error(typ._tag)
         end
 
     elseif tag == "ast.Exp.Lambda" then
@@ -649,7 +651,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinTostring(loc, dsts, xs))
             else
-                error("impossible")
+                typedecl.tag_error(cname._tag, "unknown builtin function.")
             end
 
         elseif cname and cname._tag == "checker.Name.Function" then
@@ -691,13 +693,16 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 cmd = ir.Cmd.GetTable(loc, dst_typ, dst, rec, key)
             elseif typ._tag == "types.T.Record" then
                 cmd = ir.Cmd.GetField(loc, typ, dst, rec, field)
+            elseif typedecl.tag_is_type(type._tag) then
+                typedecl.tag_error(typ._tag, "cannot index this type.")
             else
-                error("impossible")
+                typedecl.tag_error(typ._tag)
             end
+
             table.insert(cmds, cmd)
 
         else
-            error("impossible")
+            typedecl.tag_error(var._tag)
         end
 
     elseif tag == "ast.Exp.Unop" then
@@ -775,7 +780,9 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             elseif src_typ._tag == "types.T.Any" then
                 table.insert(cmds, ir.Cmd.FromDyn(loc, dst_typ, dst, v))
             else
-                error("impossible")
+                typedecl.tag_error(tag,
+                    string.format("error casting from type '%s' to '%s'",
+                        types.tostring(src_typ), types.tostring(dst_typ)))
             end
         end
 
@@ -803,8 +810,10 @@ function ToIR:value_is_truthy(cmds, exp, val)
         local b = ir.add_local(self.func, false, types.T.Boolean())
         table.insert(cmds, ir.Cmd.IsTruthy(exp.loc, b, val))
         return ir.Value.LocalVar(b)
+    elseif typedecl.tag_is_type(typ) then
+        typedecl.tag_error(typ._tag, "unable to test this type for truthiness.")
     else
-        error("impossible")
+        typedecl.tag_error(typ._tag)
     end
 end
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -693,7 +693,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 cmd = ir.Cmd.GetTable(loc, dst_typ, dst, rec, key)
             elseif typ._tag == "types.T.Record" then
                 cmd = ir.Cmd.GetField(loc, typ, dst, rec, field)
-            elseif typedecl.tag_is_type(type._tag) then
+            elseif typedecl.tag_is_type(typ._tag) then
                 typedecl.tag_error(typ._tag, "cannot index this type.")
             else
                 typedecl.tag_error(typ._tag)

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -84,9 +84,16 @@ end
 
 -- Returns true if the 2nd argument is a prefix of the first.
 --
+-- for example:
+--
+-- ```
+-- typedecl.tag_matches("ast.Exp.Bool", "ast.Exp")
+-- ```
+-- would return true since `"ast.Exp"` is indeed a prefix of
+-- "ast.Exp.bool"
+--
 -- @param tag: The type name (string)
 -- @param tag_prefix: The prefix to test (string)
-
 function typedecl.tag_matches(tag, tag_prefix)
     return type(tag) == "string"
         and string.find(tag, tag_prefix, 1, true) ~= nil
@@ -95,7 +102,6 @@ end
 -- Return true if the argument tag is has "types.T" as prefix
 --
 -- @param tag Tag name
-
 function typedecl.tag_is_type(tag)
     return typedecl.tag_matches(tag, "types.T")
 end
@@ -104,7 +110,6 @@ end
 --
 -- @param tag The type tag at which the error is to be thown (string)
 -- @param message The optional error message. (?string)
-
 function typedecl.tag_error(tag, message)
     local error_msg = message
         and string.format("error at tag '%s': %s", tag, message)

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -100,7 +100,7 @@ end
 
 -- Throw an error at the given type tag.
 --
--- @param tag The type tag at which the error is to be thown (string)
+-- @param tag The type tag (or token string) at which the error is to be thown (string)
 -- @param message The optional error message. (?string)
 function typedecl.tag_error(tag, message)
     message = message or "input has the wrong type or an elseif case is missing"

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -90,7 +90,7 @@ end
 -- typedecl.tag_matches("ast.Exp.Bool", "ast.Exp")
 -- ```
 -- would return true since `"ast.Exp"` is indeed a prefix of
--- "ast.Exp.bool"
+-- "ast.Exp.bool". Check types.lua for more usage examples.
 --
 -- @param tag: The type name (string)
 -- @param tag_prefix: The prefix to test (string)

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -95,15 +95,7 @@ end
 -- @param tag: The type name (string)
 -- @param tag_prefix: The prefix to test (string)
 function typedecl.tag_matches(tag, tag_prefix)
-    return type(tag) == "string"
-        and string.find(tag, tag_prefix, 1, true) ~= nil
-end
-
--- Return true if the argument tag is has "types.T" as prefix
---
--- @param tag Tag name
-function typedecl.tag_is_type(tag)
-    return typedecl.tag_matches(tag, "types.T")
+    return type(tag) == "string" and string.find(tag, tag_prefix, 1, true) ~= nil
 end
 
 -- Throw an error at the given type tag.

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -82,4 +82,27 @@ function typedecl.declare(module, mod_name, type_name, constructors)
     end
 end
 
+-- Returns true if the 2nd argument is a prefix of the first.
+--
+-- @param tag: The type name (string)
+-- @param tag_prefix: The prefix to test (string)
+
+function typedecl.tag_matches(tag, tag_prefix)
+    return type(tag) == "string"
+        and string.find(tag, tag_prefix, 1, true) ~= nil
+end
+
+-- Throw an error at the given type tag.
+--
+-- @param tag The type tag at which the error is to be thown (string)
+-- @param message The optional error message. (?string)
+
+function typedecl.tag_error(tag, message)
+    local error_msg = message
+        and string.format("Tag error at %s: %s", tag, message)
+        or string.format("Tag error at %s.", tag)
+
+    error(error_msg)
+end
+
 return typedecl

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -107,8 +107,8 @@ end
 
 function typedecl.tag_error(tag, message)
     local error_msg = message
-        and string.format("Type error at '%s': %s", tag, message)
-        or string.format("Type error at '%s'.", tag)
+        and string.format("error at tag '%s': %s", tag, message)
+        or string.format("error at tag '%s'.", tag)
 
     error(error_msg)
 end

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -92,6 +92,14 @@ function typedecl.tag_matches(tag, tag_prefix)
         and string.find(tag, tag_prefix, 1, true) ~= nil
 end
 
+-- Return true if the argument tag is has "types.T" as prefix
+--
+-- @param tag Tag name
+
+function typedecl.tag_is_type(tag)
+    return typedecl.tag_matches(tag, "types.T")
+end
+
 -- Throw an error at the given type tag.
 --
 -- @param tag The type tag at which the error is to be thown (string)
@@ -99,8 +107,8 @@ end
 
 function typedecl.tag_error(tag, message)
     local error_msg = message
-        and string.format("Tag error at %s: %s", tag, message)
-        or string.format("Tag error at %s.", tag)
+        and string.format("Type error at '%s': %s", tag, message)
+        or string.format("Type error at '%s'.", tag)
 
     error(error_msg)
 end

--- a/pallene/typedecl.lua
+++ b/pallene/typedecl.lua
@@ -103,11 +103,8 @@ end
 -- @param tag The type tag at which the error is to be thown (string)
 -- @param message The optional error message. (?string)
 function typedecl.tag_error(tag, message)
-    local error_msg = message
-        and string.format("error at tag '%s': %s", tag, message)
-        or string.format("error at tag '%s'.", tag)
-
-    error(error_msg)
+    message = message or "input has the wrong type or an elseif case is missing"
+    error(string.format("unhandled case '%s': %s", tag, message))
 end
 
 return typedecl

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -49,7 +49,7 @@ function types.is_gc(t)
         return true
 
     else
-        error("impossible")
+        typedecl.tag_error(tag, "unknown type.")
     end
 end
 
@@ -72,8 +72,10 @@ function types.is_condition(t)
     then
         return false
 
+    elseif not typedecl.tag_matches(tag, "types.T") then
+        typedecl.tag_error(tag, "not a type.")
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 
 end
@@ -98,7 +100,7 @@ function types.is_indexable(t)
         return false
 
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 end
 
@@ -110,8 +112,10 @@ function types.indices(t)
     elseif tag == "types.T.Record" then
         return t.field_types
 
+    elseif typedecl.tag_is_type(tag) then
+        typedecl.tag_error(tag, "cannot index this type.")
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 end
 
@@ -194,7 +198,8 @@ local function equivalent(t1, t2, is_gradual)
         return t1 == t2
 
     else
-        return error("impossible")
+        return typedecl.tag_error(tag1,
+            string.format("attempt to check equivalence of types %s and %s.", tag1, tag2))
     end
 end
 
@@ -246,8 +251,10 @@ function types.tostring(t)
 
     elseif tag == "types.T.Record" then
         return t.name
+    elseif not typedecl.tag_matches(tag, "types.T") then
+        typedecl.tag_error(tag, "not a type.")
     else
-        error("impossible")
+        typedecl.tag_error(tag)
     end
 end
 

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -112,7 +112,7 @@ function types.indices(t)
     elseif tag == "types.T.Record" then
         return t.field_types
 
-    elseif typedecl.tag_is_type(tag) then
+    elseif typedecl.tag_matches(tag, "types.T") then
         typedecl.tag_error(tag, "cannot index this type.")
     else
         typedecl.tag_error(tag)

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -49,7 +49,7 @@ function types.is_gc(t)
         return true
 
     else
-        typedecl.tag_error(tag, "unknown type.")
+        typedecl.tag_error(tag)
     end
 end
 
@@ -72,8 +72,6 @@ function types.is_condition(t)
     then
         return false
 
-    elseif not typedecl.tag_matches(tag, "types.T") then
-        typedecl.tag_error(tag, "not a type.")
     else
         typedecl.tag_error(tag)
     end
@@ -126,6 +124,9 @@ local function equivalent(t1, t2, is_gradual)
     assert(is_gradual ~= nil)
     local tag1 = t1._tag
     local tag2 = t2._tag
+
+    assert(typedecl.tag_matches(tag1, "types.T"))
+    assert(typedecl.tag_matches(tag2, "types.T"))
 
     if is_gradual and (tag1 == "types.T.Any" or tag2 == "types.T.Any") then
         return true
@@ -251,8 +252,6 @@ function types.tostring(t)
 
     elseif tag == "types.T.Record" then
         return t.name
-    elseif not typedecl.tag_matches(tag, "types.T") then
-        typedecl.tag_error(tag, "not a type.")
     else
         typedecl.tag_error(tag)
     end

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -4,7 +4,7 @@
 -- SPDX-License-Identifier: MIT
 
 local ir = require "pallene.ir"
-local typedecl = require "typedecl"
+local typedecl = require "pallene.typedecl"
 
 local uninitialized = {}
 

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -4,6 +4,7 @@
 -- SPDX-License-Identifier: MIT
 
 local ir = require "pallene.ir"
+local typedecl = require "typedecl"
 
 local uninitialized = {}
 
@@ -117,7 +118,7 @@ local function test(cmd, uninit, loop)
             return true, loop.uninit
         end
 
-    elseif string.match(tag, "^ir%.Cmd%.") then
+    elseif typedecl.tag_matches(cmd._tag, "ir.Cmd.") then
         for _, val in ipairs(ir.get_srcs(cmd)) do
             if val._tag == "ir.Value.LocalVar" then
                 check_use(val.id)

--- a/test.lua
+++ b/test.lua
@@ -1,3 +1,0 @@
-local types = require "pallene.types"
-
-types.is_gc({_tag = "myTypeLoL"})

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,3 @@
+local types = require "pallene.types"
+
+types.is_gc({_tag = "myTypeLoL"})


### PR DESCRIPTION
Previously, when an incorrect table was passed into a function dealing with a certain type of table, only an "impossible" error was thrown followed by a Lua stack trace.

Now it's possible to see the tag which caused the error, and wherever appropriate, an error message following it. Calls to `error("impossible")` have been replaced with a call to `typedecl.tag_error(tag, "(optional error message.)")`.

Hopefully, this should fix [#225 ](https://github.com/pallene-lang/pallene/issues/225).