### PR TITLE
Add support for looping with ipairs.

### DIFF
--- a/pallene/builtins.lua
+++ b/pallene/builtins.lua
@@ -8,6 +8,8 @@ local T = types.T
 
 local builtins = {}
 
+local ipairs_itertype = T.Function({T.Any(), T.Any()}, {T.Any(), T.Any()})
+
 builtins.functions = {
     ["type"] = T.Function({ T.Any() }, { T.String() }),
     ["io.write"] = T.Function({ T.String() }, {}),
@@ -15,6 +17,7 @@ builtins.functions = {
     ["string.char"] = T.Function({ T.Integer() }, { T.String() }),
     ["string.sub"] = T.Function({ T.String(), T.Integer(), T.Integer() }, { T.String() }),
     ["tostring"] = T.Function({ T.Any() }, { T.String() }),
+    ["ipairs"] = T.Function({T.Array(T.Any())}, {ipairs_itertype, T.Any(), T.Any()})
 }
 
 builtins.modules = {

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -482,11 +482,6 @@ function Checker:check_stat(stat)
                 types.tostring(itertype), types.tostring(iteratorfn._type))
         end
 
-        if iteratorfn._tag == "ast.Exp.CallFunc" then
-            local iterfn_var = iteratorfn.exp.var._name
-            stat.is_ipairs = iterfn_var._tag == "checker.Name.Builtin" and iterfn_var.name == "ipairs"
-        end
-
         rhs[2] = self:check_exp_synthesize(rhs[2])
         rhs[3] = self:check_exp_synthesize(rhs[3])
 

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -482,6 +482,11 @@ function Checker:check_stat(stat)
                 types.tostring(itertype), types.tostring(iteratorfn._type))
         end
 
+        if iteratorfn._tag == "ast.Exp.CallFunc" then
+            local iterfn_var = iteratorfn.exp.var._name
+            stat.is_ipairs = iterfn_var._tag == "checker.Name.Builtin" and iterfn_var.name == "ipairs"
+        end
+
         rhs[2] = self:check_exp_synthesize(rhs[2])
         rhs[3] = self:check_exp_synthesize(rhs[3])
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -209,8 +209,15 @@ function ToIR:convert_stat(cmds, stat)
         local decls = stat.decls
         local exps = stat.exps
 
+        local is_ipairs = false
+        local iterfn = exps[1]
+        if iterfn._tag == "ast.Exp.CallFunc" and iterfn.exp._tag == "ast.Exp.Var" then
+            local iterfn_var = iterfn.exp.var._name
+            is_ipairs = iterfn_var._tag == "checker.Name.Builtin" and iterfn_var.name == "ipairs"
+        end
 
-        if stat.is_ipairs then
+
+        if is_ipairs then
             -- `ipairs` are desugared down to regular for-loops
             -- ```
             -- for i, x in ipairs(xs) do

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -243,6 +243,7 @@ function ToIR:convert_stat(cmds, stat)
             --   i_num = i_num + 1
             -- end
             -- ```
+            
             -- the table passed as argument to `ipairs`
             local arr =  exps[2].call_exp.args[1]
             local v_arr = ir.add_local(self.func, "$xs", arr._type)

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -247,7 +247,6 @@ function ToIR:convert_stat(cmds, stat)
             -- the table passed as argument to `ipairs`
             local arr =  ipairs_args[1]
             assert(types.equals(arr._type, types.T.Array(types.T.Any())))
-            assert(arr._type.elem._tag == "types.T.Any")
             local v_arr = ir.add_local(self.func, "$xs", arr._type)
             self:exp_to_assignment(cmds, v_arr, arr)
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -241,6 +241,7 @@ function ToIR:convert_stat(cmds, stat)
 
             -- the table passed as argument to `ipairs`
             local arr =  exps[2].call_exp.args[1]
+            assert(arr._type._tag == "types.T.Any")
             local v_arr = ir.add_local(self.func, "$xs", arr._type)
             self:exp_to_assignment(cmds, v_arr, arr)
 
@@ -281,6 +282,7 @@ function ToIR:convert_stat(cmds, stat)
                 table.insert(body, ir.Cmd.FromDyn(stat.loc, decls[2]._type, v_x, ir.Value.LocalVar(v_x_dyn)))
             end
 
+            -- <loop body>
             self:convert_stat(body, stat.block)
             -- i_num = i_num + 1
             local loop_step = ir.Value.Integer(1)

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -239,8 +239,14 @@ function ToIR:convert_stat(cmds, stat)
             -- end
             -- ```
 
+            
+            local ipairs_args = exps[2].call_exp.args
+            assert(#ipairs_args == 1)
+            assert(#decls == 2)
+
             -- the table passed as argument to `ipairs`
-            local arr =  exps[2].call_exp.args[1]
+            local arr =  ipairs_args[1]
+            assert(types.equals(arr._type, types.T.Array(types.T.Any())))
             assert(arr._type.elem._tag == "types.T.Any")
             local v_arr = ir.add_local(self.func, "$xs", arr._type)
             self:exp_to_assignment(cmds, v_arr, arr)
@@ -260,7 +266,7 @@ function ToIR:convert_stat(cmds, stat)
             table.insert(body, ir.Cmd.GetArr(stat.loc, types.T.Any(), v_x_dyn, src_arr, src_i))
 
             -- if x_dyn == nil then break end
-            local v_cond_checknil = ir.add_local(self.func, "$is_"..decls[2].name.."_nil", types.T.Boolean())
+            local v_cond_checknil = ir.add_local(self.func, false, types.T.Boolean())
             table.insert(body, ir.Cmd.IsNil(stat.loc, v_cond_checknil, ir.Value.LocalVar(v_x_dyn)))
             table.insert(body, ir.Cmd.If(stat.loc, ir.Value.LocalVar(v_cond_checknil), ir.Cmd.Break(), ir.Cmd.Nop()))
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -241,7 +241,7 @@ function ToIR:convert_stat(cmds, stat)
 
             -- the table passed as argument to `ipairs`
             local arr =  exps[2].call_exp.args[1]
-            assert(arr._type._tag == "types.T.Any")
+            assert(arr._type.elem._tag == "types.T.Any")
             local v_arr = ir.add_local(self.func, "$xs", arr._type)
             self:exp_to_assignment(cmds, v_arr, arr)
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -243,7 +243,7 @@ function ToIR:convert_stat(cmds, stat)
             --   i_num = i_num + 1
             -- end
             -- ```
-            
+
             -- the table passed as argument to `ipairs`
             local arr =  exps[2].call_exp.args[1]
             local v_arr = ir.add_local(self.func, "$xs", arr._type)
@@ -255,7 +255,7 @@ function ToIR:convert_stat(cmds, stat)
             table.insert(cmds, ir.Cmd.Move(stat.loc, v_inum, start))
         
             -- local limit: integer = 1
-            local v_limit = ir.add_local(self.func, "$"..decls[2].name.."_len", types.T.Integer())
+            local v_limit = ir.add_local(self.func, "$xs_len", types.T.Integer())
             table.insert(cmds, ir.Cmd.Unop(stat.loc, v_limit, "ArrLen", ir.Value.LocalVar(v_arr)))
             local limit = ir.Value.LocalVar(v_limit)
 
@@ -278,10 +278,9 @@ function ToIR:convert_stat(cmds, stat)
 
             -- x_dyn = xs[i]
             local v_x_dyn = ir.add_local(self.func, "$"..decls[2].name.."_dyn", types.T.Any())
-            self.loc_id_of_decl[decls[2]] = v_x_dyn
             local src_arr =  ir.Value.LocalVar(v_arr)
             local src_i =  ir.Value.LocalVar(v_inum)
-            table.insert(body, ir.Cmd.GetArr(stat.loc, decls[2]._type, v_x_dyn, src_arr, src_i))
+            table.insert(body, ir.Cmd.GetArr(stat.loc, types.T.Any(), v_x_dyn, src_arr, src_i))
 
             -- if x_dyn == nil then break end
             local v_cond_checknil = ir.add_local(self.func, "$is_"..decls[2].name.."_nil", types.T.Boolean())
@@ -290,6 +289,7 @@ function ToIR:convert_stat(cmds, stat)
 
             -- local x = x_dyn as T2
             local v_x = ir.add_local(self.func, decls[2].name, decls[2]._type)
+            self.loc_id_of_decl[decls[2]] = v_x
             if decls[2]._type._tag == "types.T.Any" then
                 table.insert(body, ir.Cmd.Move(stat.loc, v_x, ir.Value.LocalVar(v_x_dyn)))
             else

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -366,7 +366,7 @@ describe("Pallene type checker", function()
         ]], "missing control variable in for-in loop")
     end)
 
-    it("checks the arguments of ipairs.", function()
+    it("checks loops with ipairs.", function()
         assert_error([[
             export function fn()
                 for i: integer in ipairs() do
@@ -382,6 +382,22 @@ describe("Pallene type checker", function()
                 end
             end
         ]], "type error: function expects 1 argument(s) but received 2")
+
+        assert_error([[
+            export function fn()
+                for i, x, z in ipairs({1, 2}) do
+                    local k = z
+                end
+            end
+        ]], "type error: expected function type (any, any) -> (any, any, any) but found function type (any, any) -> (any, any) in loop iterator")
+        
+        assert_error([[
+            export function fn()
+                for i in ipairs({1, 2}) do
+                    local k = z
+                end
+            end
+        ]], "type error: expected function type (any, any) -> (any) but found function type (any, any) -> (any, any) in loop iterator")        
     end)
 
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -366,6 +366,24 @@ describe("Pallene type checker", function()
         ]], "missing control variable in for-in loop")
     end)
 
+    it("checks the arguments of ipairs.", function()
+        assert_error([[
+            export function fn()
+                for i: integer in ipairs() do
+                    local x = i
+                end
+            end
+        ]], "type error: function expects 1 argument(s) but received 0")
+
+        assert_error([[
+            export function fn()
+                for i, x in ipairs({1, 2}, {3, 4}) do
+                    local k = i
+                end
+            end
+        ]], "type error: function expects 1 argument(s) but received 2")
+    end)
+
 
     describe("table/record initalizer", function()
         local function assert_init_error(typ, code, err)

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -1822,8 +1822,17 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 for i, x in ipairs(xs) do
                     out[i] = x as integer * 2
                 end
-
                 return out
+            end
+
+            -----------------------
+
+            export function sum_list_ipairs(xs: {integer}): integer
+                local sum = 0
+                for _: integer, x: integer in ipairs(xs) do
+                    sum = sum + x
+                end
+                return sum
             end
         ]])
 
@@ -1859,6 +1868,20 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
             run_test([[
                 local xs = test.double_list_ipairs({1, 2})
                 assert(xs[1] == 2 and xs[2] == 4)
+            ]])
+        end)
+
+        it("for-in loops with ipairs and type annotated LHS", function()
+            run_test([[
+                local sum = test.sum_list_ipairs({1, 2, 3})
+                assert(sum == 6)
+            ]])
+        end)
+
+        it("for-in loops with holes", function()
+            run_test([[
+                local sum = test.sum_list_ipairs({1, 2, 3, nil, 4, 5})
+                assert(sum == 6)
             ]])
         end)
 

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -1814,6 +1814,17 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 end
                 return sum
             end
+
+            -----------------------
+
+            export function double_list_ipairs(xs: {integer}): {integer}
+                local out: {integer} = {}
+                for i, x in ipairs(xs) do
+                    out[i] = x as integer * 2
+                end
+
+                return out
+            end
         ]])
 
         it("general for-in loops", function()
@@ -1843,6 +1854,14 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 assert(sum == 10)
             ]])
         end)
+
+        it("for-in loops with ipairs", function()
+            run_test([[
+                local xs = test.double_list_ipairs({1, 2})
+                assert(xs[1] == 2 and xs[2] == 4)
+            ]])
+        end)
+
     end)
 
     describe("Constant propagation", function()


### PR DESCRIPTION
This PR introduces an `ipairs` builtin to mirror that of Lua. (to address #164)
Only difference being, the `ipairs` in Pallene is desugared to generic for in loops.

* `ipairs` builtin added to `builtins.lua`
* `checker.lua` now marks loop statement nodes with unshadowed ipairs as (is_ipairs)
* `to_ir.lua` now handles ipairs separately
* `spec/execution_tests.lua` has one test cases added to test looping with ipairs.

