### PR TITLE
Add more test cases for `x,x = f()`

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1405,6 +1405,9 @@ gen_cmd["Return"] = function(self, cmd)
     if #cmd.srcs == 0 then
         return [[ return; ]]
     else
+        -- We assign the dsts from right to left, in order to match Lua's semantics when a
+        -- destination variable appears more than once in the LHS. For example, in `x,x = f()`.
+        -- For a more in-depth discussion, see the implementation of ast.Stat.Assign in to_ir.lua
         local returns = {}
         for i = #cmd.srcs, 2, -1 do
             local src = self:c_value(cmd.srcs[i])

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -297,8 +297,8 @@ function ToIR:convert_stat(cmds, stat)
         --  the rest of the RHS has been evaluated. However, we don't bother optimizing this last
         --  case because if the programmer has written a complicated multiple-assignment then it is
         --  likely that it isn't something that could have been written as a sequence of single
-        --  assignments. (Our implementation always ends up creating a temporary variable in this
-        --  case because save_if_necessary calls exp_to_value.)
+        --  assignments. Our implementation always ends up creating a temporary variable in this
+        --  case because save_if_necessary calls exp_to_value.
         local vals = {}
         for i, exp in ipairs(exps) do
             local is_last = (i == #exps or exps[i+1]._tag == "ast.Exp.ExtraRet")
@@ -314,23 +314,21 @@ function ToIR:convert_stat(cmds, stat)
             local lhs = lhss[i]
             local val = vals[i]
             if val then
-                local cmd
                 local ltag = lhs._tag
                 if     ltag == "to_ir.LHS.Local" then
-                    cmd = ir.Cmd.Move(loc, lhs.id, val)
+                    table.insert(cmds, ir.Cmd.Move(loc, lhs.id, val))
                 elseif ltag == "to_ir.LHS.Global" then
-                    cmd = ir.Cmd.SetGlobal(loc, lhs.id, val)
+                    table.insert(cmds, ir.Cmd.SetGlobal(loc, lhs.id, val))
                 elseif ltag == "to_ir.LHS.Array" then
-                    cmd = ir.Cmd.SetArr(loc, lhs.typ, lhs.arr, lhs.i, val)
+                    table.insert(cmds, ir.Cmd.SetArr(loc, lhs.typ, lhs.arr, lhs.i, val))
                 elseif ltag == "to_ir.LHS.Table" then
                     local str = ir.Value.String(lhs.field)
-                    cmd = ir.Cmd.SetTable(loc, lhs.typ, lhs.t, str, val)
+                    table.insert(cmds, ir.Cmd.SetTable(loc, lhs.typ, lhs.t, str, val))
                 elseif ltag == "to_ir.LHS.Record" then
-                    cmd = ir.Cmd.SetField(loc, lhs.typ, lhs.rec, lhs.field, val)
+                    table.insert(cmds, ir.Cmd.SetField(loc, lhs.typ, lhs.rec, lhs.field, val))
                 else
                     typedecl.tag_error(ltag)
                 end
-                table.insert(cmds, cmd)
             end
         end
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -211,9 +211,12 @@ function ToIR:convert_stat(cmds, stat)
         local exps = stat.exps
         assert(#vars == #exps)
 
-        -- In Lua, the expressions in an assignment are evaluated from left to right and all
-        -- sub-expressions are evaluated before the assignments are resolved. Assignments happen
-        -- from right to left.
+        -- Multiple Assignments
+        -- --------------------
+        -- According to the Lua reference manual, the expressions in a multiple assignment should be
+        -- evaluated before the assignments are performed. The order of evaluation is not specified
+        -- but we try to match what PUC-Lua does: it evaluates the expressions from left to right
+        -- and then performs the assignments from right to left.
 
         -- In a multiple assignment we have to be careful if we end up with an ir.Value that refers
         -- to a local variable because that variable can potentially be overwritten in another part

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2138,16 +2138,29 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 return (f())
             end
 
-            export function assign_same_var_1(): integer
+            export function callstatic_assign_same_var_1(): integer
                 local x: integer
                 x, x, x = f()
                 return x
             end
 
-            export function assign_same_var_2(): integer
+            export function callstatic_assign_same_var_2(): integer
                 local x: integer
                 local y: integer
                 x, y, y = f()
+                return y
+            end
+
+            export function calldyn_assign_same_var_1(p: ()->(integer,integer,integer)): integer
+                local x: integer
+                x, x, x = p()
+                return x
+            end
+
+            export function calldyn_assign_same_var_2(p: ()->(integer,integer,integer)): integer
+                local x: integer
+                local y: integer
+                x, y, y = p()
                 return y
             end
         ]])
@@ -2193,16 +2206,30 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
             ]])
         end)
 
-        it("assigns return values from right to left (1)", function()
+        it("assigns return values from right to left (callstatic/1)", function()
             run_test([[
-                local x = test.assign_same_var_1()
+                local x = test.callstatic_assign_same_var_1()
                 assert(x == 10)
             ]])
         end)
 
-        it("assigns return values from right to left (2)", function()
+        it("assigns return values from right to left (callstatic/2)", function()
             run_test([[
-                local y = test.assign_same_var_2()
+                local y = test.callstatic_assign_same_var_2()
+                assert(y == 20)
+            ]])
+        end)
+
+        it("assigns return values from right to left (calldyn/1)", function()
+            run_test([[
+                local x = test.calldyn_assign_same_var_1(test.f)
+                assert(x == 10)
+            ]])
+        end)
+
+        it("assigns return values from right to left (calldyn/2)", function()
+            run_test([[
+                local y = test.calldyn_assign_same_var_2(test.f)
                 assert(y == 20)
             ]])
         end)


### PR DESCRIPTION
@leokaplan just told me that he ran into this corner case of evaluation order while he was implementing the function inliner. This motivated me to make some small tweaks to the test suite and to the comments related to multiple assignment.

1. Also test the evaluation order for CallDyn instead of only testing for CallStatic.
2. Explicitly mention that the Lua reference manual does not specify an evaluation order for multiple assignments.