### PR TITLE
Remove local m boilerplate from some tests

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -151,7 +151,7 @@ describe("Scope analysis: ", function()
             local x: integer = 0
             return m
         ]],
-            "__test__.pln:2:31: scope error: type 'x' is not declared")
+            "type 'x' is not declared")
     end)
 end)
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -7,31 +7,37 @@ local function run_checker(code)
     return module, table.concat(errs, "\n")
 end
 
-local function assert_error(code, expected_err)
+local function assert_error_unwrapped(code, expected_err)
     local module, errs = run_checker(code)
     assert.falsy(module)
     assert.match(expected_err, errs, 1, true)
+end
+
+local function assert_error(body, expected_err)
+    local code = util.render([[
+        local m: module = {}
+        $body
+        return m
+    ]], {
+        body = body
+    })
+    return assert_error_unwrapped(code, expected_err)
 end
 
 describe("Scope analysis: ", function()
 
     it("forbids variables from being used before they are defined", function()
         assert_error([[
-            local m: module = {}
             function fn(): nil
                 x = 17
                 local x = 18
             end
-
-            return m
         ]],
             "Function must be 'local' or module function")
     end)
 
     it("forbids type variables from being used before they are defined", function()
         assert_error([[
-            local m: module = {}
-
             function m.fn(p: Point): integer
                 return p.x
             end
@@ -40,86 +46,66 @@ describe("Scope analysis: ", function()
                 x: integer
                 y: integer
             end
-
-            return m
         ]],
             "type 'Point' is not declared")
     end)
 
     it("do-end limits variable scope", function()
         assert_error([[
-            local m: module = {}
             function m.fn(): nil
                 do
                     local x = 17
                 end
                 x = 18
             end
-
-            return m
         ]],
             "variable 'x' is not declared")
     end)
 
     it("forbids multiple toplevel declarations with the same name for exported functions", function()
         assert_error([[
-            local m: module = {}
             function m.f() end
             function m.f() end
-
-            return m
         ]],
             "duplicate module field 'f', previous one at line 2")
     end)
 
     it("forbids multiple toplevel declarations with the same name for exported function and variable", function()
         assert_error([[
-            local m: module = {}
             function m.f() end
             m.f = 1
-            return m
         ]],
             "duplicate module field 'f', previous one at line 2")
     end)
 
     it("ensure toplevel variables are not in scope in their initializers", function()
         assert_error([[
-            local m: module = {}
             local a, b = 1, a
-            return m
         ]],
             "variable 'a' is not declared")
     end)
 
     it("ensure toplevel variables are not in scope in their initializers", function()
         assert_error([[
-            local m: module = {}
             local a = a
-            return m
         ]],
             "variable 'a' is not declared")
     end)
 
     it("ensure variables are not in scope in their initializers", function()
         assert_error([[
-            local m: module = {}
             local function f()
                 local a, b = 1, a
             end
-
-            return m
         ]],
             "variable 'a' is not declared")
     end)
 
     it("ensure variables are not in scope in their initializers", function()
         assert_error([[
-            local m: module = {}
             local function f()
                 local a = a
             end
-
-            return m
         ]],
             "variable 'a' is not declared")
     end)
@@ -127,9 +113,6 @@ describe("Scope analysis: ", function()
     it("forbids typealias to non-existent type", function()
         assert_error([[
             typealias point = foo
-
-            local m: module = {}
-            return m
         ]],
             "type 'foo' is not declared")
     end)
@@ -137,19 +120,14 @@ describe("Scope analysis: ", function()
     it("forbids recursive typealias", function()
         assert_error([[
             typealias point = {point}
-
-            local m: module = {}
-            return m
         ]],
             "type 'point' is not declared")
     end)
 
     it("forbids typealias to non-type name", function()
         assert_error([[
-            local m: module = {}
             typealias point = x
             local x: integer = 0
-            return m
         ]],
             "type 'x' is not declared")
     end)
@@ -159,7 +137,6 @@ describe("Pallene type checker", function()
 
     it('catches incompatible function type assignments', function()
         assert_error([[
-            local m: module = {}
             function m.f(a: integer, b: float): float
                 return 3.14
             end
@@ -173,25 +150,19 @@ describe("Pallene type checker", function()
 
     it("detects when a non-type is used in a type variable", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 local foo: integer = 10
                 local bar: foo = 11
             end
-
-            return m
         ]],
             "'foo' is not a type")
     end)
 
     it("detects when a non-type is used in a type variable", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 local bar: m = 11
             end
-
-            return m
         ]],
             "'m' is not a type")
     end)
@@ -203,21 +174,16 @@ describe("Pallene type checker", function()
                 y: integer
             end
 
-            local m: module = {}
             function m.fn()
                 local bar: integer = Point
             end
-
-            return m
         ]],
             "'Point' isn't a value")
     end)
 
     it("catches table type with repeated fields", function()
         assert_error([[
-            local m: module = {}
             function m.fn(t: {x: float, x: integer}) end
-            return m
         ]],
             "duplicate field 'x' in table")
     end)
@@ -234,159 +200,126 @@ describe("Pallene type checker", function()
 
     it("catches array expression in indexing is not an array", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x: integer)
                 x[1] = 2
             end
-            return m
         ]],
             "expected array but found integer in array indexing")
     end)
 
     it("catches wrong use of length operator", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x: integer): integer
                 return #x
             end
-
-            return m
         ]],
             "trying to take the length")
     end)
 
     it("catches wrong use of unary minus", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x: boolean): boolean
                 return -x
             end
-
-            return m
         ]],
             "trying to negate a")
     end)
 
     it("catches wrong use of bitwise not", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x: boolean): boolean
                 return ~x
             end
-
-            return m
         ]],
             "trying to bitwise negate a")
     end)
 
     it("catches wrong use of boolean not", function()
         assert_error([[
-            local m: module = {}
             function m.fn(): boolean
                 return not nil
             end
-
-            return m
         ]],
             "expression passed to 'not' operator has type nil")
     end)
 
     it("catches mismatching types in locals", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 local i: integer = 1
                 local s: string = "foo"
                 s = i
             end
-
-            return m
         ]],
             "expected string but found integer in assignment")
     end)
 
     it("requires a type annotation for an uninitialized variable", function()
         assert_error([[
-            local m: module = {}
             function m.fn(): integer
                 local x
                 x = 10
                 return x
             end
-            return m
         ]], "uninitialized variable 'x' needs a type annotation")
     end)
 
     it("catches mismatching types in arguments", function()
         assert_error([[
-            local m: module = {}
             function m.fn(i: integer, s: string): integer
                 s = i
             end
-            return m
         ]],
             "expected string but found integer in assignment")
     end)
 
     it("forbids empty array (without type annotation)", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 local xs = {}
             end
-            return m
         ]],
             "missing type hint for initializer")
     end)
 
     it("forbids non-empty array (without type annotation)", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 local xs = {10, 20, 30}
             end
-            return m
         ]],
             "missing type hint for initializer")
     end)
 
     it("forbids array initializers with a table part", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 local xs: {integer} = {10, 20, 30, x=17}
             end
-            return m
         ]],
             "named field 'x' in array initializer")
     end)
 
     it("forbids wrong type in array initializer", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 local xs: {integer} = {10, "hello"}
             end
-            return m
         ]],
             "expected integer but found string in array initializer")
     end)
 
     it("type checks the iterator function in for-in loops", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 for k, v in 5, 1, 2 do
                     local a = k + v
                 end
             end
-            return m
         ]],
         "expected function type (any, any) -> (any, any) but found integer in loop iterator")
 
         assert_error([[
-            local m: module = {}
-
             function m.foo(a: integer, b: integer): integer
                 return a * b
             end
@@ -401,7 +334,6 @@ describe("Pallene type checker", function()
 
     it("type checks the state and control values of for-in loops", function()
         assert_error([[
-            local m: module = {}
             function m.foo(): (integer, integer)
                 return 1, 2
             end
@@ -415,12 +347,10 @@ describe("Pallene type checker", function()
                     local a = k + v
                 end
             end
-            return m
         ]],
         "expected any but found integer in loop state value")
 
         assert_error([[
-            local m: module = {}
             function m.iter(a: any, b: any): (any, any)
                 return 1, 2
             end
@@ -430,11 +360,9 @@ describe("Pallene type checker", function()
                     k = v
                 end
             end
-            return m
         ]], "missing state variable in for-in loop")
 
         assert_error([[
-            local m: module = {}
             function m.iter(a: any, b: any): (any, any)
                 return 1, 2
             end
@@ -448,49 +376,40 @@ describe("Pallene type checker", function()
                     k = v
                 end
             end
-            return m
         ]], "missing control variable in for-in loop")
     end)
 
     it("checks loops with ipairs.", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 for i: integer in ipairs() do
                     local x = i
                 end
             end
-            return m
         ]], "function expects 1 argument(s) but received 0")
 
         assert_error([[
-            local m: module = {}
             function m.fn()
                 for i, x in ipairs({1, 2}, {3, 4}) do
                     local k = i
                 end
             end
-            return m
         ]], "function expects 1 argument(s) but received 2")
 
         assert_error([[
-            local m: module = {}
             function m.fn()
                 for i, x, z in ipairs({1, 2}) do
                     local k = z
                 end
             end
-            return m
         ]], "expected 2 variable(s) in for loop but found 3")
 
         assert_error([[
-            local m: module = {}
             function m.fn()
                 for i in ipairs({1, 2}) do
                     local k = z
                 end
             end
-            return m
         ]], "expected 2 variable(s) in for loop but found 1")
     end)
 
@@ -499,13 +418,11 @@ describe("Pallene type checker", function()
         local function assert_init_error(typ, code, err)
             typ = typ and (": " .. typ) or ""
             assert_error([[
-                local m: module = {}
                 record Point x: float; y:float end
 
                 function m.f(): float
                     local p ]].. typ ..[[ = ]].. code ..[[
                 end
-                return m
             ]], err)
         end
 
@@ -545,46 +462,39 @@ describe("Pallene type checker", function()
 
     it("forbids type hints that are not array, tables, or records", function()
         assert_error([[
-            local m: module = {}
             function m.fn()
                 local p: string = { 10, 20, 30 }
             end
-            return m
         ]],
             "type hint for initializer is not an array, table, or record type")
     end)
 
     it("requires while statement conditions to be boolean", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x:integer): integer
                 while x do
                     return 10
                 end
                 return 20
             end
-            return m
         ]],
             "expression passed to while loop condition has type integer")
     end)
 
     it("requires repeat statement conditions to be boolean", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x:integer): integer
                 repeat
                     return 10
                 until x
                 return 20
             end
-            return m
         ]],
             "expression passed to repeat-until loop condition has type integer")
     end)
 
     it("requires if statement conditions to be boolean", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x:integer): integer
                 if x then
                     return 10
@@ -592,92 +502,78 @@ describe("Pallene type checker", function()
                     return 20
                 end
             end
-            return m
         ]],
             "expression passed to if statement condition has type integer")
     end)
 
     it("ensures numeric 'for' variable has number type", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x: integer, s: string): integer
                 for i: string = "hello", 10, 2 do
                     x = x + i
                 end
                 return x
             end
-            return m
         ]],
             "expected integer or float but found string in for-loop control variable 'i'")
     end)
 
     it("catches 'for' errors in the start expression", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x: integer, s: string): integer
                 for i:integer = s, 10, 2 do
                     x = x + i
                 end
                 return x
             end
-            return m
         ]],
             "expected integer but found string in numeric for-loop initializer")
     end)
 
     it("catches 'for' errors in the limit expression", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x: integer, s: string): integer
                 for i = 1, s, 2 do
                     x = x + i
                 end
                 return x
             end
-            return m
         ]],
             "expected integer but found string in numeric for-loop limit")
     end)
 
     it("catches 'for' errors in the step expression", function()
         assert_error([[
-            local m: module = {}
             function m.fn(x: integer, s: string): integer
                 for i = 1, 10, s do
                     x = x + i
                 end
                 return x
             end
-            return m
         ]],
             "expected integer but found string in numeric for-loop step")
     end)
 
     it("detects too many return values", function()
         assert_error([[
-            local m: module = {}
             function m.f(): ()
                 return 1
             end
-            return m
         ]],
             "returning 1 value(s) but function expects 0")
     end)
 
     it("detects too few return values", function()
         assert_error([[
-            local m: module = {}
             function m.f(): integer
                 return
             end
-            return m
         ]],
             "returning 0 value(s) but function expects 1")
     end)
 
     it("detects too many return values when returning a function call", function()
         assert_error([[
-            local m: module = {}
             local function f(): (integer, integer)
                 return 1, 2
             end
@@ -685,51 +581,43 @@ describe("Pallene type checker", function()
             function m.g(): integer
                 return f()
             end
-            return m
         ]],
             "returning 2 value(s) but function expects 1")
     end)
 
     it("detects when a function returns the wrong type", function()
         assert_error([[
-            local m: module = {}
             function m.fn(): integer
                 return "hello"
             end
-            return m
         ]],
             "expected integer but found string in return statement")
     end)
 
     it("rejects void functions in expression contexts", function()
         assert_error([[
-            local m: module = {}
             local function f(): ()
             end
 
             local function g(): integer
                 return 1 + f()
             end
-            return m
         ]],
             "void instead of a number")
     end)
 
     it("detects attempts to call non-functions", function()
         assert_error([[
-            local m: module = {}
             function m.fn(): integer
                 local i: integer = 0
                 i()
             end
-            return m
         ]],
             "attempting to call a integer value")
     end)
 
     it("detects wrong number of arguments to functions", function()
         assert_error([[
-            local m: module = {}
             function m.f(x: integer, y: integer): integer
                 return x + y
             end
@@ -737,14 +625,12 @@ describe("Pallene type checker", function()
             function m.g(): integer
                 return m.f(1)
             end
-            return m
         ]],
             "function expects 2 argument(s) but received 1")
     end)
 
     it("detects too few arguments when expanding a function", function()
         assert_error([[
-            local m: module = {}
             function m.f(): (integer, integer)
                 return 1, 2
             end
@@ -756,14 +642,12 @@ describe("Pallene type checker", function()
             function m.test(): integer
                 return m.g(m.f())
             end
-            return m
         ]],
             "function expects 3 argument(s) but received 2")
     end)
 
     it("detects too many arguments when expanding a function", function()
         assert_error([[
-            local m: module = {}
             function m.f(): (integer, integer)
                 return 1, 2
             end
@@ -775,14 +659,12 @@ describe("Pallene type checker", function()
             function m.test(): integer
                 return m.g(m.f())
             end
-            return m
         ]],
             "function expects 1 argument(s) but received 2")
     end)
 
     it("detects wrong types of arguments to functions", function()
         assert_error([[
-            local m: module = {}
             function m.f(x: integer, y: integer): integer
                 return x + y
             end
@@ -790,7 +672,6 @@ describe("Pallene type checker", function()
             function m.g(): integer
                 return m.f(1.0, 2.0)
             end
-            return m
         ]],
             "expected integer but found float in argument 1 of call to function")
     end)
@@ -800,11 +681,9 @@ describe("Pallene type checker", function()
             local err_msg = string.format(
                 "cannot concatenate with %s value", typ)
             local test_program = util.render([[
-                local m: module = {}
                 function m.fn(x : $typ) : string
                     return "hello " .. x
                 end
-                return m
             ]], { typ = typ })
 
             it(err_msg, function()
@@ -836,11 +715,9 @@ describe("Pallene type checker", function()
                         not (t1 == "float" and t2 == "integer")
                     then
                         optest("cannot compare $t1 and $t2 using $op", [[
-                            local m: module = {}
                             function m.fn(a: $t1, b: $t2): boolean
                                 return a $op b
                              end
-                            return m
                         ]], {
                             op = op, t1 = t1, t2 = t2
                         })
@@ -860,11 +737,9 @@ describe("Pallene type checker", function()
                     local dir, t1, t2 = test[1], test[2], test[3]
                     optest(
        "$dir hand side of '$op' has type $t", [[
-                        local m: module = {}
                         function m.fn(x: $t1, y: $t2) : boolean
                             return x $op y
                         end
-                        return m
                     ]], { op = op, t = t, dir = dir, t1 = t1, t2=t2 })
                 end
             end
@@ -881,11 +756,9 @@ describe("Pallene type checker", function()
                     local dir, t1, t2 = test[1], test[2], test[3]
                     optest(
         "$dir hand side of bitwise expression is a $t instead of an integer", [[
-                        local m: module = {}
                         function m.fn(a: $t1, b: $t2): integer
                             return a $op b
                         end
-                        return m
                     ]], { op = op, t = t, dir = dir, t1 = t1, t2 = t2 })
                 end
             end
@@ -902,11 +775,9 @@ describe("Pallene type checker", function()
                     local dir, t1, t2 = test[1], test[2], test[3]
                     optest(
         "$dir hand side of arithmetic expression is a $t instead of a number", [[
-                        local m: module = {}
                         function m.fn(a: $t1, b: $t2) : float
                             return a $op b
                         end
-                        return m
                     ]], { op = op, t = t, dir = dir, t1 = t1, t2 = t2} )
                 end
             end
@@ -918,11 +789,9 @@ describe("Pallene type checker", function()
             assert_error([[
                 record Point x: float; y:float end
 
-                local m: module = {}
                 function m.f(p: ]].. typ ..[[): float
                     ]].. code ..[[
                 end
-                return m
             ]], err)
         end
 
@@ -957,11 +826,9 @@ describe("Pallene type checker", function()
             for _, t2 in ipairs(typs) do
                 if t1 ~= t2 then
                     optest("expected $t2 but found $t1 in cast expression", [[
-                        local m: module = {}
                         function m.fn(a: $t1) : $t2
                             return a as $t2
                         end
-                        return m
                     ]], { t1 = t1, t2 = t2 })
                 end
             end
@@ -970,14 +837,12 @@ describe("Pallene type checker", function()
 
     it("catches assignment to function", function ()
         assert_error([[
-            local m: module = {}
             function m.f()
             end
 
             function m.g()
                 m.f = m.g
             end
-            return m
         ]],
         --"attempting to assign to toplevel constant function 'f'")
         "type error: Can't assign module field to 'function type () -> ()'")
@@ -985,96 +850,87 @@ describe("Pallene type checker", function()
 
     it("catches assignment to builtin (with correct type)", function ()
         assert_error([[
-            local m: module = {}
             function m.f(x: string)
             end
 
             function m.g()
                 io.write = m.f
             end
-            return m
         ]],
         "attempting to assign to builtin function io.write")
     end)
 
     it("catches assignment to builtin (with wrong type)", function ()
         assert_error([[
-            local m: module = {}
             function m.f(x: integer)
             end
 
             function m.g()
                 io.write = m.f
             end
-            return m
         ]],
         "attempting to assign to builtin function io.write")
     end)
 
     it("typechecks io.write (error)", function()
         assert_error([[
-            local m: module = {}
             function m.f()
                 io.write(17)
             end
-            return m
         ]],
         "expected string but found integer in argument 1")
     end)
 
     it("checks assignment variables to modules", function()
         assert_error([[
-            local m: module = {}
             function m.f()
                 local x = io
             end
-            return m
         ]],
         "cannot reference module name 'io' without dot notation")
     end)
 
     it("checks assignment of modules", function()
         assert_error([[
-            local m: module = {}
             function m.f()
                 io = 1
             end
-            return m
         ]],
         "cannot reference module name 'io' without dot notation")
     end)
+
+    it("forbid empty program", function()
+        assert_error_unwrapped([[]], "type error: Empty modules are not permitted")
+    end)
+
     it("check if module variable is not declared", function()
-        assert_error([[
+        assert_error_unwrapped([[
             local function f()
                 local x = 2.5
             end
         ]],
         "type error: Program has no module variable")
     end)
+
     it("forbid declarion of two module variables", function()
-        assert_error([[
-            local m: module = {}
-            local n: module = {}
-            function m.f()
-                local x = 2.5
-            end
-            return m
+        assert_error_unwrapped([[
+            local m1: module = {}
+            local m2: module = {}
+            return m1
         ]],
         "type error: There can only be one module variable per program")
     end)
+
     it("forbid return of more than one variable", function()
-        assert_error([[
+        assert_error_unwrapped([[
             local m: module = {}
-            local i: integer = 2
-            function m.f()
-                local x = 2.5
-            end
-            return m, n
+            return m, m
         ]],
         "type error: returning 2 value(s) but function expects 1")
     end)
+
     it("forbid return of any variable of type other then module", function()
-        assert_error([[
+        assert_error_unwrapped([[
             local m: module = {}
             local i: integer = 2
             function m.f()
@@ -1084,6 +940,7 @@ describe("Pallene type checker", function()
         ]],
         "type error: expected module but found integer in return statement")
     end)
+
     it("forbid assignment of Record as module field", function()
         assert_error([[
             record Point
@@ -1091,31 +948,25 @@ describe("Pallene type checker", function()
                 y: integer
             end
             local p: Point = {x = 12, y = 7}
-            local m: module = {}
             m.p = p
-            return m
         ]],
         "type error: Can't assign module field to 'Point'")
     end)
+
     it("forbid assignment of Array as module field", function()
         assert_error([[
             local arr: {integer} = {1, 2, 6, -10}
-            local m: module = {}
             m.arr = arr
-            return m
         ]],
         "type error: Can't assign module field to '{ integer }'")
     end)
+
     it("forbid assignment of any as module field", function()
         assert_error([[
             local a: any
-            local m: module = {}
             m.a = a
-            return m
         ]],
         "type error: Can't assign module field to 'any'")
     end)
-    it("forbid empty program", function()
-        assert_error([[]], "type error: Empty modules are not permitted")
-    end)
+
 end)


### PR DESCRIPTION
In some test cases, move the `local m={}` to the default test template, so that we don't have to repeat it every time.

There are some test files that still keep the `local m={}`. I'll admit that the choice was somewhat arbitrary.

In the parser, I did not add the local m on purpose, because it would complicate the generated AST. The other ones that I didn't change, one of the main reasons are that they are small files with less test cases in the file.