### PR TITLE
Parsing closures

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -1064,8 +1064,8 @@ function Checker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
         -- These assertions are always true in the current version of Pallene, which does not allow
         -- nested function expressions. Once we add function expressions to the parser then we
         -- should convert these assertions into proper calls to type_error.
-        assert(expected_type._tag == "types.T.Function")
-        assert(#expected_type.arg_types == #exp.arg_decls)
+        assert(expected_type._tag == "types.T.Function", "function expressions not implemented yet")
+        assert(#expected_type.arg_types == #exp.arg_decls, "function expressions not implemented yet")
 
         table.insert(self.ret_types_stack, expected_type.ret_types)
         self.symbol_table:with_block(function()

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -494,10 +494,9 @@ function Parser:Block()
     return ast.Stat.Block(false, self:StatList())
 end
 
-function Parser:Func(is_local)
-    local start    = self:e("function")
+function Parser:FuncStat(is_local)
+    local start = self:e("function")
 
-    -- Function name
     local root = self:e("NAME")
 
     local fields = {}
@@ -516,9 +515,7 @@ function Parser:Func(is_local)
         self:syntax_error(root.loc, "Local function name has a '.' or ':'")
     end
 
-    local oparen   = self:e("(")
-    local params   = self:DeclList()
-    local _        = self:e(")", oparen)
+    local params = self:FuncParams()
 
     local return_types = {}
     if self:peek(":") then
@@ -629,7 +626,7 @@ function Parser:Stat(is_toplevel)
     elseif self:peek("local") then
         local start = self:e()
         if self:peek("function") then
-            return self:Func(true)
+            return self:FuncStat(true)
         else
             local decls = self:DeclList(); if #decls == 0 then self:forced_syntax_error("NAME") end
             local exps  = self:try("=") and self:ExpList1() or {}
@@ -653,7 +650,7 @@ function Parser:Stat(is_toplevel)
         end
 
     elseif self:peek("function") then
-        return self:Func(false)
+        return self:FuncStat(false)
 
     else
         -- Assignment or function call
@@ -760,6 +757,33 @@ function Parser:FuncArgs()
     end
 end
 
+function Parser:FuncParams()
+    local oparen = self:e("(")
+    local params = self:DeclList()
+    local _ = self:e(")", oparen)
+    return params
+end
+
+function Parser:FuncExp(func_token)
+    local params = self:FuncParams(true)
+
+    for _, decl in ipairs(params) do
+        if decl.type then
+            self:syntax_error(decl.loc, "Function expressions cannot be type annotated")
+        end
+    end
+
+    if self:peek(":") then
+        local colon = self:e()
+        self:syntax_error(colon.loc, "Function expressions cannot be type annotated")
+    end
+
+    local block = self:Block()
+    local _     = self:e("end", func_token)
+
+    return ast.Exp.Lambda(func_token.loc, params, block)
+end
+
 function Parser:SimpleExp()
     if     self:peek("NUMBER") then
         local id = self:e()
@@ -796,6 +820,9 @@ function Parser:SimpleExp()
         self:e("}", open)
         return ast.Exp.Initlist(open.loc, fields)
 
+    elseif self:peek("function") then
+        local start = self:e()
+        return self:FuncExp(start)
     else
         return self:SuffixedExp(false)
     end

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -525,8 +525,8 @@ function Parser:FuncStat(is_local)
         self:region_end()
     end
 
-    local block    = self:Block()
-    local _        = self:e("end", start)
+    local block = self:Block()
+    local _     = self:e("end", start)
 
     for _, decl in ipairs(params) do
       if not decl.type then
@@ -764,7 +764,8 @@ function Parser:FuncParams()
     return params
 end
 
-function Parser:FuncExp(func_token)
+function Parser:FuncExp()
+    local start  = self:e("function")
     local params = self:FuncParams(true)
 
     for _, decl in ipairs(params) do
@@ -779,9 +780,9 @@ function Parser:FuncExp(func_token)
     end
 
     local block = self:Block()
-    local _     = self:e("end", func_token)
+    local _     = self:e("end", start)
 
-    return ast.Exp.Lambda(func_token.loc, params, block)
+    return ast.Exp.Lambda(start.loc, params, block)
 end
 
 function Parser:SimpleExp()
@@ -821,8 +822,7 @@ function Parser:SimpleExp()
         return ast.Exp.Initlist(open.loc, fields)
 
     elseif self:peek("function") then
-        local start = self:e()
-        return self:FuncExp(start)
+        return self:FuncExp()
     else
         return self:SuffixedExp(false)
     end

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -333,6 +333,38 @@ describe("Pallene parser", function()
     } })
     end)
 
+    it ("can parse function expressions", function()
+        assert_expression_ast("function (a) return 1 end", {
+            _tag = "ast.Exp.Lambda",
+            body = {
+              _tag  = "ast.Stat.Block",
+              stats = { {
+                _tag = "ast.Stat.Return",
+                exps = { { _tag = "ast.Exp.Integer", value = 1 } } }
+              }
+            }
+        })
+
+        assert_expression_ast("function (a, b) return 1 end", {
+            _tag = "ast.Exp.Lambda",
+            body = {
+              _tag  = "ast.Stat.Block",
+              stats = { {
+                _tag = "ast.Stat.Return",
+                exps = { { _tag = "ast.Exp.Integer", value = 1 } } }
+              }
+            }
+        })
+    end)
+
+    it("does not allow function expressions with names or type annotations.", function()
+        assert_expression_syntax_error("function f() end", "Expected '(' before 'f'");
+        assert_expression_syntax_error("function (x: integer) end",
+            "Function expressions cannot be type annotated");
+        assert_expression_syntax_error("function (x): integer return x end",
+            "Function expressions cannot be type annotated");
+    end)
+
     it("can parse multiple return expressions", function()
         assert_statements_ast("return 1, 2, 3", {
             { _tag = "ast.Stat.Return",


### PR DESCRIPTION
With this PR, the parser can process functions in both statement and expression contexts.

- The checker just croaks with a `"Not implemented"` error when type-checking function expressions.
- The type annotation nodes for the functions are now stored in `ast.Exp.Lambda`, and the `decl` nodes in `ast.Stat.Func` simply reference this node.
-  Function expressions are now considered under the `SimpleExp` derivation.
- The new `FuncExp` function starts at the opening `(` and parses the entire function body, this is used by both `Func` and `SimpleExp` to parse function statements and function expressions respectively. (should there be a comment documenting this?) 