### PR TITLE
Don't discard extra values in the RHS

### DIFF
--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -125,7 +125,7 @@ function ToIR:convert_toplevel(prog_ast)
             if tag == "ast.Toplevel.Var" then
                 for i, exp in ipairs(tl_node.values) do
                     local decl = tl_node.decls[i]
-                    local val = self:exp_to_value(cmds, tl_node.values[i])
+                    local val = self:exp_to_value(cmds, exp)
                     if decl then
                         local gid = self.glb_id_of_decl[decl]
                         table.insert(cmds, ir.Cmd.SetGlobal(tl_node.loc, gid, val))
@@ -493,7 +493,7 @@ function ToIR:convert_stat(cmds, stat)
         end
 
     elseif tag == "ast.Stat.Decl" then
-        for i, decl in ipairs(stat.decls) do
+        for _, decl in ipairs(stat.decls) do
             self.loc_id_of_decl[decl] = ir.add_local(self.func, decl.name, decl._type)
         end
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -123,10 +123,13 @@ function ToIR:convert_toplevel(prog_ast)
         for _, tl_node in ipairs(prog_ast) do
             local tag = tl_node._tag
             if tag == "ast.Toplevel.Var" then
-                for i, decl in ipairs(tl_node.decls) do
+                for i, exp in ipairs(tl_node.values) do
+                    local decl = tl_node.decls[i]
                     local val = self:exp_to_value(cmds, tl_node.values[i])
-                    local gid = self.glb_id_of_decl[decl]
-                    table.insert(cmds, ir.Cmd.SetGlobal(tl_node.loc, gid, val))
+                    if decl then
+                        local gid = self.glb_id_of_decl[decl]
+                        table.insert(cmds, ir.Cmd.SetGlobal(tl_node.loc, gid, val))
+                    end
                 end
             end
         end
@@ -233,13 +236,13 @@ function ToIR:convert_stat(cmds, stat)
             --     break
             --   end
             --   local i = i_num as T1
-            --   local x = x_dyn as T2 
+            --   local x = x_dyn as T2
             --   <loop body>
             --   i_num = i_num + 1
             -- end
             -- ```
 
-            
+
             local ipairs_args = exps[2].call_exp.args
             assert(#ipairs_args == 1)
             assert(#decls == 2)
@@ -254,7 +257,7 @@ function ToIR:convert_stat(cmds, stat)
             local v_inum = ir.add_local(self.func, "$"..decls[1].name.."_num", types.T.Integer())
             local start = ir.Value.Integer(1)
             table.insert(cmds, ir.Cmd.Move(stat.loc, v_inum, start))
-        
+
             -- body of the while loop.
             local body = {}
 
@@ -294,7 +297,7 @@ function ToIR:convert_stat(cmds, stat)
             table.insert(body, ir.Cmd.Binop(stat.loc, v_inum, "IntAdd", ir.Value.LocalVar(v_inum), loop_step))
 
             table.insert(cmds, ir.Cmd.Loop(ir.Cmd.Seq(body)))
-        
+
         else
 
             -- Regular for-in loops are desugared into regurlar loops before compiling.
@@ -363,7 +366,6 @@ function ToIR:convert_stat(cmds, stat)
         local loc = stat.loc
         local vars = stat.vars
         local exps = stat.exps
-        assert(#vars == #exps)
 
         -- Multiple Assignments
         -- --------------------
@@ -458,7 +460,8 @@ function ToIR:convert_stat(cmds, stat)
         --  case because save_if_necessary calls exp_to_value.
         local vals = {}
         for i, exp in ipairs(exps) do
-            local is_last = (i == #exps or exps[i+1]._tag == "ast.Exp.ExtraRet")
+            local is_mulret = exps[i+1] and exps[i+1]._tag == "ast.Exp.ExtraRet"
+            local is_last = (i == #vars) or is_mulret
             if is_last and lhss[i]._tag == "to_ir.LHS.Local" then
                 self:exp_to_assignment(cmds, lhss[i].id, exp)
                 vals[i] = false
@@ -467,7 +470,7 @@ function ToIR:convert_stat(cmds, stat)
             end
         end
 
-        for i = #stat.vars, 1, -1 do
+        for i = #vars, 1, -1 do
             local lhs = lhss[i]
             local val = vals[i]
             if val then
@@ -491,10 +494,16 @@ function ToIR:convert_stat(cmds, stat)
 
     elseif tag == "ast.Stat.Decl" then
         for i, decl in ipairs(stat.decls) do
-            local v = ir.add_local(self.func, decl.name, decl._type)
-            self.loc_id_of_decl[decl] = v
-            if stat.exps[i] then
-                self:exp_to_assignment(cmds, v, stat.exps[i])
+            self.loc_id_of_decl[decl] = ir.add_local(self.func, decl.name, decl._type)
+        end
+
+        for i, exp in ipairs(stat.exps) do
+            local decl = stat.decls[i]
+            if decl then
+                self:exp_to_assignment(cmds, self.loc_id_of_decl[decl], exp)
+            else
+                -- Extra argument to RHS; compute it for side effects and discard result
+                local _ = self:exp_to_value(cmds, exp)
             end
         end
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -559,6 +559,19 @@ describe("Pallene type checker", function()
             "returning 0 value(s) but function expects 1")
     end)
 
+    it("detects too many return values when returning a function call", function()
+        assert_error([[
+            local function f(): (integer, integer)
+                return 1, 2
+            end
+
+            export function g(): integer
+                return f()
+            end
+        ]],
+            "returning 2 value(s) but function expects 1")
+    end)
+
     it("detects when a function returns the wrong type", function()
         assert_error([[
             export function fn(): integer
@@ -603,7 +616,7 @@ describe("Pallene type checker", function()
             "function expects 2 argument(s) but received 1")
     end)
 
-    it("detects wrong number of arguments when expanding a function", function()
+    it("detects too few arguments when expanding a function", function()
         assert_error([[
             export function f(): (integer, integer)
                 return 1, 2
@@ -618,6 +631,23 @@ describe("Pallene type checker", function()
             end
         ]],
             "function expects 3 argument(s) but received 2")
+    end)
+
+    it("detects too many arguments when expanding a function", function()
+        assert_error([[
+            export function f(): (integer, integer)
+                return 1, 2
+            end
+
+            export function g(x:integer): integer
+                return x
+            end
+
+            export function test(): integer
+                return g(f())
+            end
+        ]],
+            "function expects 1 argument(s) but received 2")
     end)
 
     it("detects wrong types of arguments to functions", function()

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -390,14 +390,14 @@ describe("Pallene type checker", function()
                 end
             end
         ]], "type error: expected function type (any, any) -> (any, any, any) but found function type (any, any) -> (any, any) in loop iterator")
-        
+
         assert_error([[
             export function fn()
                 for i in ipairs({1, 2}) do
                     local k = z
                 end
             end
-        ]], "type error: expected function type (any, any) -> (any) but found function type (any, any) -> (any, any) in loop iterator")        
+        ]], "type error: expected function type (any, any) -> (any) but found function type (any, any) -> (any, any) in loop iterator")
     end)
 
 

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2103,6 +2103,32 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 a, a, a = 10, 20, 30
                 return a
             end
+
+
+            local gn = 0
+            local function inc(): integer
+                gn = gn + 1
+                return gn
+            end
+
+            local x = inc(), inc()
+
+            export function extra_values_in_toplevel_decl(): (integer, integer)
+                return x, gn
+            end
+
+            export function extra_values_in_local_decl(): (integer, integer)
+                gn = 10
+                local y = inc(), inc()
+                return y, gn
+            end
+
+            export function extra_values_in_assign_stat(): (integer, integer)
+                local y: integer
+                gn = 20
+                y = inc(), inc()
+                return y, gn
+            end
         ]])
 
         it("preserves evaluation order with local variables", function()
@@ -2235,6 +2261,30 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
             run_test([[
                 local a = test.assign_same_var()
                 assert(10 == a)
+            ]])
+        end)
+
+        it("assignment to toplevel decl does not discard extra arguments in RHS", function()
+            run_test([[
+                local x, n = test.extra_values_in_toplevel_decl()
+                assert(2 == n)
+                assert(1 == x)
+            ]])
+        end)
+
+        it("assignment to local decl does not does not discard extra arguments in RHS", function()
+            run_test([[
+                local x, n = test.extra_values_in_local_decl()
+                assert(12 == n)
+                assert(11 == x)
+            ]])
+        end)
+
+        it("assignment statement does not does not discard extra arguments in RHS", function()
+            run_test([[
+                local x, n = test.extra_values_in_assign_stat()
+                assert(22 == n)
+                assert(21 == x)
             ]])
         end)
     end)


### PR DESCRIPTION
Currently, extra arguments in the RHS are discarded during type-checking step and are never evaluated. This doesn't match Lua's behavior. Those extra arguments might have side-effects and should still be evaluated.
    
Another related bug was Pallene's behavior when a function returning multiple values appeared in a function call or in a return statement. Pallene used to silently discard the extra return values, depending on the type of the function that is receiving the values from "g". This also does not match Lua's behavior. Here, we don't have the option to allow the extra arguments so now we raise a compile type type error instead of silently accepting it.
    
    -- "g" is a function that returns multiple values
    f(g())
    return g()
    
Fixes #347.
