### PR TITLE
Add back the CI badge to our README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Pallene
+[![Actions Status](https://github.com/pallene-lang/pallene/workflows/Github%20Actions%20CI/badge.svg)](https://github.com/pallene-lang/pallene/actions)
 
 Pallene is a statically typed, ahead-of-time-compiled sister language to
 [Lua](https://www.lua.org), with a focus on performance. It is also a


### PR DESCRIPTION
To advertise that we are a fancy project that takes our test suite seriously :)

We used to have it in the readme but I took it out when I migrated from travis to github actions.