### PR TITLE
Allow module names to be used as type names

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -122,7 +122,7 @@ declare_type("Name", {
     Global   = { "decl" },
     Function = { "decl" },
     Builtin  = { "name" },
-    Module   = { "name", "is_main_mod", "shadowed_type"}
+    Module   = { "name", "is_main_mod", "shadowed_symbol"}
 })
 -- TODO: add a comment explaining the Module case
 
@@ -165,19 +165,10 @@ end
 
 function Checker:add_module(name, is_main_mod)
     assert(type(name) == "string")
-
     -- To allow the name "string" to be used both as a module name and as a type name, module
     -- symbols are aware of the type that they are shadowing.
-    local curr = self.symbol_table:find_symbol(name)
-
-    local shadowed_type
-    if curr and curr._tag == "checker.Name.Type" then
-        shadowed_type = curr
-    else
-        shadowed_type = false
-    end
-
-    self.symbol_table:add_symbol(name, checker.Name.Module(name, is_main_mod, shadowed_type))
+    local shadowed_symbol = self.symbol_table:find_symbol(name)
+    self.symbol_table:add_symbol(name, checker.Name.Module(name, is_main_mod, shadowed_symbol))
 end
 
 --
@@ -197,8 +188,8 @@ function Checker:from_ast_type(ast_typ)
         elseif cname._tag == "checker.Name.Type" then
             return cname.typ
         elseif cname._tag == "checker.Name.Module" then
-            if cname.shadowed_type then
-                return cname.shadowed_type.typ
+            if cname.shadowed_symbol and cname.shadowed_symbol._tag == "checker.Name.Type" then
+                return cname.shadowed_symbol.typ
             else
                 -- fallthrough
             end

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -122,8 +122,9 @@ declare_type("Name", {
     Global   = { "decl" },
     Function = { "decl" },
     Builtin  = { "name" },
-    Module   = { "name", "is_main_mod" }
+    Module   = { "name", "is_main_mod", "shadowed_type"}
 })
+-- TODO: add a comment explaining the Module case
 
 function Checker:add_type(name, typ)
     assert(typedecl.match_tag(typ._tag, "types.T"))
@@ -164,7 +165,19 @@ end
 
 function Checker:add_module(name, is_main_mod)
     assert(type(name) == "string")
-    self.symbol_table:add_symbol(name, checker.Name.Module(name, is_main_mod))
+
+    -- To allow the name "string" to be used both as a module name and as a type name, module
+    -- symbols are aware of the type that they are shadowing.
+    local curr = self.symbol_table:find_symbol(name)
+
+    local shadowed_type
+    if curr and curr._tag == "checker.Name.Type" then
+        shadowed_type = curr
+    else
+        shadowed_type = false
+    end
+
+    self.symbol_table:add_symbol(name, checker.Name.Module(name, is_main_mod, shadowed_type))
 end
 
 --
@@ -183,13 +196,16 @@ function Checker:from_ast_type(ast_typ)
             scope_error(ast_typ.loc,  "type '%s' is not declared", name)
         elseif cname._tag == "checker.Name.Type" then
             return cname.typ
-        elseif cname._tag == "checker.Name.Module" and cname.name == "string" then
-            -- Currently the string type appears in the scope as a module because of functions like
-            -- string.char and string.sub. In the future we might want to consider extending this
-            -- feature to other modules that also count as types.
-            return types.T.String()
+        elseif cname._tag == "checker.Name.Module" then
+            if cname.shadowed_type then
+                return cname.shadowed_type.typ
+            else
+                -- fallthrough
+            end
+        else
+            -- fallthrough
         end
-        type_error(ast_typ.loc, "'%s' isn't a type", name)
+        type_error(ast_typ.loc, "'%s' is not a type", name)
 
     elseif tag == "ast.Type.Array" then
         local subtype = self:from_ast_type(ast_typ.subtype)
@@ -238,7 +254,7 @@ function Checker:check_program(prog_ast)
     self:add_type("boolean", types.T.Boolean())
     self:add_type("float",   types.T.Float())
     self:add_type("integer", types.T.Integer())
-    --self:add_type("string",  types.T.String()) -- treated as a "module" because of string.char
+    self:add_type("string",  types.T.String())
 
     -- Add builtins to symbol table. The order does not matter because they are distinct.
     for name, _ in pairs(builtins.functions) do
@@ -367,7 +383,7 @@ function Checker:check_program(prog_ast)
             end
         end
     end
-    
+
     local last_toplevel_node = prog_ast.tls[total_nodes]
     local last_stat = last_toplevel_node.stat
     if last_toplevel_node._tag ~= "ast.Toplevel.Stat" or

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -106,7 +106,7 @@ describe("Scope analysis: ", function()
             local function f()
                 local a, b = 1, a
             end
-            
+
             return m
         ]],
             "variable 'a' is not declared")
@@ -181,7 +181,19 @@ describe("Pallene type checker", function()
 
             return m
         ]],
-            "'foo' isn't a type")
+            "'foo' is not a type")
+    end)
+
+    it("detects when a non-type is used in a type variable", function()
+        assert_error([[
+            local m: module = {}
+            function m.fn()
+                local bar: m = 11
+            end
+
+            return m
+        ]],
+            "'m' is not a type")
     end)
 
     it("detects when a non-value is used in a value variable", function()


### PR DESCRIPTION
This removes a special case for the "string" name, which was present in the scope rules.