### PR TITLE
Explain the execution_tests vs coder_spec thing

### DIFF
--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1,6 +1,12 @@
 local util = require "pallene.util"
 local execution_tests = require "spec.execution_tests"
 
+--
+-- This file tests the C backend, the main backend of the Pallene compiler.
+-- However, the actual test cases are in the execution_tests.lua. Add new tests there.
+-- This is because those test cases are used for both the C backend and the Lua backend.
+--
+
 local function compile(filename, pallene_code)
     assert(util.set_file_contents(filename, pallene_code))
     local cmd = string.format("./pallenec %s", util.shell_quote(filename))

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -1,5 +1,10 @@
 local util = require "pallene.util"
 
+--
+-- These are the test cases that involve compiling and running a Pallene program.
+-- We use these tests for the C backend (coder_spec) and the Lua backend (translator_spec).
+--
+
 local execution_tests = {}
 
 function execution_tests.run(compile_file, backend, _ENV, only_compile)


### PR DESCRIPTION
Add some comments telling people that they have to add the test cases to the execution_tests instead of to the coder_spec (as we used to do in the past).