### PR TITLE
Added appropriate error messages for for-in loops.

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -471,8 +471,8 @@ function Checker:check_stat(stat)
         if not types.equals(iteratorfn._type, itertype) then
             if iteratorfn._type._tag == "types.T.Function" and
                #decl_types ~= #iteratorfn._type.ret_types then
-                local decl_count            = #decl_types
-                local expected_decl_count   = #iteratorfn._type.ret_types
+                local decl_count          = #decl_types
+                local expected_decl_count = #iteratorfn._type.ret_types
 
                 if expected_decl_count == 1 then
                     type_error(iteratorfn.loc, "expected 1 declaration in for loop but found %d.",

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -471,16 +471,8 @@ function Checker:check_stat(stat)
         if not types.equals(iteratorfn._type, itertype) then
             if iteratorfn._type._tag == "types.T.Function" and
                #decl_types ~= #iteratorfn._type.ret_types then
-                local decl_count          = #decl_types
-                local expected_decl_count = #iteratorfn._type.ret_types
-
-                if expected_decl_count == 1 then
-                    type_error(iteratorfn.loc, "expected 1 declaration in for loop but found %d.",
-                        decl_count)
-                else
-                    type_error(iteratorfn.loc, "expected %d declarations in for loop but found %d.",
-                        expected_decl_count, decl_count)
-                end
+                type_error(iteratorfn.loc, "expected %d variable(s) in for loop but found %d",
+                    #iteratorfn._type.ret_types, #decl_types)
             else
                 type_error(iteratorfn.loc, "expected %s but found %s in loop iterator",
                     types.tostring(itertype), types.tostring(iteratorfn._type))

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -459,18 +459,32 @@ function Checker:check_stat(stat)
             type_error(rhs[1].loc, "missing control variable in for-in loop")
         end
 
-        local expected_ret_types = {}
+        local decl_types = {}
         for _ = 1, #stat.decls do
-            table.insert(expected_ret_types, types.T.Any())
+            table.insert(decl_types, types.T.Any())
         end
 
-        local itertype = types.T.Function({ types.T.Any(), types.T.Any() }, expected_ret_types)
+        local itertype = types.T.Function({ types.T.Any(), types.T.Any() }, decl_types)
         rhs[1] = self:check_exp_synthesize(rhs[1])
         local iteratorfn = rhs[1]
 
         if not types.equals(iteratorfn._type, itertype) then
-            type_error(iteratorfn.loc, "expected %s but found %s in loop iterator",
-                types.tostring(itertype), types.tostring(iteratorfn._type))
+            if iteratorfn._type._tag == "types.T.Function" and
+               #decl_types ~= #iteratorfn._type.ret_types then
+                local decl_count            = #decl_types
+                local expected_decl_count   = #iteratorfn._type.ret_types
+
+                if expected_decl_count == 1 then
+                    type_error(iteratorfn.loc, "expected 1 declaration in for loop but found %d.",
+                        decl_count)
+                else
+                    type_error(iteratorfn.loc, "expected %d declarations in for loop but found %d.",
+                        expected_decl_count, decl_count)
+                end
+            else
+                type_error(iteratorfn.loc, "expected %s but found %s in loop iterator",
+                    types.tostring(itertype), types.tostring(iteratorfn._type))
+            end
         end
 
         rhs[2] = self:check_exp_synthesize(rhs[2])

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -306,7 +306,19 @@ describe("Pallene type checker", function()
         "expected function type (any, any) -> (any, any) but found integer in loop iterator")
 
         assert_error([[
+            export function foo(a: integer, b: integer): integer
+                return a * b
+            end
 
+            export function fn()
+                for k, v in foo, 1, 2 do
+                    local a = k + v
+                end
+            end
+        ]],
+        "expected 1 declaration in for loop but found 2")
+
+        assert_error([[
             export function foo(a: integer, b: integer): integer
                 return a * b
             end
@@ -316,7 +328,7 @@ describe("Pallene type checker", function()
                     k = v
                 end
             end
-        ]], "expected function type (any, any) -> (any, any) but found function type (integer, integer) -> (integer) in loop iterator")
+        ]], "expected 1 declaration in for loop but found 2")
     end)
 
     it("type checks the state and control values of for-in loops", function()
@@ -389,7 +401,7 @@ describe("Pallene type checker", function()
                     local k = z
                 end
             end
-        ]], "type error: expected function type (any, any) -> (any, any, any) but found function type (any, any) -> (any, any) in loop iterator")
+        ]], "expected 2 declarations in for loop but found 3")
 
         assert_error([[
             export function fn()
@@ -397,7 +409,7 @@ describe("Pallene type checker", function()
                     local k = z
                 end
             end
-        ]], "type error: expected function type (any, any) -> (any) but found function type (any, any) -> (any, any) in loop iterator")
+        ]], "expected 2 declarations in for loop but found 1")
     end)
 
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -316,7 +316,7 @@ describe("Pallene type checker", function()
                 end
             end
         ]],
-        "expected 1 declaration in for loop but found 2")
+        "expected 1 variable(s) in for loop but found 2")
 
         assert_error([[
             export function foo(a: integer, b: integer): integer
@@ -328,7 +328,7 @@ describe("Pallene type checker", function()
                     k = v
                 end
             end
-        ]], "expected 1 declaration in for loop but found 2")
+        ]], "expected 1 variable(s) in for loop but found 2")
     end)
 
     it("type checks the state and control values of for-in loops", function()
@@ -385,7 +385,7 @@ describe("Pallene type checker", function()
                     local x = i
                 end
             end
-        ]], "type error: function expects 1 argument(s) but received 0")
+        ]], "function expects 1 argument(s) but received 0")
 
         assert_error([[
             export function fn()
@@ -393,7 +393,7 @@ describe("Pallene type checker", function()
                     local k = i
                 end
             end
-        ]], "type error: function expects 1 argument(s) but received 2")
+        ]], "function expects 1 argument(s) but received 2")
 
         assert_error([[
             export function fn()
@@ -401,7 +401,7 @@ describe("Pallene type checker", function()
                     local k = z
                 end
             end
-        ]], "expected 2 declarations in for loop but found 3")
+        ]], "expected 2 variable(s) in for loop but found 3")
 
         assert_error([[
             export function fn()
@@ -409,7 +409,7 @@ describe("Pallene type checker", function()
                     local k = z
                 end
             end
-        ]], "expected 2 declarations in for loop but found 1")
+        ]], "expected 2 variable(s) in for loop but found 1")
     end)
 
 


### PR DESCRIPTION
This PR addresses #348, and issue which was left over after the introduction of `ipairs` and for-in loops.
Instead of throwing a confusing error message like so: 
```
type error: expected function type (any, any) -> (any) but found function type (any, any) -> (any, any) in loop iterator
```
The checker now throws a more comprehensible error.
```
expected 2 declarations in for loop but found 1. 
```

Currently this error is thrown for both `ipairs` and non-ipairs for-in loops.
If the return count of the iterator function doesn't match the number of declarations in the loop LHS, a shorter error is thrown as
demonstrated above.

For all other kinds of mismatches (incorrect arg count, types), the usual type mismatch error is thrown.