### PR TITLE
  Remove export keyword and expect statements at the toplevel

### DIFF
--- a/benchmarks/binarytrees/lua.lua
+++ b/benchmarks/binarytrees/lua.lua
@@ -1,35 +1,32 @@
-local BottomUpTree, ItemCheck, Stress;
-function BottomUpTree(depth)
+local m;m = {}
+
+function m.BottomUpTree(depth)
     if depth > 0 then
         depth = depth - 1
-        local left  = BottomUpTree(depth)
-        local right = BottomUpTree(depth)
+        local left  = m.BottomUpTree(depth)
+        local right = m.BottomUpTree(depth)
         return { left, right }
     else
         return { false, false }
     end
 end
 
-function ItemCheck(tree)
+function m.ItemCheck(tree)
     if tree[1] then
-        return 1 + ItemCheck(tree[1]) + ItemCheck(tree[2])
+        return 1 + m.ItemCheck(tree[1]) + m.ItemCheck(tree[2])
     else
         return 1
     end
 end
 
-function Stress(mindepth, maxdepth, depth)
+function m.Stress(mindepth, maxdepth, depth)
     local iterations = 1 << (maxdepth - depth + mindepth)
     local check = 0
     for _ = 1, iterations do
-        local t = BottomUpTree(depth)
-        check = check + ItemCheck(t)
+        local t = m.BottomUpTree(depth)
+        check = check + m.ItemCheck(t)
     end
     return { iterations, check }
 end
 
-return {
-    BottomUpTree = BottomUpTree,
-    ItemCheck = ItemCheck,
-    Stress = Stress,
-}
+return m

--- a/benchmarks/binarytrees/pallene.pln
+++ b/benchmarks/binarytrees/pallene.pln
@@ -1,29 +1,32 @@
+local m: module = {}
 
-export function BottomUpTree(depth: integer): {any}
+function m.BottomUpTree(depth: integer): {any}
     if depth > 0 then
         depth = depth - 1
-        local left  = BottomUpTree(depth)
-        local right = BottomUpTree(depth)
+        local left  = m.BottomUpTree(depth)
+        local right = m.BottomUpTree(depth)
         return { left, right }
     else
         return { false, false }
     end
 end
 
-export function ItemCheck(tree: {any}): integer
+function m.ItemCheck(tree: {any}): integer
     if tree[1] then
-        return 1 + ItemCheck(tree[1]) + ItemCheck(tree[2])
+        return 1 + m.ItemCheck(tree[1]) + m.ItemCheck(tree[2])
     else
         return 1
     end
 end
 
-export function Stress(mindepth: integer, maxdepth: integer, depth: integer): {integer}
+function m.Stress(mindepth: integer, maxdepth: integer, depth: integer): {integer}
     local iterations = 1 << (maxdepth - depth + mindepth)
     local check = 0
     for _ = 1, iterations do
-        local t = BottomUpTree(depth)
-        check = check + ItemCheck(t)
+        local t = m.BottomUpTree(depth)
+        check = check + m.ItemCheck(t)
     end
     return { iterations, check }
 end
+
+return m

--- a/benchmarks/binsearch/lua.lua
+++ b/benchmarks/binsearch/lua.lua
@@ -1,5 +1,6 @@
-local binsearch, test;
-function binsearch(t, x)
+local m;m = {}
+
+function m.binsearch(t, x)
     -- lo <= x <= hi
     local lo = 1
     local hi = #t
@@ -25,17 +26,14 @@ function binsearch(t, x)
     return steps
 end
 
-function test(t, nrep)
+function m.test(t, nrep)
     local s = 0
     for i = 1, nrep do
-        if binsearch(t, i) ~= 22 then
+        if m.binsearch(t, i) ~= 22 then
             s = s + 1
         end
     end
     return s
 end
 
-return {
-    binsearch = binsearch,
-    test = test,
-}
+return m

--- a/benchmarks/binsearch/pallene.pln
+++ b/benchmarks/binsearch/pallene.pln
@@ -1,5 +1,6 @@
+local m: module = {}
 
-export function binsearch(t: {integer}, x: integer): integer
+function m.binsearch(t: {integer}, x: integer): integer
     -- lo <= x <= hi
     local lo = 1
     local hi = #t
@@ -25,12 +26,14 @@ export function binsearch(t: {integer}, x: integer): integer
     return steps
 end
 
-export function test(t: {integer}, nrep:integer): integer
+function m.test(t: {integer}, nrep:integer): integer
     local s = 0
     for i = 1, nrep do
-        if binsearch(t, i) ~= 22 then
+        if m.binsearch(t, i) ~= 22 then
             s = s + 1
         end
     end
     return s
 end
+
+return m

--- a/benchmarks/centroid/lua.lua
+++ b/benchmarks/centroid/lua.lua
@@ -1,9 +1,10 @@
-local new, centroid;
-function new(x, y)
+local m;m = {}
+
+function m.new(x, y)
     return { x, y }
 end
 
-function centroid(points, nrep)
+function m.centroid(points, nrep)
     local x = 0.0
     local y = 0.0
     local npoints = #points
@@ -19,7 +20,4 @@ function centroid(points, nrep)
     return { x / npoints, y / npoints }
 end
 
-return {
-    new = new,
-    centroid = centroid,
-}
+return m

--- a/benchmarks/centroid/pallene.pln
+++ b/benchmarks/centroid/pallene.pln
@@ -1,9 +1,10 @@
+local m: module = {}
 
-export function new(x: float, y: float): {float}
+function m.new(x: float, y: float): {float}
     return { x, y }
 end
 
-export function centroid(points: {{float}}, nrep: integer): {float}
+function m.centroid(points: {{float}}, nrep: integer): {float}
     local x = 0.0
     local y = 0.0
     local npoints = #points
@@ -18,3 +19,5 @@ export function centroid(points: {{float}}, nrep: integer): {float}
     end
     return { x / npoints, y / npoints }
 end
+
+return m

--- a/benchmarks/conway/lua.lua
+++ b/benchmarks/conway/lua.lua
@@ -1,9 +1,10 @@
-local ALIVE, DEAD, new_canvas, wrap, draw, spawn, step;
+local m, ALIVE, DEAD;m = {}
+
 ALIVE = "*"
 DEAD  = " "
 
 -- Create a new grid for the simulation.
-function new_canvas(N, M)
+function m.new_canvas(N, M)
     local t = {}
     for i = 1, N do
         local line = {}
@@ -16,12 +17,12 @@ function new_canvas(N, M)
 end
 
 -- Our grid has a toroidal topology with wraparound
-function wrap(i, N)
+function m.wrap(i, N)
     return (i - 1) % N + 1
 end
 
 -- Print the grid to stdout.
-function draw(N, M, cells)
+function m.draw(N, M, cells)
     local out = "" -- accumulate to reduce flicker
     for i = 1, N do
         local cellsi = cells[i]
@@ -39,25 +40,25 @@ function draw(N, M, cells)
 end
 
 -- Place a shape in the grid
-function spawn(N, M, cells, shape,
+function m.spawn(N, M, cells, shape,
 top, left)
     for i = 1, #shape do
-        local ci = wrap(i+top-1, N)
+        local ci = m.wrap(i+top-1, N)
         local shape_row = shape[i]
         local cell_row = cells[ci]
         for j = 1, #shape_row do
-            local cj = wrap(j+left-1, M)
+            local cj = m.wrap(j+left-1, M)
             cell_row[cj] = shape_row[j]
         end
     end
 end
 
 -- Run one step of the simulation.
-function step(N, M, curr_cells,
+function m.step(N, M, curr_cells,
 next_cells)
     for i2 = 1, N do
-        local i1 = wrap(i2-1, N)
-        local i3 = wrap(i2+1, N)
+        local i1 = m.wrap(i2-1, N)
+        local i3 = m.wrap(i2+1, N)
 
         local cells1 = curr_cells[i1]
         local cells2 = curr_cells[i2]
@@ -66,8 +67,8 @@ next_cells)
         local next2 = next_cells[i2]
 
         for j2 = 1, M do
-            local j1 = wrap(j2-1, M)
-            local j3 = wrap(j2+1, M)
+            local j1 = m.wrap(j2-1, M)
+            local j3 = m.wrap(j2+1, M)
 
             local c11 = cells1[j1]
             local c12 = cells1[j2]
@@ -95,10 +96,4 @@ next_cells)
     end
 end
 
-return {
-    new_canvas = new_canvas,
-    wrap = wrap,
-    draw = draw,
-    spawn = spawn,
-    step = step,
-}
+return m

--- a/benchmarks/conway/pallene.pln
+++ b/benchmarks/conway/pallene.pln
@@ -1,9 +1,10 @@
+local m: module = {}
 
 local ALIVE = "*"
 local DEAD  = " "
 
 -- Create a new grid for the simulation.
-export function new_canvas(N:integer, M:integer): {{integer}}
+function m.new_canvas(N:integer, M:integer): {{integer}}
     local t:{{integer}} = {}
     for i = 1, N do
         local line: {integer} = {}
@@ -16,12 +17,12 @@ export function new_canvas(N:integer, M:integer): {{integer}}
 end
 
 -- Our grid has a toroidal topology with wraparound
-export function wrap(i:integer, N:integer): integer
+function m.wrap(i:integer, N:integer): integer
     return (i - 1) % N + 1
 end
 
 -- Print the grid to stdout.
-export function draw(N:integer, M:integer, cells:{{integer}})
+function m.draw(N:integer, M:integer, cells:{{integer}})
     local out = "" -- accumulate to reduce flicker
     for i = 1, N do
         local cellsi = cells[i]
@@ -39,25 +40,25 @@ export function draw(N:integer, M:integer, cells:{{integer}})
 end
 
 -- Place a shape in the grid
-export function spawn(N:integer, M:integer, cells:{{integer}}, shape:{{integer}},
+function m.spawn(N:integer, M:integer, cells:{{integer}}, shape:{{integer}},
 top:integer, left:integer)
     for i = 1, #shape do
-        local ci = wrap(i+top-1, N)
+        local ci = m.wrap(i+top-1, N)
         local shape_row = shape[i]
         local cell_row = cells[ci]
         for j = 1, #shape_row do
-            local cj = wrap(j+left-1, M)
+            local cj = m.wrap(j+left-1, M)
             cell_row[cj] = shape_row[j]
         end
     end
 end
 
 -- Run one step of the simulation.
-export function step(N:integer, M:integer, curr_cells:{{integer}},
+function m.step(N:integer, M:integer, curr_cells:{{integer}},
 next_cells:{{integer}}): ()
     for i2 = 1, N do
-        local i1 = wrap(i2-1, N)
-        local i3 = wrap(i2+1, N)
+        local i1 = m.wrap(i2-1, N)
+        local i3 = m.wrap(i2+1, N)
 
         local cells1 = curr_cells[i1]
         local cells2 = curr_cells[i2]
@@ -66,8 +67,8 @@ next_cells:{{integer}}): ()
         local next2 = next_cells[i2]
 
         for j2 = 1, M do
-            local j1 = wrap(j2-1, M)
-            local j3 = wrap(j2+1, M)
+            local j1 = m.wrap(j2-1, M)
+            local j3 = m.wrap(j2+1, M)
 
             local c11 = cells1[j1]
             local c12 = cells1[j2]
@@ -94,3 +95,5 @@ next_cells:{{integer}}): ()
         end
     end
 end
+
+return m

--- a/benchmarks/fannkuchredux/lua.lua
+++ b/benchmarks/fannkuchredux/lua.lua
@@ -1,5 +1,6 @@
-local fannkuch;
-function fannkuch(N)
+local m;m = {}
+
+function m.fannkuch(N)
 
     local initial_perm = {}
     for i = 1, N do
@@ -81,6 +82,4 @@ function fannkuch(N)
     end
 end
 
-return {
-    fannkuch = fannkuch,
-}
+return m

--- a/benchmarks/fannkuchredux/pallene.pln
+++ b/benchmarks/fannkuchredux/pallene.pln
@@ -1,5 +1,6 @@
+local m: module = {}
 
-export function fannkuch(N: integer): {integer}
+function m.fannkuch(N: integer): {integer}
 
     local initial_perm: {integer} = {}
     for i = 1, N do
@@ -80,3 +81,5 @@ export function fannkuch(N: integer): {integer}
         perm_count = perm_count + 1
     end
 end
+
+return m

--- a/benchmarks/fasta/lua.lua
+++ b/benchmarks/fasta/lua.lua
@@ -1,4 +1,5 @@
-local IM, IA, IC, seed, random, WIDTH, print_fasta_header, repeat_fasta, linear_search, random_fasta;
+local m, IM, IA, IC, seed, random, WIDTH, print_fasta_header, linear_search;m = {}
+
 IM   = 139968
 IA   = 3877
 IC   = 29573
@@ -15,7 +16,7 @@ function print_fasta_header(id, desc)
     io.write(">" .. id .. " " .. desc .. "\n")
 end
 
-function repeat_fasta(id, desc, alu, n)
+function m.repeat_fasta(id, desc, alu, n)
     print_fasta_header(id, desc)
 
     local alusize = #alu
@@ -49,7 +50,7 @@ function linear_search(ps, p)
     return 1
 end
 
-function random_fasta(id, desc, frequencies, n)
+function m.random_fasta(id, desc, frequencies, n)
     print_fasta_header(id, desc)
 
     -- Prepare the cummulative probability table
@@ -87,7 +88,4 @@ function random_fasta(id, desc, frequencies, n)
     end
 end
 
-return {
-    repeat_fasta = repeat_fasta,
-    random_fasta = random_fasta,
-}
+return m

--- a/benchmarks/fasta/pallene.pln
+++ b/benchmarks/fasta/pallene.pln
@@ -1,3 +1,4 @@
+local m: module = {}
 
 local IM   = 139968
 local IA   = 3877
@@ -15,7 +16,7 @@ local function print_fasta_header(id: string, desc: string)
     io.write(">" .. id .. " " .. desc .. "\n")
 end
 
-export function repeat_fasta(id: string, desc: string, alu: string, n: integer)
+function m.repeat_fasta(id: string, desc: string, alu: string, n: integer)
     print_fasta_header(id, desc)
 
     local alusize = #alu
@@ -49,7 +50,7 @@ local function linear_search(ps: {float}, p: float): integer
     return 1
 end
 
-export function random_fasta(id: string, desc: string, frequencies: {{any}}, n: integer)
+function m.random_fasta(id: string, desc: string, frequencies: {{any}}, n: integer)
     print_fasta_header(id, desc)
 
     -- Prepare the cummulative probability table
@@ -86,3 +87,5 @@ export function random_fasta(id: string, desc: string, frequencies: {{any}}, n: 
         io.write("\n")
     end
 end
+
+return m

--- a/benchmarks/mandelbrot/lua.lua
+++ b/benchmarks/mandelbrot/lua.lua
@@ -1,5 +1,6 @@
-local mandelbrot;
-function mandelbrot(N)
+local m;m = {}
+
+function m.mandelbrot(N)
     local bits  = 0
     local nbits = 0
 
@@ -44,6 +45,4 @@ function mandelbrot(N)
     end
 end
 
-return {
-    mandelbrot = mandelbrot,
-}
+return m

--- a/benchmarks/mandelbrot/pallene.pln
+++ b/benchmarks/mandelbrot/pallene.pln
@@ -1,5 +1,6 @@
+local m: module = {}
 
-export function mandelbrot(N: integer)
+function m.mandelbrot(N: integer)
     local bits  = 0
     local nbits = 0
 
@@ -43,3 +44,5 @@ export function mandelbrot(N: integer)
         end
     end
 end
+
+return m

--- a/benchmarks/matmul/lua.lua
+++ b/benchmarks/matmul/lua.lua
@@ -1,5 +1,6 @@
-local matmul;
-function matmul(A, B)
+local m;m = {}
+
+function m.matmul(A, B)
     local C = {}
     local NI = #A
     local NK = #B
@@ -24,6 +25,4 @@ function matmul(A, B)
     return C
 end
 
-return {
-    matmul = matmul,
-}
+return m

--- a/benchmarks/matmul/pallene.pln
+++ b/benchmarks/matmul/pallene.pln
@@ -1,5 +1,6 @@
+local m: module = {}
 
-export function matmul(A: {{float}}, B:{{float}}): {{float}}
+function m.matmul(A: {{float}}, B:{{float}}): {{float}}
     local C: {{float}} = {}
     local NI = #A
     local NK = #B
@@ -23,3 +24,5 @@ export function matmul(A: {{float}}, B:{{float}}): {{float}}
     end
     return C
 end
+
+return m

--- a/benchmarks/nbody/lua.lua
+++ b/benchmarks/nbody/lua.lua
@@ -1,4 +1,4 @@
-local new_body, offset_momentum, advance, advance_multiple_steps, energy;
+local m;m = {}
 
 
 
@@ -9,7 +9,8 @@ local new_body, offset_momentum, advance, advance_multiple_steps, energy;
 
 
 
-function new_body(
+
+function m.new_body(
     x, y, z,
     vx, vy, vz, mass)
 
@@ -24,7 +25,7 @@ function new_body(
     }
 end
 
-function offset_momentum(bodies)
+function m.offset_momentum(bodies)
     local n = #bodies
     local px = 0.0
     local py = 0.0
@@ -44,7 +45,7 @@ function offset_momentum(bodies)
     sun.vz = sun.vz - pz / solar_mass
 end
 
-function advance(bodies, dt)
+function m.advance(bodies, dt)
     local n = #bodies
     for i = 1, n do
         local bi = bodies[i]
@@ -76,13 +77,13 @@ function advance(bodies, dt)
     end
 end
 
-function advance_multiple_steps(nsteps, bodies, dt)
+function m.advance_multiple_steps(nsteps, bodies, dt)
     for _ = 1, nsteps do
-        advance(bodies, dt)
+        m.advance(bodies, dt)
     end
 end
 
-function energy(bodies)
+function m.energy(bodies)
     local n = #bodies
     local e = 0.0
     for i = 1, n do
@@ -103,10 +104,4 @@ function energy(bodies)
     return e
 end
 
-return {
-    new_body = new_body,
-    offset_momentum = offset_momentum,
-    advance = advance,
-    advance_multiple_steps = advance_multiple_steps,
-    energy = energy,
-}
+return m

--- a/benchmarks/nbody/pallene.pln
+++ b/benchmarks/nbody/pallene.pln
@@ -1,3 +1,4 @@
+local m: module = {}
 
 record Body
     x: float
@@ -9,7 +10,7 @@ record Body
     mass: float
 end
 
-export function new_body(
+function m.new_body(
     x: float, y: float, z: float,
     vx: float, vy: float, vz: float, mass: float): Body
 
@@ -24,7 +25,7 @@ export function new_body(
     }
 end
 
-export function offset_momentum(bodies: {Body})
+function m.offset_momentum(bodies: {Body})
     local n = #bodies
     local px = 0.0
     local py = 0.0
@@ -44,7 +45,7 @@ export function offset_momentum(bodies: {Body})
     sun.vz = sun.vz - pz / solar_mass
 end
 
-export function advance(bodies: {Body}, dt: float)
+function m.advance(bodies: {Body}, dt: float)
     local n = #bodies
     for i = 1, n do
         local bi = bodies[i]
@@ -76,13 +77,13 @@ export function advance(bodies: {Body}, dt: float)
     end
 end
 
-export function advance_multiple_steps(nsteps: integer, bodies: {Body}, dt: float)
+function m.advance_multiple_steps(nsteps: integer, bodies: {Body}, dt: float)
     for _ = 1, nsteps do
-        advance(bodies, dt)
+        m.advance(bodies, dt)
     end
 end
 
-export function energy(bodies: {Body}): float
+function m.energy(bodies: {Body}): float
     local n = #bodies
     local e = 0.0
     for i = 1, n do
@@ -102,3 +103,5 @@ export function energy(bodies: {Body}): float
     end
     return e
 end
+
+return m

--- a/benchmarks/objmandelbrot/lua.lua
+++ b/benchmarks/objmandelbrot/lua.lua
@@ -1,34 +1,28 @@
-local new, clone, conj, add, mul, norm2;
-function new(x, y)
+local m;m = {}
+
+function m.new(x, y)
     return { x, y }
 end
 
-function clone(x)
-    return new(x[1], x[2])
+function m.clone(x)
+    return m.new(x[1], x[2])
 end
 
-function conj(x)
-    return new(x[1], -x[2])
+function m.conj(x)
+    return m.new(x[1], -x[2])
 end
 
-function add(x, y)
-    return new(x[1] + y[1], x[2] + y[2])
+function m.add(x, y)
+    return m.new(x[1] + y[1], x[2] + y[2])
 end
 
-function mul(x, y)
-    return new(x[1] * y[1] - x[2] * y[2], x[1] * y[2] + x[2] * y[1])
+function m.mul(x, y)
+    return m.new(x[1] * y[1] - x[2] * y[2], x[1] * y[2] + x[2] * y[1])
 end
 
-function norm2(x)
-    local n = mul(x, conj(x))
+function m.norm2(x)
+    local n = m.mul(x, m.conj(x))
     return n[1]
 end
 
-return {
-    new = new,
-    clone = clone,
-    conj = conj,
-    add = add,
-    mul = mul,
-    norm2 = norm2,
-}
+return m

--- a/benchmarks/objmandelbrot/pallene.pln
+++ b/benchmarks/objmandelbrot/pallene.pln
@@ -1,25 +1,28 @@
+local m: module = {}
 
-export function new(x: float, y: float): {float}
+function m.new(x: float, y: float): {float}
     return { x, y }
 end
 
-export function clone(x: {float}): {float}
-    return new(x[1], x[2])
+function m.clone(x: {float}): {float}
+    return m.new(x[1], x[2])
 end
 
-export function conj(x: {float}): {float}
-    return new(x[1], -x[2])
+function m.conj(x: {float}): {float}
+    return m.new(x[1], -x[2])
 end
 
-export function add(x: {float}, y: {float}): {float}
-    return new(x[1] + y[1], x[2] + y[2])
+function m.add(x: {float}, y: {float}): {float}
+    return m.new(x[1] + y[1], x[2] + y[2])
 end
 
-export function mul(x: {float}, y: {float}): {float}
-    return new(x[1] * y[1] - x[2] * y[2], x[1] * y[2] + x[2] * y[1])
+function m.mul(x: {float}, y: {float}): {float}
+    return m.new(x[1] * y[1] - x[2] * y[2], x[1] * y[2] + x[2] * y[1])
 end
 
-export function norm2(x: {float}): float
-    local n = mul(x, conj(x))
+function m.norm2(x: {float}): float
+    local n = m.mul(x, m.conj(x))
     return n[1]
 end
+
+return m

--- a/benchmarks/queen/lua.lua
+++ b/benchmarks/queen/lua.lua
@@ -1,4 +1,5 @@
-local isplaceok, printsolution, addqueen, nqueens;
+local m, isplaceok, printsolution, addqueen;m = {}
+
 -- check whether position (n,c) is free from attacks
 function isplaceok (a, n, c)
   for i = 1, n - 1 do   -- for each queen already placed
@@ -48,10 +49,8 @@ function addqueen (N, a, n)
 end
 
 -- run the program
-function nqueens(N)
+function m.nqueens(N)
     addqueen(N, {}, 1)
 end
 
-return {
-    nqueens = nqueens,
-}
+return m

--- a/benchmarks/queen/pallene.pln
+++ b/benchmarks/queen/pallene.pln
@@ -1,3 +1,4 @@
+local m: module = {}
 
 -- check whether position (n,c) is free from attacks
 local function isplaceok (a:{integer}, n:integer, c:integer): boolean
@@ -48,6 +49,8 @@ local function addqueen (N:integer, a:{integer}, n:integer)
 end
 
 -- run the program
-export function nqueens(N:integer)
+function m.nqueens(N:integer)
     addqueen(N, {}, 1)
 end
+
+return m

--- a/benchmarks/sieve/lua.lua
+++ b/benchmarks/sieve/lua.lua
@@ -1,5 +1,6 @@
-local sieve;
-function sieve(N)
+local m;m = {}
+
+function m.sieve(N)
     local is_prime = {}
     is_prime[1] = false
     for n = 2, N do
@@ -22,6 +23,4 @@ function sieve(N)
     return primes
 end
 
-return {
-    sieve = sieve,
-}
+return m

--- a/benchmarks/sieve/pallene.pln
+++ b/benchmarks/sieve/pallene.pln
@@ -1,5 +1,6 @@
+local m: module = {}
 
-export function sieve(N: integer): {integer}
+function m.sieve(N: integer): {integer}
     local is_prime: {boolean} = {}
     is_prime[1] = false
     for n: integer = 2, N do
@@ -21,3 +22,5 @@ export function sieve(N: integer): {integer}
 
     return primes
 end
+
+return m

--- a/benchmarks/spectralnorm/lua.lua
+++ b/benchmarks/spectralnorm/lua.lua
@@ -1,4 +1,5 @@
-local A, MultiplyAv, MultiplyAtv, MultiplyAtAv, Approximate;
+local m, A, MultiplyAv, MultiplyAtv, MultiplyAtAv;m = {}
+
 -- Return A[i][j], for the infinite matrix A
 --
 --  A = 1/1  1/2  1/4 ...
@@ -39,7 +40,7 @@ function MultiplyAtAv(N, v, out)
     MultiplyAtv(N, u, out)
 end
 
-function Approximate(N)
+function m.Approximate(N)
     -- Create unit vector
     local u = {}
     for i = 1, N do
@@ -65,6 +66,4 @@ function Approximate(N)
     return math.sqrt(vBv/vv)
 end
 
-return {
-    Approximate = Approximate,
-}
+return m

--- a/benchmarks/spectralnorm/pallene.pln
+++ b/benchmarks/spectralnorm/pallene.pln
@@ -1,3 +1,4 @@
+local m: module = {}
 
 -- Return A[i][j], for the infinite matrix A
 --
@@ -39,7 +40,7 @@ local function MultiplyAtAv(N: integer, v: {float}, out: {float})
     MultiplyAtv(N, u, out)
 end
 
-export function Approximate(N: integer): float
+function m.Approximate(N: integer): float
     -- Create unit vector
     local u: {float} = {}
     for i = 1, N do
@@ -64,3 +65,5 @@ export function Approximate(N: integer): float
 
     return math.sqrt(vBv/vv)
 end
+
+return m

--- a/examples/arithmetic/arithmetic.pln
+++ b/examples/arithmetic/arithmetic.pln
@@ -3,10 +3,14 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-export function add(a: any, b: any): integer
+local m: module = {}
+
+function m.add(a: any, b: any): integer
     return (a as integer) + (b as integer)
 end
 
-export function subtract(a: any, b: any): float
+function m.subtract(a: any, b: any): float
     return (a as float) - (b as float)
 end
+
+return m

--- a/examples/factorial/factorial.pln
+++ b/examples/factorial/factorial.pln
@@ -3,10 +3,14 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-export function factorial(n: integer): integer
+local m: module = {}
+
+function m.factorial(n: integer): integer
     if n <= 1 then
         return 1
     else
-        return n * factorial(n - 1)
+        return n * m.factorial(n - 1)
     end
 end
+
+return m

--- a/examples/fibonacci/fibonacci.pln
+++ b/examples/fibonacci/fibonacci.pln
@@ -3,7 +3,9 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-export function fibonacci(N: integer): { integer }
+local m: module = {}
+
+function m.fibonacci(N: integer): { integer }
     local result: { integer } = {}
     local a, b = 0, 1
     for i = 1, N do
@@ -12,3 +14,5 @@ export function fibonacci(N: integer): { integer }
     end
     return result
 end
+
+return m

--- a/examples/rectangle/rectangle.pln
+++ b/examples/rectangle/rectangle.pln
@@ -5,7 +5,11 @@
 
 typealias rectangle = { width: float, height: float }
 
-export function find_area(r: rectangle): float
+local m: module = {}
+
+function m.find_area(r: rectangle): float
 	local result = r.width * r.height
 	return result
 end
+
+return m

--- a/examples/sum_of_array/sum_of_array.pln
+++ b/examples/sum_of_array/sum_of_array.pln
@@ -3,10 +3,14 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-export function sum(array: { float }): float
+local m: module = {}
+
+function m.sum(array: { float }): float
     local result = 0.0
     for i = 1, #array do
         result = result + array[i]
     end
     return result
 end
+
+return m

--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -12,7 +12,7 @@ local function declare_type(type_name, cons)
 end
 
 declare_type("Program", {
-    Program = {"tls", "type_regions", "comment_regions"}
+    Program = {"loc", "tls", "type_regions", "comment_regions"}
 })
 
 declare_type("Type", {
@@ -21,11 +21,11 @@ declare_type("Type", {
     Array    = {"loc", "subtype"},
     Table    = {"loc", "fields"},
     Function = {"loc", "arg_types", "ret_types"},
+    Module   = {"loc"},
 })
 
 declare_type("Toplevel", {
-    Func      = {"loc", "visibility", "decl", "value"},
-    Var       = {"loc", "visibility", "decls", "values"},
+    Stat      = {"loc", "stat"},
     Typealias = {"loc", "name", "type",},
     Record    = {"loc", "name", "field_decls"},
 })
@@ -46,6 +46,7 @@ declare_type("Stat", {
     Call   = {"loc", "call_exp"},
     Return = {"loc", "exps"},
     Break  = {"loc"},
+    Func   = {"loc", "name", "decl", "value"},
 })
 
 -- Things that can appear in the LHS of an assignment. For example: x, x[i], x.name
@@ -82,28 +83,5 @@ declare_type("Field", {
 --
 -- note: the following functions are why we need `if type(conss) == "table"` in parser.lua
 --
-
--- Returns a sequence containing the variable names declared by the specified
--- toplevel node.
-function ast.toplevel_names(tl_node)
-    local names = {}
-    local tag = tl_node._tag
-    if     tag == "ast.Toplevel.Func" then
-        table.insert(names, tl_node.decl.name)
-    elseif tag == "ast.Toplevel.Var" then
-        for _, decl in ipairs(tl_node.decls) do
-            table.insert(names, decl.name)
-        end
-    elseif tag == "ast.Toplevel.Typealias" then
-        table.insert(names, tl_node.name)
-    elseif tag == "ast.Toplevel.Record" then
-        table.insert(names, tl_node.name)
-    elseif tag == "ast.Toplevel.Builtin" then
-        table.insert(names, tl_node.name)
-    else
-        typedecl.tag_error(tag)
-    end
-    return names
-end
 
 return ast

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -21,6 +21,8 @@ local util = require "pallene.util"
 --      - ast.Toplevel.Record
 --
 --   * _name: In ast.Var.Name nodes, a checker.Name that points to the matching declaration.
+--   * _modname: In ast.Stat.Decl nodes, which represent a module variable or function declaration.
+--   It holds the module's name. For instance, m.var = 2, would have _modname = "m"
 --
 -- We also make some adjustments to the AST:
 --
@@ -120,7 +122,7 @@ declare_type("Name", {
     Global   = { "decl" },
     Function = { "decl" },
     Builtin  = { "name" },
-    Module   = { "name" }
+    Module   = { "name", "is_main_mod" }
 })
 
 function Checker:add_type(name, typ)
@@ -133,14 +135,26 @@ function Checker:add_local(decl)
     self.symbol_table:add_symbol(decl.name, checker.Name.Local(decl))
 end
 
+local function verify_mod_decl(name, decl, symbol_table)
+    local cname = symbol_table:find_symbol(name)
+    if decl._modname and cname then
+        scope_error(decl.loc,
+          "duplicate module field '%s', previous one at line %d", decl.name, cname.decl.loc.line)
+    end
+end
+
 function Checker:add_global(decl)
     assert(decl._tag == "ast.Decl.Decl")
-    self.symbol_table:add_symbol(decl.name, checker.Name.Global(decl))
+    local name = decl._modname and (decl._modname .. '.' .. decl.name) or decl.name
+    verify_mod_decl(name, decl, self.symbol_table)
+    self.symbol_table:add_symbol(name, checker.Name.Global(decl))
 end
 
 function Checker:add_function(decl)
     assert(decl._tag == "ast.Decl.Decl")
-    self.symbol_table:add_symbol(decl.name, checker.Name.Function(decl))
+    local name = decl._modname and (decl._modname .. '.' .. decl.name) or decl.name
+    verify_mod_decl(name, decl, self.symbol_table)
+    self.symbol_table:add_symbol(name, checker.Name.Function(decl))
 end
 
 function Checker:add_builtin(name, id)
@@ -148,9 +162,9 @@ function Checker:add_builtin(name, id)
     self.symbol_table:add_symbol(name, checker.Name.Builtin(id))
 end
 
-function Checker:add_module(name)
+function Checker:add_module(name, is_main_mod)
     assert(type(name) == "string")
-    self.symbol_table:add_symbol(name, checker.Name.Module(name))
+    self.symbol_table:add_symbol(name, checker.Name.Module(name, is_main_mod))
 end
 
 --
@@ -212,32 +226,12 @@ local letrec_groups = {
     ["ast.Toplevel.Func"]      = "Func",
     ["ast.Toplevel.Typealias"] = "Type",
     ["ast.Toplevel.Record"]    = "Type",
+    ["ast.Toplevel.Stat"]      = "Stat",
 }
 
 function Checker:check_program(prog_ast)
     assert(prog_ast._tag == "ast.Program.Program")
     local tls = prog_ast.tls
-    do
-        -- Forbid top-level duplicates
-        --
-        -- To avoid ambiguities that could happen if the programmer tried to declare
-        -- multiple toplevel entities with the same name, we give a compilation
-        -- error.
-        local names = {}
-        for _, top_level_node in ipairs(tls) do
-            local top_level_names = ast.toplevel_names(top_level_node)
-            local node_location = top_level_node.loc
-            for _, name in ipairs(top_level_names) do
-                local old_location = names[name]
-                if old_location then
-                    scope_error(node_location,
-                        "duplicate toplevel '%s', previous one at line %d",
-                        name, old_location.line)
-                end
-                names[name] = node_location
-            end
-        end
-    end
 
     -- Add most primitive types to the symbol table
     self:add_type("any",     types.T.Any())
@@ -264,6 +258,7 @@ function Checker:check_program(prog_ast)
             local tag1  = node1._tag
             assert(letrec_groups[tag1])
 
+            node1.i = i
             local group = { node1 }
             local j = i + 1
             while j <= N do
@@ -275,6 +270,7 @@ function Checker:check_program(prog_ast)
                     break
                 end
 
+                node2.i = j
                 table.insert(group, node2)
                 j = j + 1
             end
@@ -290,38 +286,6 @@ function Checker:check_program(prog_ast)
         if     group_kind == "Import" then
             local loc = tl_group[1].loc
             type_error(loc, "modules are not implemented yet")
-
-        elseif group_kind == "Var" then
-
-            for _, tl_var in ipairs(tl_group) do
-
-                self:expand_function_returns(tl_var.values)
-
-                for i, decl in ipairs(tl_var.decls) do
-                    tl_var.values[i] =
-                        self:check_initializer_exp(
-                            decl, tl_var.values[i],
-                            "declaration of module variable %s", decl.name)
-                end
-
-                for _, decl in ipairs(tl_var.decls) do
-                    self:add_global(decl)
-                end
-            end
-
-
-        elseif group_kind == "Func" then
-
-            for _, tl_func in ipairs(tl_group) do
-                local decl = tl_func.decl
-                decl._type = self:from_ast_type(decl.type)
-                self:add_function(decl)
-            end
-
-            for _, tl_func in ipairs(tl_group) do
-                tl_func.value =
-                    self:check_exp_verify(tl_func.value, tl_func.decl._type, "toplevel function")
-            end
 
         elseif group_kind == "Type" then
 
@@ -349,14 +313,92 @@ function Checker:check_program(prog_ast)
                 end
             end
 
+        elseif group_kind == "Stat" then
+            for _, tl_node in ipairs(tl_group) do
+                local stat = tl_node.stat
+                if stat._tag ==  "ast.Stat.Decl" then
+                    for _, decl in ipairs(stat.decls) do
+                        local typ = decl.type
+                        if typ and typ._tag == "ast.Type.Name" then
+                            if typ.name == "module" then
+                                if self.mod_name then
+                                  type_error(decl.loc,
+                                     "There can only be one module variable per program")
+                                end
+                                self.mod_name = decl.name
+                                decl._type = types.T.Module()
+                                self:add_module(decl.name, true)
+                            end
+                        end
+                    end
+                elseif stat._tag == "ast.Stat.Func" then
+                    local decl = stat.decl
+                    local fname_exp = stat.name
+                    decl._type = self:from_ast_type(decl.type)
+                    self:check_funcname(fname_exp, decl)
+                end
+            end
+            if not self.mod_name then
+                type_error(prog_ast.loc, "Program has no module variable")
+            end
+            for _, tl_node in ipairs(tl_group) do
+                local stat = tl_node.stat
+                local i = tl_node.i
+                if stat._tag ~= "ast.Stat.Return" then
+                  tls[i].stat = self:check_stat(stat, true)
+                end
+            end
+
         else
             error("impossible")
         end
     end
 
+    local total_nodes = #tls
+    if total_nodes == 0 then
+        type_error(prog_ast.loc, "Empty modules are not permitted")
+    end
+
+     for i = 1, total_nodes - 1 do
+        if tls[i]._tag == "ast.Toplevel.Stat" then
+            local stat = tls[i].stat
+            if stat._tag == "ast.Stat.Return" then
+                type_error(stat.loc, "Only the last toplevel node can be a return statement")
+            end
+        end
+    end
+    
+    local last_toplevel_node = prog_ast.tls[total_nodes]
+    local last_stat = last_toplevel_node.stat
+    if last_toplevel_node._tag ~= "ast.Toplevel.Stat" or
+       not last_stat or last_stat._tag ~= "ast.Stat.Return" then
+        type_error(last_toplevel_node.loc, "Last Toplevel element must be a return statement")
+    end
+
+    local ret_types = {}
+    ret_types[1] = types.T.Module()
+    table.insert(self.ret_types_stack, ret_types)
+    self:check_stat(last_stat, true)
+    table.remove(self.ret_types_stack)
+    table.remove(prog_ast.tls)
+
     return prog_ast
 end
 
+function Checker:mod_assign_rhs_type(exp)
+    local typ = exp._type
+    local tag = typ._tag
+    if     tag == "types.T.Record" or
+           tag == "types.T.Array" or
+           tag == "types.T.Module" or
+           tag == "types.T.Function" or
+           tag == "types.T.Any" or
+           tag == "types.T.Void"
+    then
+        type_error(exp.loc,
+          "Can't assign module field to '%s'", types.tostring(typ))
+    end
+end
 -- If the last expression in @rhs is a function call that returns multiple values, add ExtraRet
 -- nodes to the end of the list.
 function Checker:expand_function_returns(rhs)
@@ -370,40 +412,53 @@ function Checker:expand_function_returns(rhs)
     end
 end
 
-function Checker:check_stat(stat)
+function Checker:check_stat(stat, istoplevel)
     local tag = stat._tag
     if     tag == "ast.Stat.Decl" then
 
         self:expand_function_returns(stat.exps)
 
         for i, decl in ipairs(stat.decls) do
-            stat.exps[i] =
-                self:check_initializer_exp(
-                    decl, stat.exps[i],
-                    "declaration of local variable %s", decl.name)
+            if not (decl._type and decl._type._tag == "types.T.Module") then
+                stat.exps[i] =
+                    self:check_initializer_exp(
+                        decl, stat.exps[i],
+                        "declaration of local variable %s", decl.name)
+            end
         end
 
-        for _, decl in ipairs(stat.decls) do
-            self:add_local(decl)
+        for i, decl in ipairs(stat.decls) do
+            local typ = decl._type
+            if decl._modname then
+                self:mod_assign_rhs_type(stat.exps[i])
+            end
+            local not_main_mod = typ and typ._tag ~= "types.T.Module"
+            if istoplevel then
+                if not_main_mod then
+                    self:add_global(decl)
+                end
+            else
+                self:add_local(decl)
+            end
         end
 
     elseif tag == "ast.Stat.Block" then
         self.symbol_table:with_block(function()
             for _, inner_stat in ipairs(stat.stats) do
-                self:check_stat(inner_stat)
+                self:check_stat(inner_stat, false)
             end
         end)
 
     elseif tag == "ast.Stat.While" then
         stat.condition = self:check_exp_synthesize(stat.condition)
         check_type_is_condition(stat.condition, "while loop condition")
-        self:check_stat(stat.block)
+        self:check_stat(stat.block, false)
 
     elseif tag == "ast.Stat.Repeat" then
         assert(stat.block._tag == "ast.Stat.Block")
         self.symbol_table:with_block(function()
             for _, inner_stat in ipairs(stat.block.stats) do
-                self:check_stat(inner_stat)
+                self:check_stat(inner_stat, false)
             end
             stat.condition = self:check_exp_synthesize(stat.condition)
             check_type_is_condition(stat.condition, "repeat-until loop condition")
@@ -441,7 +496,7 @@ function Checker:check_stat(stat)
 
         self.symbol_table:with_block(function()
             self:add_local(stat.decl)
-            self:check_stat(stat.block)
+            self:check_stat(stat.block, false)
         end)
     elseif tag == "ast.Stat.ForIn" then
         local rhs = stat.exps
@@ -511,13 +566,32 @@ function Checker:check_stat(stat)
                 end
                 self:add_local(stat.decls[i])
             end
-            self:check_stat(stat.block)
+            self:check_stat(stat.block, false)
         end)
 
     elseif tag == "ast.Stat.Assign" then
         self:expand_function_returns(stat.exps)
 
         for i = 1, #stat.vars do
+            if stat.vars[i]._tag == "ast.Var.Dot" then
+                if stat.vars[i].exp._tag == "ast.Exp.Var" then
+                    local top_var = stat.vars[i].exp.var
+                    local mod_cname = self.symbol_table:find_symbol(top_var.name)
+                    if mod_cname and mod_cname._tag == "checker.Name.Module" and
+                       mod_cname.is_main_mod then
+                        if #stat.vars > 1 then
+                            type_error(stat.loc,
+                              "Module assignment can only have one element at the lhs")
+                        end
+                        local loc, name = stat.loc, stat.vars[i].name
+                        local decl = ast.Decl.Decl(loc, name, nil)
+                        decl._modname = top_var.name
+                        local newstat = ast.Stat.Decl(loc, {decl}, stat.exps)
+                        stat = newstat
+                        return self:check_stat(stat, istoplevel)
+                    end
+                end
+            end
             stat.vars[i] = self:check_var(stat.vars[i])
             if stat.vars[i]._tag == "ast.Var.Name" then
                 local ntag = stat.vars[i]._name._tag
@@ -555,17 +629,40 @@ function Checker:check_stat(stat)
     elseif tag == "ast.Stat.If" then
         stat.condition = self:check_exp_synthesize(stat.condition)
         check_type_is_condition(stat.condition, "if statement condition")
-        self:check_stat(stat.then_)
-        self:check_stat(stat.else_)
+        self:check_stat(stat.then_, false)
+        self:check_stat(stat.else_, false)
 
     elseif tag == "ast.Stat.Break" then
         -- ok
+
+    elseif tag == "ast.Stat.Func" then
+        local decl = stat.decl
+        stat.value = self:check_exp_verify(stat.value, decl._type, "toplevel function")
 
     else
         typedecl.tag_error(tag)
     end
 
     return stat
+end
+
+function Checker:check_funcname(name, decl)
+    local var = name.var
+    local tag = var._tag
+    decl.name = var.name
+    if tag == "ast.Var.Dot" then
+        if var.exp._tag == "ast.Exp.Var" then
+            if var.exp.var._tag == "ast.Var.Name" then
+                local mod_cname = self.symbol_table:find_symbol(var.exp.var.name)
+                if not mod_cname or mod_cname._tag ~= "checker.Name.Module" then
+                    type_error(name.loc, "'%s' is not a module", var.exp.var.name)
+                end
+                name.var = ast.Var.Name(name.loc, var.name)
+                decl._modname = var.exp.var.name
+            end
+        end
+    end
+    self:add_function(decl)
 end
 
 function Checker:check_var(var)
@@ -590,9 +687,13 @@ function Checker:check_var(var)
         elseif cname._tag == "checker.Name.Module" then
             -- Module names can appear only in the dot notation.
             -- For example, a statement like `local x = io` is illegal.
-            type_error(var.loc,
-                "cannot reference module name '%s' without dot notation",
-                var.name)
+            if cname.is_main_mod then
+                var._type = types.T.Module()
+            else
+                type_error(var.loc,
+                    "cannot reference module name '%s' without dot notation",
+                    var.name)
+            end
         else
             typedecl.tag_error(cname._tag)
         end
@@ -606,21 +707,36 @@ function Checker:check_var(var)
         end
 
         if mod_cname and mod_cname._tag == "checker.Name.Module" then
-            local module_name = mod_cname.name
-            local function_name = var.name
-            local internal_name = module_name .. "." .. function_name
-
-            local typ = builtins.functions[internal_name]
-            if typ then
+            if mod_cname.is_main_mod then
+                local module_name = mod_cname.name
+                local field_name = var.name
+                local internal_name = module_name .. '.' .. field_name
                 local cname = self.symbol_table:find_symbol(internal_name)
-                local flat_var = ast.Var.Name(var.exp.loc, internal_name)
+                if not cname then
+                    scope_error(var.loc, "variable '%s' is not declared", internal_name)
+                end
+                local flat_var = ast.Var.Name(var.exp.loc, field_name)
                 flat_var._name = cname
-                flat_var._type = typ
+                flat_var._type = cname.decl._type
                 var = flat_var
             else
-                type_error(var.loc,
-                    "unknown function '%s'", internal_name)
+                local module_name = mod_cname.name
+                local function_name = var.name
+                local internal_name = module_name .. "." .. function_name
+
+                local typ = builtins.functions[internal_name]
+                if typ then
+                    local cname = self.symbol_table:find_symbol(internal_name)
+                    local flat_var = ast.Var.Name(var.exp.loc, internal_name)
+                    flat_var._name = cname
+                    flat_var._type = typ
+                    var = flat_var
+                else
+                    type_error(var.loc,
+                        "unknown function '%s'", internal_name)
+                end
             end
+
         else
             var.exp = self:check_exp_synthesize(var.exp)
             local ind_type = var.exp._type
@@ -950,6 +1066,8 @@ function Checker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
                     typedecl.tag_error(ftag)
                 end
             end
+        elseif expected_type._tag == "types.T.Module" then
+            -- Fallthrough to default
 
         elseif types.is_indexable(expected_type) then
             local initialized_fields = {}
@@ -1007,7 +1125,7 @@ function Checker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
                 decl._type = assert(expected_type.arg_types[i])
                 self:add_local(decl)
             end
-            self:check_stat(exp.body)
+            self:check_stat(exp.body, false)
         end)
         table.remove(self.ret_types_stack)
 

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -27,6 +27,7 @@ declare_type("T", {
         "field_names", -- same order as the source type declaration
         "field_types", -- map { string => types.T }
     },
+    Module  = {},
 })
 
 function types.is_gc(t)
@@ -93,7 +94,8 @@ function types.is_indexable(t)
            tag == "types.T.Any" or
            tag == "types.T.String" or
            tag == "types.T.Function" or
-           tag == "types.T.Array"
+           tag == "types.T.Array" or
+           tag == "types.T.Module"
     then
         return false
 
@@ -140,7 +142,8 @@ local function equivalent(t1, t2, is_gradual)
            tag1 == "types.T.Boolean" or
            tag1 == "types.T.Integer" or
            tag1 == "types.T.Float" or
-           tag1 == "types.T.String"
+           tag1 == "types.T.String" or
+           tag1 == "types.T.Module"
     then
         return true
 
@@ -230,6 +233,7 @@ function types.tostring(t)
     elseif tag == "types.T.Integer"     then return "integer"
     elseif tag == "types.T.Float"       then return "float"
     elseif tag == "types.T.String"      then return "string"
+    elseif tag == "types.T.Module"      then return "module"
     elseif tag == "types.T.Function" then
         return string.format("function type %s -> %s",
             join_type_list(t.arg_types), join_type_list(t.ret_types))

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1031,4 +1031,79 @@ describe("Pallene type checker", function()
         ]],
         "cannot reference module name 'io' without dot notation")
     end)
+    it("check if module variable is not declared", function()
+        assert_error([[
+            local function f()
+                local x = 2.5
+            end
+        ]],
+        "type error: Program has no module variable")
+    end)
+    it("forbid declarion of two module variables", function()
+        assert_error([[
+            local m: module = {}
+            local n: module = {}
+            function m.f()
+                local x = 2.5
+            end
+            return m
+        ]],
+        "type error: There can only be one module variable per program")
+    end)
+    it("forbid return of more than one variable", function()
+        assert_error([[
+            local m: module = {}
+            local i: integer = 2
+            function m.f()
+                local x = 2.5
+            end
+            return m, n
+        ]],
+        "type error: returning 2 value(s) but function expects 1")
+    end)
+    it("forbid return of any variable of type other then module", function()
+        assert_error([[
+            local m: module = {}
+            local i: integer = 2
+            function m.f()
+                local x = 2.5
+            end
+            return i
+        ]],
+        "type error: expected module but found integer in return statement")
+    end)
+    it("forbid assignment of Record as module field", function()
+        assert_error([[
+            record Point
+                x: integer
+                y: integer
+            end
+            local p: Point = {x = 12, y = 7}
+            local m: module = {}
+            m.p = p
+            return m
+        ]],
+        "type error: Can't assign module field to 'Point'")
+    end)
+    it("forbid assignment of Array as module field", function()
+        assert_error([[
+            local arr: {integer} = {1, 2, 6, -10}
+            local m: module = {}
+            m.arr = arr
+            return m
+        ]],
+        "type error: Can't assign module field to '{ integer }'")
+    end)
+    it("forbid assignment of any as module field", function()
+        assert_error([[
+            local a: any
+            local m: module = {}
+            m.a = a
+            return m
+        ]],
+        "type error: Can't assign module field to 'any'")
+    end)
+    it("forbid empty program", function()
+        assert_error([[]], "type error: Empty modules are not permitted")
+    end)
 end)

--- a/spec/pallenec_spec.lua
+++ b/spec/pallenec_spec.lua
@@ -3,9 +3,11 @@ local util = require "pallene.util"
 describe("pallenec", function()
     before_each(function()
         util.set_file_contents("__test__.pln", [[
-            export function f(x:integer): integer
+            local m: module = {}
+            function m.f(x:integer): integer
                 return x + 17
             end
+            return m
         ]])
         util.set_file_contents("__test__script__.lua", [[
             local test = require "__test__"

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -62,204 +62,259 @@ describe("Pallene to Lua translator / #translator", function ()
         "type 'unknown' is not declared")
     end)
 
-    it("empty input results in an empty result", function ()
-        assert_translation("", "")
-    end)
-
     it("copy the program as is when there are no type annotations", function ()
         assert_translation(
 [[
+local m: module = {}
 local i = 10
 local function print_hello()
     -- This is a comment.
     -- This is another line comment.
     io.write("Hello, world!")
 end
+return m
 ]],
 [[
-local i, print_hello;i = 10
+local m, i, print_hello;m = {}
+i = 10
 function print_hello()
     -- This is a comment.
     -- This is another line comment.
     io.write("Hello, world!")
 end
+return m
 ]])
     end)
 
     it("Remove #type annotations from a top-level variable", function ()
         assert_translation(
 [[
+local m: module = {}
 local xs: integer = 10
+return m
 ]],
 [[
-local xs;xs = 10
+local m, xs;m = {}
+xs = 10
+return m
 ]])
     end)
 
     it("Remove #type annotations from top-level variables", function ()
         assert_translation(
 [[
+local m: module = {}
 local a: integer, b: integer, c: string = 5, 3, 'Marshall Mathers'
+return m
 ]],
 [[
-local a, b, c;a, b, c = 5, 3, 'Marshall Mathers'
+local m, a, b, c;m = {}
+a, b, c = 5, 3, 'Marshall Mathers'
+return m
 ]])
     end)
 
     it("Keep newlines that appear after the colon in a top-level variable type annotation", function ()
         assert_translation(
 [[
+local m: module = {}
 local xs:
     integer = 10
+return m
 ]],
 [[
-local xs;xs
+local m, xs;m = {}
+xs
  = 10
+return m
 ]])
     end)
 
     it("Keep newlines that appear inside a top-level variable type annotation", function ()
         assert_translation(
 [[
+local m: module = {}
 local a: {
     integer
 } = { 5, 3, 19 }
+return m
 ]],
 [[
-local a;a
+local m, a;m = {}
+a
 
  = { 5, 3, 19 }
+return m
 ]])
     end)
 
     it("Keep tabs that appear in a top-level variable type annotation", function ()
         assert_translation(
-            "local xs:\tinteger = 10\n",
-            "local xs;xs = 10\n")
+            "local m: module = {} local xs:\tinteger = 10\treturn m",
+            "local m, xs;m = {}xs = 10\treturn m")
     end)
 
     it("Keep return carriages that appear in a top-level variable type annotation", function ()
         assert_translation(
-            "local xs:\rinteger = 10\n",
-            "local xs;xs\r = 10\n")
+            "local m: module = {} local xs:\rinteger = 10\treturn m\n",
+            "local m, xs;m = {}xs\r = 10\treturn m\n")
     end)
 
     it("Keep newlines that appear after colons in top-level variable type annotations", function ()
         assert_translation(
 [[
+local m: module = {}
 local a:
     integer, b:
         string, c:
             integer = 53, 'Madyanam', 19
+return m
 ]],
 [[
-local a, b, c;a
+local m, a, b, c;m = {}
+a
 , b
 , c
  = 53, 'Madyanam', 19
+return m
 ]])
     end)
 
     it("Keep comments that appear after the colon in a top-level variable type annotation", function ()
         assert_translation(
 [[
+local m: module = {}
 local xs: -- This is a comment.
     integer = 10
+return m
 ]],
 [[
-local xs;xs-- This is a comment.
+local m, xs;m = {}
+xs-- This is a comment.
  = 10
+return m
 ]])
     end)
 
     it("Keep comments that appear outside type annotations", function ()
         assert_translation([[
 -- Knock knock
+local m: module = {}
 local x: { -- Who's there?
     integer -- Baby Yoda
 } = { 5, 3, 19 } -- Baby Yoda who?
 -- Baby Yoda one for me. XD
+local xs: { -- This is a comment.
+    integer -- This is another comment.
+} = { 5, 3, 19 }
+return m
 ]],
 [[
-local x;-- Knock knock
+local m, x, xs;-- Knock knock
+m = {}
 x-- Who's there?
 -- Baby Yoda
- = { 5, 3, 19 } -- Baby Yoda who?
+ = { 5, 3, 19 }-- Baby Yoda who?
 -- Baby Yoda one for me. XD
+xs-- This is a comment.
+-- This is another comment.
+ = { 5, 3, 19 }
+return m
 ]])
     end)
 
     it("Keep comments that appear inside in a top-level variable type annotation", function ()
         assert_translation(
 [[
+local m: module = {}
 local xs: { -- This is a comment.
     integer -- This is another comment.
 } = { 5, 3, 19 }
+return m
 ]],
 [[
-local xs;xs-- This is a comment.
+local m, xs;m = {}
+xs-- This is a comment.
 -- This is another comment.
  = { 5, 3, 19 }
+return m
 ]])
     end)
 
     it("Remove type annotations from top-level function parameters", function ()
         assert_translation(
 [[
+local m: module = {}
 local function f(x: integer, y: integer)
 end
+return m
 ]],
 [[
-local f;function f(x, y)
+local m, f;m = {}
+function f(x, y)
 end
+return m
 ]])
     end)
 
     it("Remove type annotations from local variable declarations", function ()
         assert_translation(
 [[
+local m: module = {}
 local function f()
     local i: integer = 5
 end
+return m
 ]],
 [[
-local f;function f()
+local m, f;m = {}
+function f()
     local i = 5
 end
+return m
 ]])
     end)
 
     it("Remove type annotations when multiple variables are declared together", function ()
         assert_translation(
 [[
+local m: module = {}
 local function f()
     local a: string, m: string = "preets", "yoda"
 end
+return m
 ]],
 [[
-local f;function f()
+local m, f;m = {}
+function f()
     local a, m = "preets", "yoda"
 end
+return m
 ]])
     end)
 
     it("Remove type annotations when multiple variables are declared together", function ()
         assert_translation(
 [[
+local m: module = {}
 local function f()
     local a, m: string = "preets", "yoda"
 end
+return m
 ]],
 [[
-local f;function f()
+local m, f;m = {}
+function f()
     local a, m = "preets", "yoda"
 end
+return m
 ]])
     end)
 
     it("Remove simple type aliases", function ()
         assert_translation(
 [[
+local m: module = {}
 local function a()
 end
 
@@ -267,21 +322,25 @@ typealias int = integer
 
 local function b()
 end
+return m
 ]],
 [[
-local a, b;function a()
+local m, a, b;m = {}
+function a()
 end
 
 
 
 function b()
 end
+return m
 ]])
     end)
 
     it("Remove multiline type aliases", function ()
         assert_translation(
 [[
+local m: module = {}
 local function a()
 end
 
@@ -292,9 +351,11 @@ typealias point = {
 
 local function b()
 end
+return m
 ]],
 [[
-local a, b;function a()
+local m, a, b;m = {}
+function a()
 end
 
 
@@ -304,12 +365,14 @@ end
 
 function b()
 end
+return m
 ]])
     end)
 
     it("Remove records", function ()
         assert_translation(
 [[
+local m: module = {}
 local function a()
 end
 
@@ -320,9 +383,11 @@ end
 
 local function b()
 end
+return m
 ]],
 [[
-local a, b;function a()
+local m, a, b;m = {}
+function a()
 end
 
 
@@ -332,240 +397,275 @@ end
 
 function b()
 end
+return m
 ]])
     end)
 
     it("Remove return type", function ()
         assert_translation(
 [[
+local m: module = {}
 local function a(): integer
     return 0
 end
+return m
 ]],
 [[
-local a;function a()
+local m, a;m = {}
+function a()
     return 0
 end
+return m
 ]])
     end)
 
     it("Remove return types", function ()
         assert_translation(
 [[
+local m: module = {}
 local function a(): ( integer, string )
     return 0, "Kush"
 end
+return m
 ]],
 [[
-local a;function a()
+local m, a;m = {}
+function a()
     return 0, "Kush"
 end
+return m
 ]])
     end)
 
     it("Generate return statement for exported variable", function ()
         assert_translation(
 [[
-export i: integer = 0
+local m: module = {}
+m.i = 0
+return m
 ]],
 [[
-local i;i = 0
-
-return {
-    i = i,
-}
+local m;m = {}
+m.i = 0
+return m
 ]])
     end)
 
     it("Generate return statement for exported function", function ()
         assert_translation(
 [[
-export function f()
+local m: module = {}
+function m.f()
 end
+return m
 ]],
 [[
-local f;function f()
+local m;m = {}
+function m.f()
 end
-
-return {
-    f = f,
-}
+return m
 ]])
     end)
 
     it("Generate the same return statement for both exported functions and variables", function ()
         assert_translation(
 [[
-export i: integer = 0
-
-export function f()
+local m: module = {}
+m.i = 0
+function m.f()
 end
+return m
 ]],
 [[
-local i, f;i = 0
-
-function f()
+local m;m = {}
+m.i = 0
+function m.f()
 end
-
-return {
-    i = i,
-    f = f,
-}
+return m
 ]])
     end)
 
     it("Do not include local symbols in the module return statement", function ()
         assert_translation(
 [[
-export i: integer = 0
+local m: module = {}
+m.i = 0
 
-export function a()
+function m.a()
 end
 
-local function s()
+function m.s()
 end
 
 local j: { integer } = { 1, 2, 3 }
+return m
 ]],
 [[
-local i, a, s, j;i = 0
+local m, j;m = {}
+m.i = 0
 
-function a()
+function m.a()
 end
 
-function s()
+function m.s()
 end
 
 j = { 1, 2, 3 }
-
-return {
-    i = i,
-    a = a,
-}
+return m
 ]])
     end)
 
     it("Mutually recursive functions (infinite)", function ()
         assert_translation(
 [[
+local m: module = {}
 local function a()
     b()
 end
-
 local function b()
     a()
 end
+return m
 ]],
 [[
-local a, b;function a()
+local m, a, b;m = {}
+function a()
     b()
 end
-
 function b()
     a()
 end
-]])
+return m
+]]
+)
     end)
 
     it("Remove any type annotation", function ()
         assert_translation(
 [[
+local m: module = {}
 local xs: {any} = {10, "hello", 3.14}
 
 local function f(x: any, y: any): any
 end
+
+return m
 ]],
 [[
-local xs, f;xs = {10, "hello", 3.14}
+local m, xs, f;m = {}
+xs = {10, "hello", 3.14}
 
 function f(x, y)
 end
+
+return m
 ]])
     end)
 
     it("Remove function shapes", function ()
         assert_translation(
 [[
+local m: module = {}
 local function invoke(x: (integer, integer) -> (float, float)): (float, float)
     return x(1, 2)
 end
+return m
 ]],
 [[
-local invoke;function invoke(x)
+local m, invoke;m = {}
+function invoke(x)
     return x(1, 2)
 end
+return m
 ]])
     end)
 
     it("Remove casts from initializer list", function ()
         assert_translation(
 [[
+local m: module = {}
 typealias point = {
     x: integer,
     y: integer
 }
 local i: any = 1
 local p: point = { x = i as integer, y = i as integer }
+return m
 ]],
 [[
-local i, p;
+local m, i, p;m = {}
+
 
 
 
 i = 1
 p = { x = i, y = i }
+return m
 ]])
     end)
 
     it("Remove casts from toplevel variables", function ()
         assert_translation(
 [[
+local m: module = {}
 local i: any = 1
 local j: integer = i as integer
+return m
 ]],
 [[
-local i, j;i = 1
+local m, i, j;m = {}
+i = 1
 j = i
+return m
 ]])
     end)
 
     it("Remove redundant casts from toplevel variables", function ()
         assert_translation(
 [[
+local m: module = {}
 local i: any = 1
 local j: integer = i as integer
 local k: integer = (j as integer) + 1
+return m
 ]],
 [[
-local i, j, k;i = 1
+local m, i, j, k;m = {}
+i = 1
 j = i
 k = (j) + 1
+return m
 ]])
     end)
 
     it("Remove casts from if condition", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
     if k as boolean then
     end
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     if k then
     end
 end
+return m
 ]])
     end)
 
     it("Remove casts from if body", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
@@ -573,21 +673,25 @@ local function f()
         local j: boolean = k as boolean
     end
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     if true then
         local j = k
     end
 end
+return m
 ]])
     end)
 
     it("Remove casts from else if condition", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
@@ -597,9 +701,11 @@ local function f()
         -- Nothing
     end
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     if false then
@@ -608,12 +714,14 @@ function f()
         -- Nothing
     end
 end
+return m
 ]])
     end)
 
     it("Remove casts from else if body", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
@@ -623,9 +731,11 @@ local function f()
         local j: integer = k as integer
     end
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     if false then
@@ -634,12 +744,14 @@ function f()
         local j = k
     end
 end
+return m
 ]])
     end)
 
     it("Remove casts from else body", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
@@ -649,9 +761,11 @@ local function f()
         local j: integer = k as integer
     end
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     if false then
@@ -660,12 +774,14 @@ function f()
         local j = k
     end
 end
+return m
 ]])
     end)
 
     it("Remove casts from repeat condition", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
@@ -673,21 +789,25 @@ local function f()
         -- Nothing
     until k as boolean
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     repeat
         -- Nothing
     until k
 end
+return m
 ]])
     end)
 
     it("Remove casts from repeat body", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
@@ -695,21 +815,25 @@ local function f()
         local j: integer = k as integer
     until true
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     repeat
         local j = k
     until true
 end
+return m
 ]])
     end)
 
     it("Remove casts from for expressions", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
@@ -717,21 +841,25 @@ local function f()
         -- Nothing
     end
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     for j = k, k + 10, k do
         -- Nothing
     end
 end
+return m
 ]])
     end)
 
     it("Remove casts from for body", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
@@ -739,225 +867,277 @@ local function f()
         local m: integer = k as integer
     end
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     for j = 1, 10 do
         local m = k
     end
 end
+return m
 ]])
     end)
 
     it("Remove casts from assignments", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
     k, k = k as integer, k as boolean
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     k, k = k, k
 end
+return m
 ]])
     end)
 
     it("Remove casts in nested casts", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
     k = ((k as integer) as integer)
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     k = ((k))
 end
+return m
 ]])
     end)
 
     it("Remove casts from local variable declarations", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = 1
 
 local function f()
     local j: integer = k as integer
 end
+return m
 ]],
 [[
-local k, f;k = 1
+local m, k, f;m = {}
+k = 1
 
 function f()
     local j = k
 end
+return m
 ]])
     end)
 
     it("Remove casts from function calls", function ()
         assert_translation(
 [[
+local m: module = {}
 local k: any = "Madyanam"
 
 local function f()
     io.write(k as string)
 end
+return m
 ]],
 [[
-local k, f;k = "Madyanam"
+local m, k, f;m = {}
+k = "Madyanam"
 
 function f()
     io.write(k)
 end
+return m
 ]])
     end)
 
     it("Remove casts from function calls", function ()
         assert_translation(
 [[
+local m: module ={}
 local name1: any = "Anushka"
 local name2: any = "Samuel"
 
 local function get_names(): (string, string)
     return name1 as string, name2 as string
 end
+return m
 ]],
 [[
-local name1, name2, get_names;name1 = "Anushka"
+local m, name1, name2, get_names;m ={}
+name1 = "Anushka"
 name2 = "Samuel"
 
 function get_names()
     return name1, name2
 end
+return m
 ]])
     end)
 
     it("Keep the strings quotes as is", function ()
         assert_translation(
 [[
+local m: module = {}
 local function print_hello()
     io.write('Hello, ')
     io.write("world!")
 end
+return m
 ]],
 [[
-local print_hello;function print_hello()
+local m, print_hello;m = {}
+function print_hello()
     io.write('Hello, ')
     io.write("world!")
 end
+return m
 ]])
     end)
 
     it("Remove return type annotations", function ()
         assert_translation(
 [[
+local m: module = {}
 local function get_numbers(): ( integer, integer )
     return 53, 519
 end
+return m
 ]],
 [[
-local get_numbers;function get_numbers()
+local m, get_numbers;m = {}
+function get_numbers()
     return 53, 519
 end
+return m
 ]])
     end)
 
     it("Remove parameter and return type annotations", function ()
         assert_translation(
 [[
+local m: module = {}
 local function add(x: integer, y: integer): integer
     return x + y
 end
+return m
 ]],
 [[
-local add;function add(x, y)
+local m, add;m = {}
+function add(x, y)
     return x + y
 end
+return m
 ]])
     end)
 
     it("Remove local variable type annotations.", function ()
         assert_translation(
 [[
+local m: module = {}
 local function f()
     local x: integer = 10
     local y: integer = 20
     local z: integer = x + y
 end
+return m
 ]],
 [[
-local f;function f()
+local m, f;m = {}
+function f()
     local x = 10
     local y = 20
     local z = x + y
 end
+return m
 ]])
     end)
 
     it("Expressions are copied as is", function ()
         assert_translation(
 [[
+local m: module = {}
 local x = (1 + 2) * (100 / 30)
+return m
 ]],
 [[
-local x;x = (1 + 2) * (100 / 30)
+local m, x;m = {}
+x = (1 + 2) * (100 / 30)
+return m
 ]])
     end)
 
     it("While statements", function ()
         assert_translation(
 [[
+local m: module = {}
 local function count()
     local i: integer = 1
     while i <= 10 do
         i = i + 1
     end
 end
+return m
 ]],
 [[
-local count;function count()
+local m, count;m = {}
+function count()
     local i = 1
     while i <= 10 do
         i = i + 1
     end
 end
+return m
 ]])
     end)
 
     it("Do Statement", function ()
         assert_translation(
 [[
+local m: module = {}
 local function f()
     local i: integer = 10
     do
         local i: integer = 20
     end
 end
+return m
 ]],
 [[
-local f;function f()
+local m, f;m = {}
+function f()
     local i = 10
     do
         local i = 20
     end
 end
+return m
 ]])
     end)
 
     it("If statement", function ()
         assert_translation(
 [[
+local m: module = {}
 local function is_even(n: integer): boolean
     if (n % 2) == 0 then
         return true
@@ -965,31 +1145,38 @@ local function is_even(n: integer): boolean
         return false
     end
 end
+return m
 ]],
 [[
-local is_even;function is_even(n)
+local m, is_even;m = {}
+function is_even(n)
     if (n % 2) == 0 then
         return true
     else
         return false
     end
 end
+return m
 ]])
     end)
 
     it("For statement", function ()
         assert_translation(
 [[
+local m: module = {}
 local function f()
     for i: integer = 1, 10 do
     end
 end
+return m
 ]],
 [[
-local f;function f()
+local m, f;m = {}
+function f()
     for i = 1, 10 do
     end
 end
+return m
 ]])
     end)
 end)

--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -18,14 +18,17 @@ describe("Uninitialized variable analysis: ", function()
 
     it("empty function", function()
         assert_error([[
-            export function fn(): integer
+            local m: module = {}
+            function m.fn(): integer
             end
+            return m
         ]], missing_return)
     end)
 
     it("missing return in elseif", function()
         assert_error([[
-            export function getval(a:integer): integer
+            local m: module = {}
+            function m.getval(a:integer): integer
                 if a == 1 then
                     return 10
                 elseif a == 2 then
@@ -33,12 +36,14 @@ describe("Uninitialized variable analysis: ", function()
                     return 30
                 end
             end
+            return m
         ]], missing_return)
     end)
 
     it("missing return in deep elseif", function()
         assert_error([[
-            export function getval(a:integer): integer
+            local m: module = {}
+            function m.getval(a:integer): integer
                 if a == 1 then
                     return 10
                 elseif a == 2 then
@@ -53,21 +58,25 @@ describe("Uninitialized variable analysis: ", function()
                     end
                 end
             end
+            return m
         ]], missing_return)
     end)
 
     it("catches use of uninitialized variable", function()
         assert_error([[
-            export function foo(): integer
+            local m: module = {}
+            function m.foo(): integer
                 local x:integer
                 return x
             end
+            return m
         ]], "variable 'x' is used before being initialized")
     end)
 
     it("assumes that loops might not execute", function()
         assert_error([[
-            export function foo(cond: boolean): integer
+            local m: module = {}
+            function m.foo(cond: boolean): integer
                 local x: integer
                 while cond do
                     x = 0
@@ -75,6 +84,7 @@ describe("Uninitialized variable analysis: ", function()
                 end
                 return x
             end
+            return m
         ]], "variable 'x' is used before being initialized")
     end)
 end)


### PR DESCRIPTION
Instead of exporting variables and functions by means of the `export` keyword, this PR implements a different approach, similar to the one Lua uses, that is, if you want to export variables or functions in your program, you should create a variable of type `module` and return it at the end of the program.
Example:

```
local m: module = {}
m.var = 22.0
return m
```

Other examples are available at the `examples` folder in this PR.
