### PR TITLE
Remove "export" keyword

### DIFF
--- a/pallene/Lexer.lua
+++ b/pallene/Lexer.lua
@@ -49,7 +49,7 @@ local is_keyword = {}
 do
     local strs = [[
         and break do else elseif end for false function goto if in local nil not or repeat return
-        then true until while   as export import record typealias
+        then true until while   as import record typealias
     ]]
     for s in string.gmatch(strs, "%S+") do
         is_keyword[s] = true

--- a/spec/lexer_spec.lua
+++ b/spec/lexer_spec.lua
@@ -35,14 +35,14 @@ describe("Pallene lexer", function()
 
     it("can lex some keywords", function()
         assert_lex("and", {"and"}, {})
-        assert_lex("export", {"export"}, {})
+        assert_lex("function", {"function"}, {})
     end)
 
     it("can lex keywords that contain other keywords", function()
         assert_lex("if",     {"if"},     {})
         assert_lex("else",   {"else"},   {})
         assert_lex("elseif", {"elseif"}, {})
-        assert_lex("export", {"export"}, {})
+        assert_lex("import", {"import"}, {})
     end)
 
     it("does not generate semantic values for keywords", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -185,7 +185,7 @@ describe("Pallene parser", function()
             "Toplevel assignments are only possible with module fields")
     end)
 
-    it("cannot define function without export or local modifier", function()
+    it("cannot define function without local modifier", function()
         assert_program_syntax_error([[
             function f() : integer
                 return 5319
@@ -194,42 +194,38 @@ describe("Pallene parser", function()
         "Function must be 'local' or module function")
     end)
 
-    it("last function without export or local modifier", function()
+    it("last function without local modifier", function()
         assert_program_syntax_error([[
-            local m: module = {}
             function m.a()
             end
 
             function f() : integer
                 return 5319
             end
-            return m
         ]],
         "Function must be 'local' or module function")
     end)
 
-    it("first function without export or local modifier", function()
+    it("first function without local modifier", function()
         assert_program_syntax_error([[
-            local m: module = {}
             function a()
             end
 
             function m.f() : integer
                 return 5319
             end
-            return m
         ]],
         "Function must be 'local' or module function")
     end)
 
-    it("toplevel variable declaration without export or local modifier", function()
+    it("toplevel variable declaration without local modifier", function()
         assert_program_syntax_error([[
-            a,m="s","r"
+            x, y = "s", "r"
         ]],
         "Toplevel assignments are only possible with module fields")
     end)
 
-    it("toplevel variable declaration without export or local modifier (without comma)", function()
+    it("toplevel variable declaration without local modifier (without comma)", function()
         assert_program_syntax_error([[
             a="s"
         ]],


### PR DESCRIPTION
Remove the references to the export keyword that were still present in the lexer and in the test
cases