### PR TITLE
Implement a -o option to select output path.

### DIFF
--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -166,21 +166,22 @@ end
 -- Writes the resulting output to [output_file_name] with extension [output_ext].
 -- If [output_file_name] is nil then the output is written to a file in the same
 -- directory as [input_file_name] and  having the same  base name as the input file.
-function driver.compile(argv0, input_ext, output_ext, input_file_name, opt_level, output_file_name)
-    local base_name, err =
+function driver.compile(argv0, opt_level, input_ext, output_ext, input_file_name, output_file_name)
+    local input_base_name, err =
         check_source_filename(argv0, input_file_name, input_ext)
-    if not base_name then return false, {err} end
+
+    if not input_base_name then return false, {err} end
 
     local output_base_name
     if not output_file_name then
-        output_base_name = base_name
+        output_base_name = input_base_name
     else
         output_base_name, err =
             check_source_filename(argv0, output_file_name, output_ext)
         if not output_base_name then return false, {err} end
     end
 
-    local mod_name = string.gsub(base_name, "/", "_")
+    local mod_name = string.gsub(input_base_name, "/", "_")
 
     if output_ext == "lua" then
         return compile_pln_to_lua(input_ext, output_ext, input_file_name, output_base_name)
@@ -193,7 +194,7 @@ function driver.compile(argv0, input_ext, output_ext, input_file_name, opt_level
         for i = first_step, last_step do
             local step = compiler_steps[i]
             if i == first_step then
-                file_names[i] = base_name .. "." .. step.name
+                file_names[i] = input_base_name .. "." .. step.name
             elseif i == last_step then
                 file_names[i] = output_base_name .. "." .. step.name
             else

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -161,15 +161,29 @@ local function compile_pln_to_lua(input_ext, output_ext, input_file_name, base_n
     return true, {}
 end
 
-function driver.compile(argv0, input_ext, output_ext, input_file_name, opt_level)
+
+-- Compile the contents of [input_file_name] with extension [input_ext].
+-- Writes the resulting output to [output_file_name] with extension [output_ext].
+-- If [output_file_name] is nil then the output is written to a file in the same
+-- directory as [input_file_name] and  having the same  base name as the input file.
+function driver.compile(argv0, input_ext, output_ext, input_file_name, opt_level, output_file_name)
     local base_name, err =
         check_source_filename(argv0, input_file_name, input_ext)
     if not base_name then return false, {err} end
 
+    local output_base_name
+    if not output_file_name then
+        output_base_name = base_name
+    else
+        output_base_name, err =
+            check_source_filename(argv0, output_file_name, output_ext)
+        if not output_base_name then return false, {err} end
+    end
+
     local mod_name = string.gsub(base_name, "/", "_")
 
     if output_ext == "lua" then
-        return compile_pln_to_lua(input_ext, output_ext, input_file_name, base_name)
+        return compile_pln_to_lua(input_ext, output_ext, input_file_name, output_base_name)
     else
         local first_step = step_index[input_ext]  or error("invalid extension")
         local last_step  = step_index[output_ext] or error("invalid extension")
@@ -178,8 +192,10 @@ function driver.compile(argv0, input_ext, output_ext, input_file_name, opt_level
         local file_names = {}
         for i = first_step, last_step do
             local step = compiler_steps[i]
-            if (i == first_step or i == last_step) then
+            if i == first_step then
                 file_names[i] = base_name .. "." .. step.name
+            elseif i == last_step then
+                file_names[i] = output_base_name .. "." .. step.name
             else
                 file_names[i] = os.tmpname()
             end

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -172,16 +172,13 @@ function driver.compile(argv0, opt_level, input_ext, output_ext, input_file_name
 
     if not input_base_name then return false, {err} end
 
-    local output_base_name
-    if not output_file_name then
-        output_base_name = input_base_name
-    else
-        output_base_name, err =
-            check_source_filename(argv0, output_file_name, output_ext)
-        if not output_base_name then return false, {err} end
-    end
+    output_file_name = output_file_name or (input_base_name.."."..output_ext)
+    local output_base_name, err =
+        check_source_filename(argv0, output_file_name, output_ext)
 
-    local mod_name = string.gsub(input_base_name, "/", "_")
+    if not output_base_name then return false, {err} end
+
+    local mod_name = string.gsub(output_base_name, "/", "_")
 
     if output_ext == "lua" then
         return compile_pln_to_lua(input_ext, output_ext, input_file_name, output_base_name)

--- a/pallenec
+++ b/pallenec
@@ -33,7 +33,7 @@ p:option("-O", "Optimization level")
     :choices({"0", "1", "2", "3"})
     :default(2)
 
-p:option("-o --output", "Output file path.")
+p:option("-o --output", "Output file path")
 
 
 local args = p:parse()
@@ -45,7 +45,7 @@ local opt_level = args.O
 local compiler_name = arg[0]
 
 local function compile(in_ext, out_ext)
-    local ok, errs = driver.compile(compiler_name, in_ext, out_ext, args.source_file, opt_level,
+    local ok, errs = driver.compile(compiler_name, opt_level, in_ext, out_ext, args.source_file,
         args.output)
     if not ok then util.abort(table.concat(errs, "\n")) end
 end

--- a/pallenec
+++ b/pallenec
@@ -39,7 +39,6 @@ p:option("-o --output", "Output file path.")
 local args = p:parse()
 
 local opt_level = args.O
-local output_file = args.output
 
 -- For compilation errors that don't happen inside a source file.
 -- Inspired by gcc, eg. "gcc: fatal error: no input files".
@@ -47,7 +46,7 @@ local compiler_name = arg[0]
 
 local function compile(in_ext, out_ext)
     local ok, errs = driver.compile(compiler_name, in_ext, out_ext, args.source_file, opt_level,
-        output_file)
+        args.output)
     if not ok then util.abort(table.concat(errs, "\n")) end
 end
 

--- a/pallenec
+++ b/pallenec
@@ -33,17 +33,21 @@ p:option("-O", "Optimization level")
     :choices({"0", "1", "2", "3"})
     :default(2)
 
+p:option("-o --output", "Output file path.")
+
 
 local args = p:parse()
 
 local opt_level = args.O
+local output_file = args.output
 
 -- For compilation errors that don't happen inside a source file.
 -- Inspired by gcc, eg. "gcc: fatal error: no input files".
 local compiler_name = arg[0]
 
 local function compile(in_ext, out_ext)
-    local ok, errs = driver.compile(compiler_name, in_ext, out_ext, args.source_file, opt_level)
+    local ok, errs = driver.compile(compiler_name, in_ext, out_ext, args.source_file, opt_level,
+        output_file)
     if not ok then util.abort(table.concat(errs, "\n")) end
 end
 

--- a/spec/pallenec_spec.lua
+++ b/spec/pallenec_spec.lua
@@ -11,6 +11,10 @@ describe("pallenec", function()
             local test = require "__test__"
             print(test.f(0))
         ]])
+        util.set_file_contents("__test__script__flag__.lua", [[
+            local test = require "__test__flag__"
+            print(test.f(0))
+        ]])
     end)
 
     after_each(function()
@@ -18,12 +22,21 @@ describe("pallenec", function()
         os.remove("__test__.c")
         os.remove("__test__.s")
         os.remove("__test__.so")
+        os.remove("__test__flag__.so")
         os.remove("__test__script__.lua")
+        os.remove("__test__script__flag__.lua")
     end)
 
     it("Can compile pallene files", function()
         assert(util.execute("./pallenec __test__.pln"))
         local ok, err, out, _ = util.outputs_of_execute("./lua/src/lua __test__script__.lua")
+        assert(ok, err)
+        assert.equals("17\n", out)
+    end)
+
+    it("Can compile with --output flag", function()
+        assert(util.execute("./pallenec __test__.pln -o __test__flag__.so"))
+        local ok, err, out, _ = util.outputs_of_execute("./lua/src/lua __test__script__flag__.lua")
         assert(ok, err)
         assert.equals("17\n", out)
     end)


### PR DESCRIPTION
This Pull Request attempts to address #321
Prior to this, Pallene was capable of emitting compiled files in the same directory as the source file.
Some small changes have been made to `pallenec` and `pallene/driver.lua (driver.compile)` to support a `-o` (`--output`) option that lets the user select an output directory. 

This works with all `--emit-x` flags as well.

Example:

```bash
# direct compilation
./pallenec my_dir/test.pln -o my_dir/__test_out.so

# pln -> c
./pallenec --emit-c  my_dir/test.pln -o my_dir/test_c_out.c

# c -> asm
./pallenec --emit-asm my_dir/test_c_out.c -o my_dir/__test_out.so

# pln -> lua
./pallenec --emit-lua my_dir/test.pln  -o my_dir/lua_dir/test_lua.lua
```