### PR TITLE
Clean up the parser tests

### DIFF
--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -662,7 +662,7 @@ function Parser:Stat(is_toplevel)
                 local var = exp.var
                 if var._tag ~= "ast.Var.Dot" then
                     self:syntax_error(exp.loc,
-                        "Toplevel assignments are only possible with module fields")
+                        "toplevel assignments are only possible with module fields")
                 end
             end
             local lhs = { self:to_var(exp) }
@@ -693,7 +693,7 @@ function Parser:to_var(exp)
     if exp._tag == "ast.Exp.Var" then
         return exp.var
     else
-        self:syntax_error(exp.loc, "This expression is not an lvalue")
+        self:syntax_error(exp.loc, "this expression is not an lvalue")
     end
 end
 
@@ -973,7 +973,7 @@ end
 
 function Parser:unexpected_token_error(non_terminal)
     local where = self:describe_token(self.next)
-    self:syntax_error(self.next.loc, "Unexpected %s while trying to parse %s", where, non_terminal)
+    self:syntax_error(self.next.loc, "unexpected %s while trying to parse %s", where, non_terminal)
 end
 
 function Parser:wrong_token_error(expected_name, open_tok)
@@ -981,10 +981,10 @@ function Parser:wrong_token_error(expected_name, open_tok)
     local what  = self:describe_token_name(expected_name)
     local where = self:describe_token(self.next)
     if not open_tok or loc.line == open_tok.loc.line then
-        self:syntax_error(loc, "Expected %s before %s", what, where)
+        self:syntax_error(loc, "expected %s before %s", what, where)
     else
         local owhat = self:describe_token_name(open_tok.name)
-        self:syntax_error(loc, "Expected %s before %s, to close the %s at line %d",
+        self:syntax_error(loc, "expected %s before %s, to close the %s at line %d",
             what, where, owhat, open_tok.loc.line)
     end
 end

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -147,11 +147,11 @@ function Parser:Program()
 
         if decl.type and not (decl.type._tag == "ast.Type.Name" and decl.type.name == "module") then
             self:syntax_error(decl.type.loc,
-                "if the module table has a type annotation, it must be exactly 'module'")
+                "if the module variable has a type annotation, it must be exactly 'module'")
         end
 
         if not (exp and exp._tag == "ast.Exp.Initlist" and #exp.fields == 0) then
-            self:syntax_error(stat.loc, "module initializer must be exactly {}")
+            self:syntax_error(stat.loc, "the module initializer must be exactly {}")
         end
 
         modname = decl.name
@@ -174,12 +174,12 @@ function Parser:Program()
 
     if not self:peek("EOF") then
         local tok = self:e()
-        self:syntax_error(tok.loc, "statement after the return statement") -- TODO
+        self:syntax_error(tok.loc, "the module return statement must be the last thing in the file")
     end
 
     if #return_stat.exps ~= 1 then
         self:syntax_error(return_stat.loc,
-            "final return statement must return a single value")
+            "the module return statement must return a single value")
     end
 
     local returned_exp = return_stat.exps[1]
@@ -191,7 +191,7 @@ function Parser:Program()
     then
         -- The checker also needs to check that this name has not been shadowed
         self:syntax_error(returned_exp.loc,
-            "must return exactly the module variable '%s'", modname)
+            "the module return statement must return exactly the module variable '%s'", modname)
     end
 
     return ast.Program.Program(
@@ -237,7 +237,7 @@ function Parser:Toplevel()
                stat._tag ~= "ast.Stat.Func"
             then
                 self:syntax_error(stat.loc,
-                    "Toplevel statements can only be Returns, Declarations or Assignments")
+                    "toplevel statements can only be Returns, Declarations or Assignments")
             end
             table.insert(stats, stat)
         end
@@ -510,9 +510,11 @@ function Parser:FuncStat(is_local)
         method = self:e("NAME").value
     end
 
-    local has_dot = (#fields > 0 or method)
-    if is_local and has_dot then
-        self:syntax_error(root.loc, "Local function name has a '.' or ':'")
+    if is_local and #fields > 0 then
+        self:syntax_error(root.loc, "local function name has a '.'")
+    end
+    if is_local and method then
+        self:syntax_error(root.loc, "local function name has a ':'")
     end
 
     local params = self:FuncParams()
@@ -531,7 +533,7 @@ function Parser:FuncStat(is_local)
     for _, decl in ipairs(params) do
       if not decl.type then
         self:syntax_error(decl.loc,
-          "Parameter '%s' is missing a type annotation", decl.name)
+          "parameter '%s' is missing a type annotation", decl.name)
       end
     end
 
@@ -676,7 +678,7 @@ function Parser:Stat(is_toplevel)
                 return ast.Stat.Call(exp.loc, exp)
             else
                 self:syntax_error(exp.loc,
-                    "This expression in a statement position is not a function call")
+                    "this expression in a statement position is not a function call")
             end
         end
     end

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -95,10 +95,6 @@ local function assert_type_ast(code, expected_ast)
     assert_is_subset(expected_ast, type_ast)
 end
 
-local function assert_type_syntax_error(code, expected_error)
-    assert_program_error(type_test_program(code), expected_error)
-end
-
 --
 -- Assertions for statements
 --
@@ -141,10 +137,6 @@ local function assert_expression_ast(code, expected_ast)
     local program_ast = assert_parses_successfuly(expression_test_program(code))
     local exp_ast = program_ast.tls[1].stats[1].value.body.stats[1].exps[1]
     assert_is_subset(expected_ast, exp_ast)
-end
-
-local function assert_expression_error(code, expected_error)
-    assert_program_error(expression_test_program(code), expected_error)
 end
 
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -40,7 +40,7 @@ end
 local function assert_parses_successfuly(program_str)
     local prog_ast, errors = parse(program_str)
     if not prog_ast then
-        error(string.format("Unexpected Pallene syntax error: %s", errors[1]))
+        error(string.format("unexpected Pallene syntax error: %s", errors[1]))
     end
     return prog_ast
 end
@@ -49,7 +49,7 @@ local function assert_program_error(program_str, expected_error)
     local prog_ast, errors = parse(program_str)
     if prog_ast then
         error(string.format(
-            "Expected Pallene syntax error %s but parsed successfuly",
+            "expected Pallene syntax error %s but parsed successfuly",
             expected_error))
     end
     assert.matches(expected_error, errors[1], 1, true)
@@ -369,14 +369,14 @@ describe("Parser /", function()
         it("cannot be followed by a multiple semicolons", function()
             assert_statements_error([[
                 return;;
-            ]], "Expected 'end' before ';', to close the 'function' at line 2")
+            ]], "expected 'end' before ';', to close the 'function' at line 2")
         end)
 
         it("must be the last statement in the block", function()
             assert_statements_error([[
                 return 10
                 return 11
-            ]], "Expected 'end' before 'return', to close the 'function' at line 2")
+            ]], "expected 'end' before 'return', to close the 'function' at line 2")
         end)
     end)
 
@@ -386,7 +386,7 @@ describe("Parser /", function()
             assert_toplevel_error([[
                 local function (): integer
                 end
-            ]], "Expected a name before '('")
+            ]], "expected a name before '('")
         end)
 
         it("disallow complex names for local functions (1/2)", function()
@@ -516,7 +516,7 @@ describe("Parser /", function()
         it("are only allowed to module fields", function()
             assert_toplevel_error([[
                 x = 17
-            ]], "Toplevel assignments are only possible with module fields")
+            ]], "toplevel assignments are only possible with module fields")
         end)
     end)
 
@@ -531,7 +531,7 @@ describe("Parser /", function()
         it("are the only expression allowed as a statement (2/2)", function()
             assert_statements_error([[
                 1 + 1
-            ]], "Unexpected number")
+            ]], "unexpected number")
         end)
     end)
 
@@ -545,7 +545,7 @@ describe("Parser /", function()
         it("cannot be any expression", function()
             assert_statements_error([[
                 (x) = 42
-            ]], "This expression is not an lvalue")
+            ]], "this expression is not an lvalue")
         end)
     end)
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -139,6 +139,10 @@ local function assert_expression_ast(code, expected_ast)
     assert_is_subset(expected_ast, exp_ast)
 end
 
+local function assert_expression_error(code, expected_error)
+    assert_program_error(expression_test_program(code), expected_error)
+end
+
 
 -- Organization of the Parser Test Suite
 -- --------------------------------------
@@ -622,6 +626,24 @@ describe("Parser /", function()
                 },
             })
         end)
+    end)
+
+    describe("Function expressions", function()
+
+        it("cannot have a name", function()
+            assert_expression_error([[ function f() end ]], "expected '(' before 'f'")
+        end)
+
+        it("cannot have argument annotations", function()
+            assert_expression_error([[ function (x:integer) return x+1 end ]],
+            "Function expressions cannot be type annotated")
+        end)
+
+        it("cannot have return type annotation", function()
+            assert_expression_error([[ function (x) : integer return x+1 end ]],
+            "Function expressions cannot be type annotated")
+        end)
+
     end)
 
     describe("Function calls without parenthesis", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -29,15 +29,15 @@ local function assert_is_subset(expected_ast, parsed_ast)
     assert.are.same(expected_ast, restrict(expected_ast, parsed_ast))
 end
 
---
--- Assertions for full programs (without module boilerplate)
---
-
 local function parse(code)
     return driver.compile_internal("__test__.pln", code, "ast")
 end
 
-local function assert_parses_successfuly_unwrapped(program_str)
+--
+-- Assertions for full programs
+--
+
+local function assert_parses_successfuly(program_str)
     local prog_ast, errors = parse(program_str)
     if not prog_ast then
         error(string.format("Unexpected Pallene syntax error: %s", errors[1]))
@@ -45,18 +45,7 @@ local function assert_parses_successfuly_unwrapped(program_str)
     return prog_ast
 end
 
-local function assert_program_ast_unwrapped(program_str, expected_tls)
-    local expected_ast = {
-        _tag = "ast.Program.Program",
-        tls = expected_tls,
-        type_regions = {},
-        comment_regions = {}
-    }
-    local prog_ast = assert_parses_successfuly_unwrapped(program_str)
-    assert_is_subset(expected_ast, prog_ast)
-end
-
-local function assert_program_syntax_error_unwrapped(program_str, expected_error)
+local function assert_program_error(program_str, expected_error)
     local prog_ast, errors = parse(program_str)
     if prog_ast then
         error(string.format(
@@ -66,29 +55,26 @@ local function assert_program_syntax_error_unwrapped(program_str, expected_error
     assert.matches(expected_error, errors[1], 1, true)
 end
 
-
 --
--- Assertions for full programs (with module boilerplate)
+-- Assertions for toplevel components
 --
 
-local function wrap(body)
+local function toplevel_test_program(s)
     return util.render([[
-        local m:module = {}
-        $body
+        local m = {}
+        $TL
         return m
-    ]], { body = body })
+    ]], { TL = s })
 end
 
-local function assert_parses_successfuly(program_str)
-    return assert_parses_successfuly_unwrapped(wrap(program_str))
+local function assert_toplevel_ast(code, expected_ast)
+    local program_ast = assert_parses_successfuly(toplevel_test_program(code))
+    local tl_ast = program_ast.tls[1]
+    assert_is_subset(expected_ast, tl_ast)
 end
 
-local function assert_program_ast(program_str, expected_tls)
-    return assert_program_ast_unwrapped(wrap(program_str), expected_tls)
-end
-
-local function assert_program_syntax_error(program_str, expected_error)
-    return assert_program_syntax_error_unwrapped(wrap(program_str), expected_error )
+local function assert_toplevel_error(code, expected_error)
+    assert_program_error(toplevel_test_program(code), expected_error)
 end
 
 --
@@ -97,44 +83,20 @@ end
 
 local function type_test_program(s)
     return (util.render([[
+        local m = {}
         local x: ${TYPE} = nil
+        return m
     ]], { TYPE = s } ))
 end
 
 local function assert_type_ast(code, expected_ast)
-    local program_str = type_test_program(code)
-    local program_ast = assert_parses_successfuly(program_str)
+    local program_ast = assert_parses_successfuly(type_test_program(code))
     local type_ast = program_ast.tls[1].stats[1].decls[1].type
     assert_is_subset(expected_ast, type_ast)
 end
 
 local function assert_type_syntax_error(code, expected_error)
-    local program_str = type_test_program(code)
-    assert_program_syntax_error(program_str, expected_error)
-end
-
---
--- Assertions for expressions
---
-
-local function expression_test_program(s)
-    return (util.render([[
-        local function foo()
-            x = ${EXPR}
-        end
-    ]], { EXPR = s }))
-end
-
-local function assert_expression_ast(code, expected_ast)
-    local program_str = expression_test_program(code)
-    local program_ast = assert_parses_successfuly(program_str)
-    local exp_ast = program_ast.tls[1].stats[1].value.body.stats[1].exps[1]
-    assert_is_subset(expected_ast, exp_ast)
-end
-
-local function assert_expression_syntax_error(code, expected_error)
-    local program_str = expression_test_program(code)
-    assert_program_syntax_error(program_str, expected_error)
+    assert_program_error(type_test_program(code), expected_error)
 end
 
 --
@@ -143,1229 +105,611 @@ end
 
 local function statements_test_program(s)
     return (util.render([[
+        local m = {}
         local function foo()
             ${STATS}
         end
+        return m
     ]], { STATS = s }))
 end
 
 local function assert_statements_ast(code, expected_ast)
-    local program_str = statements_test_program(code)
-    local program_ast = assert_parses_successfuly(program_str)
+    local program_ast = assert_parses_successfuly(statements_test_program(code))
     local stats_ast = program_ast.tls[1].stats[1].value.body.stats
     assert_is_subset(expected_ast, stats_ast)
 end
 
-local function assert_statements_syntax_error(code, expected_error)
-    local program_str = statements_test_program(code)
-    assert_program_syntax_error(program_str, expected_error)
+local function assert_statements_error(code, expected_error)
+    assert_program_error(statements_test_program(code), expected_error)
 end
 
 --
+-- Assertions for expressions
 --
+
+local function expression_test_program(s)
+    return (util.render([[
+        local m = {}
+        local function foo()
+            x = ${EXPR}
+        end
+        return m
+    ]], { EXPR = s }))
+end
+
+local function assert_expression_ast(code, expected_ast)
+    local program_ast = assert_parses_successfuly(expression_test_program(code))
+    local exp_ast = program_ast.tls[1].stats[1].value.body.stats[1].exps[1]
+    assert_is_subset(expected_ast, exp_ast)
+end
+
+local function assert_expression_error(code, expected_error)
+    assert_program_error(expression_test_program(code), expected_error)
+end
+
+
+-- Organization of the Parser Test Suite
+-- --------------------------------------
 --
+-- Try to order the tests by the order that things appear in parser.lua.
+-- This way, it's easier to know if a test case is missing.
+--
+-- Where possible, prefer testing a working program in the coder instead of looking at the AST.
+-- The AST changes more often than the surface syntax, which means that AST tests tend to break.
+-- Reserve the AST tests for tricky things such as operator precedence.
 
-describe("Pallene parser", function()
-    local ORIGINAL_FORMAT_LEVEL
+describe("Parser /", function()
 
-    setup(function()
-        -- Print the whole AST when it doesn't match, instead of just a handful
-        -- of nodes. A depth of 100 should be more than enough. Although the
-        -- luassert docs suggest -1 to show an infinite number of levels, that
-        -- can get stuck in an infinite loop if we have self-referential tables.
-        ORIGINAL_FORMAT_LEVEL = assert:get_parameter("TableFormatLevel")
-        assert:set_parameter("TableFormatLevel", 100)
+    do
+        local ORIGINAL_FORMAT_LEVEL
+
+        setup(function()
+            -- Print the whole AST when it doesn't match, instead of just a handful of nodes.
+            -- A depth of 100 should be sufficient. In the past we also tried using -1 to remove the
+            -- limit but that could get stuck in an infinite loop due to self-referential tables.
+            ORIGINAL_FORMAT_LEVEL = assert:get_parameter("TableFormatLevel")
+            assert:set_parameter("TableFormatLevel", 100)
+        end)
+
+        teardown(function()
+            assert:set_parameter("TableFormatLevel", ORIGINAL_FORMAT_LEVEL)
+        end)
+    end
+
+
+    describe("Programs", function()
+
+        it("must not be empty", function()
+            assert_program_error([[]], "empty modules are not allowed")
+        end)
+
+        it("must start with a valid module declaration", function()
+            assert_program_error([[
+                return m
+            ]], "must begin with a module declaration")
+
+            assert_program_error([[
+                local m, n = {}, {}
+            ]], "cannot use a multiple-assignment to declare the module table")
+
+            assert_program_error([[
+                local m : foo = {}
+            ]], "if the module variable has a type annotation, it must be exactly 'module'")
+
+            assert_program_error([[
+                local m = 123
+            ]], "the module initializer must be exactly {}")
+        end)
+
+        it("must end with a valid return statement", function()
+            assert_program_error([[
+                local m = {}
+            ]], "must end by returning the module table")
+
+            assert_program_error([[
+                local m = {}
+                return m
+                local x = 1
+            ]], "the module return statement must be the last thing in the file")
+
+            assert_program_error([[
+                local m: module = {}
+                return m, m
+            ]], "the module return statement must return a single value")
+
+            assert_program_error([[
+                local m: module = {}
+                local i: integer = 2
+                return i
+            ]], "the module return statement must return exactly the module variable 'm'")
+        end)
     end)
 
-    teardown(function()
-        assert:set_parameter("TableFormatLevel", ORIGINAL_FORMAT_LEVEL)
-    end)
+    --
+    -- Toplevel
+    --
 
-    it("can parse programs starting with whitespace or comments", function()
-        -- This is easy to get wrong in hand-written LPeg grammars...
-        local prog_ast = assert_parses_successfuly_unwrapped([[
-            --hello\n--bla\n
-            local m: module = {}
-            return m
-        ]])
-        assert.are.same({}, prog_ast.tls)
-    end)
+    describe("Record declarations", function()
 
-    it("can parse toplevel var declarations", function()
-        assert_program_ast([[ local x=17 ]], { {
-      _tag = "ast.Toplevel.Stats",
-      stats = { {
-        _tag = "ast.Stat.Decl",
-        decls = { {
-            _tag = "ast.Decl.Decl",
-            name = "x",
-            type = false
-          } },
-        exps = { {
-            _tag = "ast.Exp.Integer",
-            value = 17
-          } }
-      } },
-    } })
-    end)
+        it("can be empty", function()
+            assert_toplevel_ast([[ record Empty end ]], {
+                _tag = "ast.Toplevel.Record",
+                name = "Empty",
+                field_decls = {}
+            })
+        end)
 
-    it("does not allow global variables", function()
-        assert_program_syntax_error([[ x=17 ]],
-            "Toplevel assignments are only possible with module fields")
-    end)
-
-    it("toplevel variable declaration without local modifier", function()
-        assert_program_syntax_error([[
-            x, y = "s", "r"
-        ]],
-        "Toplevel assignments are only possible with module fields")
-    end)
-
-    it("toplevel variable declaration without local modifier (without comma)", function()
-        assert_program_syntax_error([[
-            a="s"
-        ]],
-        "Toplevel assignments are only possible with module fields")
-    end)
-
-    it("can parse toplevel function declarations", function()
-        assert_program_ast([[
-            local function fA() : float
-            end
-        ]], { {
-          _tag = "ast.Toplevel.Stats",
-          stats = { {
-            _tag = "ast.Stat.Func",
-            is_local = true,
-            root = "fA",
-            fields = {},
-            method = false,
-            ret_types = { { _tag = "ast.Type.Name", name = "float" } },
-            value = {
-              _tag = "ast.Exp.Lambda",
-              arg_decls = {},
-              body = {
-                _tag = "ast.Stat.Block",
-                stats = {}
-              }
-            }
-          } }
-        } })
-
-        assert_program_ast([[
-            local function fB(x:integer) : float
-            end
-        ]], { {
-      _tag = "ast.Toplevel.Stats",
-        stats = { {
-          _tag = "ast.Stat.Func",
-          is_local = true,
-          root = "fB",
-          fields = {},
-          method = false,
-          ret_types = { { _tag = "ast.Type.Name", name = "float" } },
-          value = {
-            _tag = "ast.Exp.Lambda",
-            arg_decls = { {
-                _tag = "ast.Decl.Decl",
-                name = "x",
-              } },
-            body = {
-              _tag = "ast.Stat.Block",
-              stats = {}
-            }
-          }
-        } }
-      } })
-
-        assert_program_ast([[
-            local function fC(x:integer, y:integer) : float
-            end
-        ]], { {
-            _tag = "ast.Toplevel.Stats",
-            stats = { {
-              _tag = "ast.Stat.Func",
-            is_local = true,
-              root = "fC",
-              fields = {},
-              method = false,
-              ret_types = { { _tag = "ast.Type.Name", name = "float" } },
-              value = {
-                _tag = "ast.Exp.Lambda",
-                arg_decls = { {
-                    _tag = "ast.Decl.Decl",
-                    name = "x",
-                  }, {
-                    _tag = "ast.Decl.Decl",
-                    name = "y",
-                  } },
-                body = {
-                  _tag = "ast.Stat.Block",
-                  stats = {}
+        it("can use semocolons as a separator", function()
+            assert_toplevel_ast([[ record Point x: float; y: float; end ]], {
+                _tag = "ast.Toplevel.Record",
+                name = "Point",
+                field_decls = {
+                    { name = "x" },
+                    { name = "y" }
                 }
-              }
-            } }
-        } })
+            })
+        end)
     end)
 
-    it("allows ommiting the optional return type annotation", function ()
-        assert_program_ast([[
-            local function bar()
-            end
-        ]], { {
-      _tag = "ast.Toplevel.Stats",
-      stats = { {
-          _tag = "ast.Stat.Func",
-          is_local = true,
-          root = "bar",
-          fields = {},
-          method = false,
-          ret_types = {},
-          value = {
-            _tag = "ast.Exp.Lambda",
-            arg_decls = {},
-            body = {
-              _tag = "ast.Stat.Block",
-              stats = {}
-            }
-          }
-        } }
-    } })
+
+    describe("Toplevel statements", function()
+
+        it("only allow certain statements", function()
+            assert_toplevel_error([[
+                while true do end
+            ]], "toplevel statements can only be Returns, Declarations or Assignments")
+        end)
     end)
 
-    it ("can parse function expressions", function()
-        assert_expression_ast("function (a) return 1 end", {
-            _tag = "ast.Exp.Lambda",
-            body = {
-              _tag  = "ast.Stat.Block",
-              stats = { {
-                _tag = "ast.Stat.Return",
-                exps = { { _tag = "ast.Exp.Integer", value = 1 } } }
-              }
-            }
-        })
 
-        assert_expression_ast("function (a, b) return 1 end", {
-            _tag = "ast.Exp.Lambda",
-            body = {
-              _tag  = "ast.Stat.Block",
-              stats = { {
-                _tag = "ast.Stat.Return",
-                exps = { { _tag = "ast.Exp.Integer", value = 1 } } }
-              }
-            }
-        })
-    end)
+    describe("Function types", function()
 
-    it("does not allow function expressions with names or type annotations.", function()
-        assert_expression_syntax_error("function f() end", "Expected '(' before 'f'");
-        assert_expression_syntax_error("function (x: integer) end",
-            "Function expressions cannot be type annotated");
-        assert_expression_syntax_error("function (x): integer return x end",
-            "Function expressions cannot be type annotated");
-    end)
-
-    it("can parse multiple return expressions", function()
-        assert_statements_ast("return 1, 2, 3", {
-            { _tag = "ast.Stat.Return",
-              exps = { { _tag = "ast.Exp.Integer", value = 1 },
-                       { _tag = "ast.Exp.Integer", value = 2 },
-                       { _tag = "ast.Exp.Integer", value = 3 } } }
-        })
-    end)
-
-    it("can parse multiple declarations", function()
-        assert_statements_ast("local a, b = 1, 2", {
-            { _tag  = "ast.Stat.Decl",
-              decls = { { _tag = "ast.Decl.Decl", name = "a" },
-                        { _tag = "ast.Decl.Decl", name = "b" } },
-              exps  = { { _tag = "ast.Exp.Integer", value = 1 },
-                        { _tag = "ast.Exp.Integer", value = 2 } } }
-        })
-    end)
-
-    it("can parse multiple assignments", function()
-        assert_statements_ast("a, b = 1, 2", {
-            { _tag = "ast.Stat.Assign",
-              exps = { { _tag = "ast.Exp.Integer", value = 1 },
-                        { _tag = "ast.Exp.Integer", value = 2 } },
-              vars = { { _tag = "ast.Var.Name", name = "a" },
-                       { _tag = "ast.Var.Name", name = "b" } } }
-        })
-    end)
-
-    it("can parse primitive types", function()
-        assert_type_ast("nil", { _tag = "ast.Type.Nil" } )
-        assert_type_ast("int", { _tag = "ast.Type.Name", name = "int" } )
-    end)
-
-    it("can parse array types", function()
-        assert_type_ast("{int}",
-            { _tag = "ast.Type.Array", subtype =
-                {_tag = "ast.Type.Name", name = "int" } } )
-
-        assert_type_ast("{{int}}",
-            { _tag = "ast.Type.Array", subtype =
-                { _tag = "ast.Type.Array", subtype =
-                    {_tag = "ast.Type.Name", name = "int" } } } )
-    end)
-
-    it("can parse table types", function()
-        assert_type_ast("{}",
-            { _tag = "ast.Type.Table",
-                fields = {} })
-
-        assert_type_ast("{ x: float }",
-            { _tag = "ast.Type.Table",
-              fields = {
-                { name = "x", type = { _tag = "ast.Type.Name", name = "float" } } } })
-
-        assert_type_ast("{ x: float, y: integer }",
-            { _tag = "ast.Type.Table",
-              fields = {
-                { name = "x", type = { _tag = "ast.Type.Name", name = "float" } },
-                { name = "y", type = { _tag = "ast.Type.Name", name = "integer" } } } })
-
-        assert_type_ast("{ a: {integer} }",
-            { _tag = "ast.Type.Table",
-              fields = {
-                { name = "a", type = { _tag = "ast.Type.Array" } } } })
-    end)
-
-    describe("can parse function types", function()
-        it("with parameter lists of length = 0", function()
-            assert_type_ast("() -> ()",
-                { _tag = "ast.Type.Function",
-                    arg_types = { },
-                    ret_types = { } } )
+        it("can have type lists of length = 0", function()
+            assert_type_ast("() -> ()", {
+                _tag = "ast.Type.Function",
+                arg_types = {},
+                ret_types = {},
+            })
         end)
 
-        it("with parameter lists of length = 1", function()
-            assert_type_ast("(a) -> (b)",
-                { _tag = "ast.Type.Function",
-                    arg_types = { { _tag = "ast.Type.Name", name = "a" } },
-                    ret_types = { { _tag = "ast.Type.Name", name = "b" } } } )
+        it("can have type lists of length = 1", function()
+            assert_type_ast("(a) -> (b)", {
+                _tag = "ast.Type.Function",
+                arg_types = { { _tag = "ast.Type.Name", name = "a" } },
+                ret_types = { { _tag = "ast.Type.Name", name = "b" } },
+            })
         end)
 
-        it("with parameter lists of length >= 2 ", function()
-            assert_type_ast("(a,b) -> (c,d,e)",
-                { _tag = "ast.Type.Function",
-                    arg_types = {
-                        { _tag = "ast.Type.Name", name = "a" },
-                        { _tag = "ast.Type.Name", name = "b" },
-                    },
-                    ret_types = {
-                        { _tag = "ast.Type.Name", name = "c" },
-                        { _tag = "ast.Type.Name", name = "d" },
-                        { _tag = "ast.Type.Name", name = "e" },
-                    }
-                 })
-        end)
-
-        it("without the optional parenthesis", function()
-            assert_type_ast("a -> b",
-                { _tag = "ast.Type.Function",
-                    arg_types = { { _tag = "ast.Type.Name", name = "a" } },
-                    ret_types = { { _tag = "ast.Type.Name", name = "b" } } } )
-        end)
-
-
-        it("and -> is right associative", function()
-            local ast1 = {
+        it("can have type lists of length >= 2 ", function()
+            assert_type_ast("(a,b) -> (c,d,e)", {
                 _tag = "ast.Type.Function",
                 arg_types = {
-                    { _tag = "ast.Type.Name", name = "a" } },
+                    { _tag = "ast.Type.Name", name = "a" },
+                    { _tag = "ast.Type.Name", name = "b" },
+                },
                 ret_types = {
-                    { _tag = "ast.Type.Function",
-                        arg_types = { { _tag = "ast.Type.Name", name = "b" } },
-                        ret_types = { { _tag = "ast.Type.Name", name = "c" } } } } }
+                    { _tag = "ast.Type.Name", name = "c" },
+                    { _tag = "ast.Type.Name", name = "d" },
+                    { _tag = "ast.Type.Name", name = "e" },
+                },
+            })
+        end)
+
+        it("can omit the optional parenthesis", function()
+            assert_type_ast("a -> b", {
+                _tag = "ast.Type.Function",
+                arg_types = { { _tag = "ast.Type.Name", name = "a" } },
+                ret_types = { { _tag = "ast.Type.Name", name = "b" } },
+            } )
+        end)
+
+        it("are right-associative", function()
+            local ast1 = {
+                _tag = "ast.Type.Function",
+                arg_types = { { _tag = "ast.Type.Name", name = "a" }, },
+                ret_types = { {
+                    _tag = "ast.Type.Function",
+                    arg_types = { { _tag = "ast.Type.Name", name = "b" } },
+                    ret_types = { { _tag = "ast.Type.Name", name = "c" } },
+                } }
+            }
 
             local ast2 = {
                 _tag = "ast.Type.Function",
-                arg_types = {
-                    { _tag = "ast.Type.Function",
-                        arg_types = { { _tag = "ast.Type.Name", name = "a" } },
-                        ret_types = { { _tag = "ast.Type.Name", name = "b" } } } },
-                ret_types = {
-                    { _tag = "ast.Type.Name", name = "c" } } }
+                arg_types = { {
+                    _tag = "ast.Type.Function",
+                    arg_types = { { _tag = "ast.Type.Name", name = "a" } },
+                    ret_types = { { _tag = "ast.Type.Name", name = "b" } },
+                } },
+                ret_types = { { _tag = "ast.Type.Name", name = "c" } },
+            }
 
             assert_type_ast("a -> b -> c",   ast1)
             assert_type_ast("a -> (b -> c)", ast1)
             assert_type_ast("(a -> b) -> c", ast2)
         end)
 
-        it("and '->' has higher precedence than ','", function()
-            assert_type_ast("(a, b -> c, d) -> e",
-                { _tag = "ast.Type.Function",
-                    arg_types = {
-                        { _tag = "ast.Type.Name", name = "a" },
-                        { _tag = "ast.Type.Function",
-                          arg_types = { { _tag = "ast.Type.Name", name = "b" } },
-                          ret_types = { { _tag = "ast.Type.Name", name = "c" } } },
-                        { _tag = "ast.Type.Name", name = "d" } },
-                    ret_types = { { _tag = "ast.Type.Name", name = "e" } } } )
+        it("have higher precedence than ','", function()
+            assert_type_ast("(a, b -> c, d) -> e", {
+                _tag = "ast.Type.Function",
+                arg_types = {
+                    { _tag = "ast.Type.Name", name = "a" },
+                    {
+                        _tag = "ast.Type.Function",
+                        arg_types = { { _tag = "ast.Type.Name", name = "b" } },
+                        ret_types = { { _tag = "ast.Type.Name", name = "c" } },
+                    },
+                    { _tag = "ast.Type.Name", name = "d" }
+                },
+                ret_types = { { _tag = "ast.Type.Name", name = "e" } },
+            })
         end)
     end)
 
-    it("can parse type alias", function()
-        assert_program_ast([[ typealias point = {float} ]], {
-            { _tag = "ast.Toplevel.Typealias",
-                name = "point", type = { _tag = "ast.Type.Array" } }
-        })
+    --
+    -- Stat
+    --
+
+    describe("Break statements", function()
+
+        it("are not allowed outsize a loop", function()
+            assert_statements_error([[
+                do
+                    if x then
+                        break
+                    end
+                end
+            ]], "break statement outside of a loop")
+        end)
     end)
 
-    it("can parse values", function()
-        assert_expression_ast("nil",   { _tag = "ast.Exp.Nil" })
-        assert_expression_ast("false", { _tag = "ast.Exp.Bool", value = false })
-        assert_expression_ast("true",  { _tag = "ast.Exp.Bool", value = true })
-        assert_expression_ast("10",    { _tag = "ast.Exp.Integer", value = 10})
-        assert_expression_ast("10.0",  { _tag = "ast.Exp.Float", value = 10.0})
-        assert_expression_ast("'asd'", { _tag = "ast.Exp.String", value = "asd" })
+
+    describe("Return statements", function()
+
+        it("can be empty", function()
+            assert_statements_ast("return", {
+                { _tag = "ast.Stat.Return", exps = {} }
+            })
+        end)
+
+        it("can be followed by a single semicolon", function()
+            assert_statements_ast("return 10;", {
+                { _tag = "ast.Stat.Return", exps = { { _tag = "ast.Exp.Integer", value = 10 } } }
+            })
+        end)
+
+        it("cannot be followed by a multiple semicolons", function()
+            assert_statements_error([[
+                return;;
+            ]], "Expected 'end' before ';', to close the 'function' at line 2")
+        end)
+
+        it("must be the last statement in the block", function()
+            assert_statements_error([[
+                return 10
+                return 11
+            ]], "Expected 'end' before 'return', to close the 'function' at line 2")
+        end)
     end)
 
-    it("can parse variables", function()
-        assert_expression_ast("y", { _tag = "ast.Exp.Var", var = { _tag = "ast.Var.Name", name = "y" }})
+    describe("Function statements", function()
+
+        it("must have a name", function()
+            assert_toplevel_error([[
+                local function (): integer
+                end
+            ]], "Expected a name before '('")
+        end)
+
+        it("disallow complex names for local functions (1/2)", function()
+            assert_toplevel_error([[
+                local function foo.bar()
+                end
+            ]], "local function name has a '.'")
+        end)
+
+        it("disallow complex names for local functions (2/2)", function()
+            assert_toplevel_error([[
+                local function foo:bar()
+                end
+            ]], "local function name has a ':'")
+        end)
+
+        it("must have argument type annotations (argument)", function()
+            assert_toplevel_error([[
+                local function foo(x): integer
+                    return 10
+                end
+            ]], "parameter 'x' is missing a type annotation")
+        end)
     end)
 
-    it("can parse parenthesized expressions", function()
-        assert_expression_ast("((1))",
-            { _tag = "ast.Exp.Paren",
-                exp = { _tag = "ast.Exp.Paren",
-                    exp = { _tag = "ast.Exp.Integer", value = 1 }}})
+    --
+    -- TODO Mutually recursive functions
+    --
+
+    -- TODO: Move this test to the type checker?
+    describe("Toplevel assignments", function()
+        it("are only allowed to module fields", function()
+            assert_toplevel_error([[
+                x = 17
+            ]], "Toplevel assignments are only possible with module fields")
+        end)
     end)
 
-    it("can parse table constructors", function()
-        assert_expression_ast("{}",
-            { _tag = "ast.Exp.Initlist", fields = {} })
+    describe("Function call statements", function()
 
-        assert_expression_ast("{10,20,30}",
-            { _tag = "ast.Exp.Initlist", fields = {
-                { exp = { value = 10 } },
-                { exp = { value = 20 } },
-                { exp = { value = 30 } }, }})
+        it("are the only expression allowed as a statement (1/2)", function()
+            assert_statements_error([[
+                (f)
+            ]], "this expression in a statement position is not a function call")
+        end)
 
-        assert_expression_ast("{40;50;60;}", -- (semicolons)
-            { _tag = "ast.Exp.Initlist", fields = {
-                { exp = { value = 40 } },
-                { exp = { value = 50 } },
-                { exp = { value = 60 } }, }})
+        it("are the only expression allowed as a statement (2/2)", function()
+            assert_statements_error([[
+                1 + 1
+            ]], "Unexpected number")
+        end)
     end)
 
-    describe("can parse while statements", function()
-        assert_statements_ast("while true do end", {
-            { _tag = "ast.Stat.While",
-              condition = { _tag = "ast.Exp.Bool" },
-              block = { _tag = "ast.Stat.Block" } }
-        })
+    --
+    -- Var
+    --
+    --
+
+    describe("Lvalue", function()
+        it("cannot be any expression", function()
+            assert_statements_error([[
+                (x) = 42
+            ]], "This expression is not an lvalue")
+        end)
     end)
 
-    describe("can parse repeat-until statements", function()
-        assert_statements_ast("repeat until false", {
-            { _tag = "ast.Stat.Repeat",
-              block = { _tag = "ast.Stat.Block" },
-              condition = { _tag = "ast.Exp.Bool" }, }
-        })
+    --
+    -- Expr
+    --
+
+
+
+    -- In Lua, parenthesis can matter for multiple function returns
+    describe("Parenthesized expressions", function()
+        it("are preserverd in the AST", function()
+            assert_expression_ast("((1))",
+                { _tag = "ast.Exp.Paren",
+                    exp = { _tag = "ast.Exp.Paren",
+                        exp = { _tag = "ast.Exp.Integer", value = 1 }}})
+        end)
     end)
 
-    describe("can parse if statements", function()
-        assert_statements_ast("if 10 then end", {
-            { _tag = "ast.Stat.If",
-                condition = { value = 10 },
-                then_ = { _tag = "ast.Stat.Block" },
-                else_ = { _tag = "ast.Stat.Block" }, }
-        })
 
-        assert_statements_ast("if 20 then else end", {
-            { _tag = "ast.Stat.If",
-                condition = { value = 20 },
-                then_ = { _tag = "ast.Stat.Block" },
-                else_ = { _tag = "ast.Stat.Block" }, }
-        })
+    describe("Table constructors", function()
+        it("can be empty", function()
+            assert_expression_ast("{}",
+                { _tag = "ast.Exp.Initlist", fields = {} })
+        end)
 
-        assert_statements_ast("if 30 then elseif 40 then end", {
-            { _tag = "ast.Stat.If",
-                condition = { value = 30 },
-                then_ = { _tag = "ast.Stat.Block" },
-                else_ = { _tag = "ast.Stat.If",
-                    condition = { value = 40 }, }, }
-        })
+        it("can use commas", function()
+            assert_expression_ast("{10,20,30}",
+                { _tag = "ast.Exp.Initlist", fields = {
+                    { exp = { value = 10 } },
+                    { exp = { value = 20 } },
+                    { exp = { value = 30 } }, }})
+        end)
 
-        assert_statements_ast("if 50 then elseif 60 then else end", {
-            { _tag = "ast.Stat.If",
-                condition = { value = 50 },
-                then_ = { _tag = "ast.Stat.Block" },
-                else_ = { _tag = "ast.Stat.If",
-                    condition = { value = 60 }, }, }
-        })
+        it("can use semicolons", function()
+            assert_expression_ast("{40;50;60;}",
+                { _tag = "ast.Exp.Initlist", fields = {
+                    { exp = { value = 40 } },
+                    { exp = { value = 50 } },
+                    { exp = { value = 60 } }, }})
+        end)
     end)
 
-    it("can parse do-while blocks", function()
-        assert_statements_ast([[
-            do
-                local x = 10; x = 11
-                print("Hello", "World")
-            end
-        ]], {
-            { _tag = "ast.Stat.Block",
-                stats = {
-                    { _tag = "ast.Stat.Decl",
-                        decls = { { name = "x" } },
-                        exps = { { value = 10 } } },
-                    { _tag = "ast.Stat.Assign",
-                        vars = { { name = "x" } },
-                        exps = { { value = 11 } } },
-                    { _tag = "ast.Stat.Call",
-                        call_exp = { _tag = "ast.Exp.CallFunc" } } } },
-        })
-    end)
-
-    it("can parse numeric for loops", function()
-        assert_statements_ast([[
-            for i = 1, 2, 3 do
-                x = i
-            end
-        ]], {
-            { _tag = "ast.Stat.ForNum",
-              block = {
-                stats = {
-                  { _tag = "ast.Stat.Assign",
-                    exps = { { var = { _tag = "ast.Var.Name", name = "i" } } },
-                    vars = { { _tag = "ast.Var.Name", name = "x" } } } } },
-              decl = { _tag = "ast.Decl.Decl", name = "i", type = false },
-              start =  { _tag = "ast.Exp.Integer", value = 1 },
-              limit =  { _tag = "ast.Exp.Integer", value = 2 },
-              step =   { _tag = "ast.Exp.Integer", value = 3 }, },
-        })
-    end)
-
-    it("can parse for-in loops", function()
-        assert_statements_ast([[
-            for k, v in ipairs(t) do
-                x = v
-            end
-        ]], {
-            { _tag = "ast.Stat.ForIn",
-              block = {
-                stats = {
-                  { _tag = "ast.Stat.Assign",
-                    exps = { { var = { _tag = "ast.Var.Name", name = "v" } } },
-                    vars = { { _tag = "ast.Var.Name", name = "x" } } } } },
-              decls = {
-                { _tag = "ast.Decl.Decl", name = "k", type = false },
-                { _tag = "ast.Decl.Decl", name = "v", type = false }, },
-              exps =  {
-                { _tag = "ast.Exp.CallFunc", exp  = { _tag = "ast.Exp.Var",
-                  var = { _tag = "ast.Var.Name", name = "ipairs" } },
-                  args = {
-                    { _tag = "ast.Exp.Var" ,
-                    var = { name = "t" } } } } }
-            }
-        })
-
-        assert_statements_ast([[
-            for x in foo() do
-                x = 1
-            end
-        ]], {
-            { _tag = "ast.Stat.ForIn",
-              block = {
-                stats = {
-                  { _tag = "ast.Stat.Assign",
-                   exps = { { value = 1 } },
-                   vars = { { _tag = "ast.Var.Name", name = "x" } } } } },
-              decls = { { _tag = "ast.Decl.Decl", name = "x", type = false } },
-              exps = {
-              { _tag = "ast.Exp.CallFunc",
-                exp  = { _tag = "ast.Exp.Var",
-                var  = { _tag = "ast.Var.Name", name = "foo" } },
-                args = { --[[ no args ]] } } }
-            }
-        })
-    end)
-
-    it("can parse return statements", function()
-        assert_statements_ast("return", {
-            { _tag = "ast.Stat.Return", exps = {} }})
-
-        assert_statements_ast("return;", {
-            { _tag = "ast.Stat.Return", exps = {} }})
-
-        assert_statements_ast("return x", {
-            { _tag = "ast.Stat.Return", exps = { { _tag = "ast.Exp.Var" } } },
-        })
-        assert_statements_ast("return x;", {
-            { _tag = "ast.Stat.Return", exps = { { _tag = "ast.Exp.Var" } } },
-        })
-    end)
-
-    it("requires that return statements be the last in the block", function()
-        assert_statements_syntax_error([[
-            return 10
-            return 11
-        ]], "Expected 'end' before 'return', to close the 'function' at line 2")
-    end)
-
-    it("does not allow extra semicolons after a return", function()
-        assert_statements_syntax_error([[
-            return;;
-        ]], "Expected 'end' before ';', to close the 'function' at line 2")
-    end)
-
-    it("can parse binary and unary operators", function()
-        assert_expression_ast([[not 1 or 2 and 3 and 4]],
-            { op = "or",
-                lhs = { op = "not", exp = { value = 1 } },
-                rhs = { op = "and",
-                    lhs = { op = "and",
-                        lhs = { value = 2 },
-                        rhs = { value = 3 } },
-                    rhs = { value = 4} } })
-
-        assert_expression_ast([[(1 <= 2) == (4 < 5) == (6 ~= 7)]],
-            { op = "==",
-                lhs = { op = "==",
-                    lhs = { _tag = "ast.Exp.Paren", exp = { op = "<=",
-                        lhs = { value = 1 },
-                        rhs = { value = 2 } } },
-                    rhs = { _tag = "ast.Exp.Paren", exp = { op = "<",
-                        lhs = { value = 4 },
-                        rhs = { value = 5 } } } },
-                rhs = { _tag = "ast.Exp.Paren", exp = { op = "~=",
-                    lhs = { value = 6 },
-                    rhs = { value = 7 } } } })
-
-        assert_expression_ast([[~~1 ~ 2 << 3 >> 4 | 5 & 6]],
-            { op = "|",
-                lhs = { op = "~",
-                    lhs = { op = "~", exp = { op = "~", exp = { value = 1 } } },
-                    rhs = { op = ">>",
-                        lhs = { op = "<<",
-                            lhs = { value = 2 },
-                            rhs = { value = 3 } } } },
-                rhs = { op = "&",
-                    lhs = { value = 5 },
-                    rhs = { value = 6 } } })
-
-        assert_expression_ast([[- -1 / 2 + 3 * # "a"]],
-            { op = "+",
-                lhs = { op = "/",
-                    lhs = { op = "-", exp = { op = "-", exp = { value = 1 } } },
-                    rhs = { value = 2 } },
-                rhs = { op = "*",
-                    lhs = { value = 3 },
-                    rhs = { op = "#", exp = { value = "a" } } } })
-
-        -- concatenation is right associative
-        -- and has less precedence than prefix operators
-        assert_expression_ast([[-x .. -y .. -z]],
-            { _tag = "ast.Exp.Binop", op = "..",
-                lhs = { op = "-", exp = { var = { name = "x" } } },
-                rhs = { _tag = "ast.Exp.Binop", op = "..",
-                    lhs = { op = "-", exp = { var = { name = "y" } } },
-                    rhs = { op = "-", exp = { var = { name = "z" } } }, } })
-
-        -- exponentiation is also right associative
-        -- but it has a higher precedence than prefix operators
-        assert_expression_ast([[-1 ^ -2 ^ 3 * 4]],
-            { op = "*",
-                lhs = { op = "-",
-                    exp = { op = "^",
-                        lhs = { value = 1 },
-                        rhs = { op = "-",
-                            exp = { op = "^",
-                                lhs = { value = 2 },
-                                rhs = { value = 3 } } } } },
-                 rhs = { value = 4 } })
-    end)
-
-    it("can parse suffix operators", function()
-        assert_expression_ast([[ - x()()[2] ^ 3]],
-            { _tag = "ast.Exp.Unop", op = "-",
-                exp = { _tag = "ast.Exp.Binop", op = "^",
-                    rhs = { value = 3 },
-                    lhs = { _tag = "ast.Exp.Var", var = {
-                        _tag = "ast.Var.Bracket",
-                        k = { value = 2 },
-                        t = { _tag = "ast.Exp.CallFunc",
-                            args = { },
-                            exp = { _tag = "ast.Exp.CallFunc",
-                                args = { },
-                                exp = { _tag = "ast.Exp.Var",
-                                    var = { _tag = "ast.Var.Name", name = "x" }}}}}}}})
-    end)
-
-    it("can parse function calls without the optional parenthesis", function()
-        assert_expression_ast([[ f() ]],
-            { _tag = "ast.Exp.CallFunc", args = { } })
-
-        assert_expression_ast([[ f "qwe" ]],
-            { _tag = "ast.Exp.CallFunc", args = {
-                { _tag = "ast.Exp.String", value = "qwe" } } })
-
-        assert_expression_ast([[ f {} ]],
-            { _tag = "ast.Exp.CallFunc", args = {
-                { _tag = "ast.Exp.Initlist" } } })
-    end)
-
-    it("can parse method calls without the optional parenthesis", function()
-        assert_expression_ast([[ o:m () ]],
-            { _tag = "ast.Exp.CallMethod",
-                method = "m",
-                args = { } })
-
-        assert_expression_ast([[ o:m "asd" ]],
-            { _tag = "ast.Exp.CallMethod",
-                method = "m",
-                args = {
-                    { _tag = "ast.Exp.String", value = "asd" } } })
-
-        assert_expression_ast([[ o:m {} ]],
-            { _tag = "ast.Exp.CallMethod",
-                method = "m",
-                args = {
-                    { _tag = "ast.Exp.Initlist" } } })
-    end)
-
-    it("only allows call expressions as statements", function()
-        assert_statements_syntax_error([[
-            (f)
-        ]], "This expression in a statement position is not a function call")
-
-        assert_statements_syntax_error([[
-            1 + 1
-        ]], "Unexpected number")
-    end)
-
-    it("can parse references to module members", function ()
-        assert_statements_ast([[
-            foo.bar = 50
-            print(foo.bar)
-            foo.write(a, b, c)
-        ]], {
-            { vars = { {
-                _tag = "ast.Var.Dot",
-                exp = { _tag = "ast.Exp.Var",
-                  var = { _tag = "ast.Var.Name", name = "foo" }
-              },
-                name = "bar" } } },
-            { call_exp = { args = { { var = {
-                _tag = "ast.Var.Dot",
-                exp = { _tag = "ast.Exp.Var",
-                  var = { _tag = "ast.Var.Name", name = "foo" }
-                },
-              name = "bar" } } } } },
-            { call_exp = {
-                exp = { var = {
-                    _tag = "ast.Var.Dot",
-                    exp = { _tag = "ast.Exp.Var",
-                      var = { _tag = "ast.Var.Name", name = "foo" }
+    describe("Suffixed expresions", function()
+        it("have the right precedence", function()
+            assert_expression_ast([[ - x(1)(2)[3].f ^ 4]], {
+                op = "-",
+                exp = {
+                    op = "^",
+                    lhs = {
+                        _tag = "ast.Exp.Var",
+                        var = {
+                            _tag ="ast.Var.Dot",
+                            exp = {
+                                _tag = "ast.Exp.Var",
+                                var = {
+                                    _tag = "ast.Var.Bracket",
+                                    t = {
+                                        _tag = "ast.Exp.CallFunc",
+                                        exp = {
+                                            _tag = "ast.Exp.CallFunc",
+                                            exp = { _tag = "ast.Exp.Var", var = { name = "x" } },
+                                            args = { { value = 1 }},
+                                        },
+                                        args = { { value = 2 } },
+                                    },
+                                    k = { value = 3 },
+                                },
+                            },
+                            name = "f",
+                        },
                     },
-                    name = "write" } } } }
-        })
+                    rhs = { value = 4 },
+                },
+            })
+        end)
     end)
 
-    it("can parse record declarations", function()
-        assert_program_ast([[
-            record Point
-                x: float
-                y: float
-            end
-        ]], {
-            { _tag = "ast.Toplevel.Record",
-              name = "Point",
-              field_decls = {
-                { name = "x", type = { _tag = "ast.Type.Name", name = "float" } },
-                { name = "y", type = { _tag = "ast.Type.Name", name = "float" } } } },
-        })
+    describe("Function calls without parenthesis", function()
+        it("for string literals", function()
+            assert_expression_ast([[ f "qwe" ]], {
+                _tag = "ast.Exp.CallFunc",
+                args = { { _tag = "ast.Exp.String", value = "qwe" } }
+            })
+        end)
 
-        assert_program_ast([[
-            record List
-                p: {Point}
-                next: List
-            end
-        ]], {
-            { _tag = "ast.Toplevel.Record",
-              name = "List",
-              field_decls = {
-                { name = "p",
-                  type = { subtype = { name = "Point" } } },
-                { name = "next", type = { name = "List" } } } },
-        })
+        it("for table literals", function()
+            assert_expression_ast([[ f {} ]], {
+                _tag = "ast.Exp.CallFunc",
+                args = { { _tag = "ast.Exp.Initlist" } }
+            })
+        end)
     end)
 
-    it("allows empty record declarations", function()
-        assert_program_ast([[
-            record Empty
-            end
-        ]], {
-            { _tag = "ast.Toplevel.Record",
-              name = "Empty",
-              field_decls = {}},
-        })
+    describe("Method calls without parenthesis", function()
+        it("for string literals", function()
+            assert_expression_ast([[ o:m "asd" ]], {
+                _tag = "ast.Exp.CallMethod",
+                method = "m",
+                args = { { _tag = "ast.Exp.String", value = "asd" } }
+            })
+        end)
+
+        it("for table literals", function()
+            assert_expression_ast([[ o:m {} ]], {
+                _tag = "ast.Exp.CallMethod",
+                method = "m",
+                args = { { _tag = "ast.Exp.Initlist" } }
+            })
+        end)
     end)
 
-    it("can parse the record field optional separator", function()
-        local expected_ast = { {
-            field_decls = {
-                { name = "x" },
-                { name = "y" }
-            }
-        } }
+    describe("Cast expressions", function()
 
-        assert_program_ast([[
-            record Point x: float y: float end
-        ]], expected_ast)
-
-        assert_program_ast([[
-            record Point x: float; y: float end
-        ]], expected_ast)
-
-        assert_program_ast([[
-            record Point x: float y: float; end
-        ]], expected_ast)
-
-        assert_program_ast([[
-            record Point x: float; y: float; end
-        ]], expected_ast)
-    end)
-
-    it("can parse record constructors", function()
-        assert_expression_ast([[ { x = 1.1, y = 2.2 } ]],
-            { _tag = "ast.Exp.Initlist", fields = {
-                { name = "x", exp = { value = 1.1 } },
-                { name = "y", exp = { value = 2.2 } } }})
-
-        assert_expression_ast([[ { p = {}, next = nil } ]],
-            { _tag = "ast.Exp.Initlist", fields = {
-                { name = "p",    exp = { _tag = "ast.Exp.Initlist" } },
-                { name = "next", exp = { _tag = "ast.Exp.Nil" } } }})
-
-        assert_expression_ast([[ Point.new(1.1, 2.2) ]],
-            { _tag = "ast.Exp.CallFunc",
-                args = {
-                  { value = 1.1 },
-                  { value = 2.2 } },
-                exp = { var = {
-                    _tag = "ast.Var.Dot",
-                    exp = { var = { name = "Point" } },
-                    name = "new" } } })
-
-        assert_expression_ast([[ List.new({}, nil) ]],
-            { _tag = "ast.Exp.CallFunc",
-                args = {
-                  { _tag = "ast.Exp.Initlist" },
-                  { _tag = "ast.Exp.Nil" } },
-                exp = { var = {
-                    _tag = "ast.Var.Dot",
-                    exp = { var = { name = "List" } },
-                    name = "new" } } })
-    end)
-
-    it("can parse record field access", function()
-        assert_expression_ast([[ p.x ]],
-            { _tag = "ast.Exp.Var", var = { _tag = "ast.Var.Dot",
-                name = "x",
-                exp = { _tag = "ast.Exp.Var", var = { _tag = "ast.Var.Name",
-                    name = "p" } } } })
-
-        assert_expression_ast([[ a.b[1].c ]],
-            { _tag = "ast.Exp.Var", var = { _tag = "ast.Var.Dot",
-                name = "c",
-                exp = { _tag = "ast.Exp.Var", var = { _tag = "ast.Var.Bracket",
-                    k = { value = 1 },
-                    t = { _tag = "ast.Exp.Var", var = { _tag = "ast.Var.Dot",
-                        name = "b",
-                        exp = { _tag = "ast.Exp.Var", var = { _tag = "ast.Var.Name",
-                            name = "a" } } } } } } } })
-    end)
-
-    it("can parse cast expressions", function()
-
-        assert_expression_ast([[ foo as integer ]],
-            { _tag = "ast.Exp.Cast",
-                exp = { _tag = "ast.Exp.Var" },
-                target = { _tag = "ast.Type.Name", name = "integer" } })
-
-        assert_expression_ast([[ a.b[1].c as integer ]],
-            { _tag = "ast.Exp.Cast",
-                exp = { _tag = "ast.Exp.Var" },
-                target = { _tag = "ast.Type.Name", name = "integer" } })
-
-        assert_expression_ast([[ foo as { integer } ]],
-            { _tag = "ast.Exp.Cast",
-                exp = { _tag = "ast.Exp.Var" },
-                target = { _tag = "ast.Type.Array" } })
-
-        assert_expression_ast([[ 2 + foo as integer ]],
-            { rhs = {
+        it("have lower precedence than suffixes", function()
+            assert_expression_ast([[ a.b[1].c as integer ]], {
                 _tag = "ast.Exp.Cast",
                 exp = { _tag = "ast.Exp.Var" },
-                target = { _tag = "ast.Type.Name", name = "integer" } }})
+                target = { _tag = "ast.Type.Name", name = "integer" },
+            })
+        end)
 
-        assert_expression_ast([[ 1 as integer as any ]],
-            { _tag = "ast.Exp.Cast",
+        it("have higherprecedence than arithmetic", function()
+            assert_expression_ast([[ 2 + foo as integer ]], {
+                _tag = "ast.Exp.Binop",
+                lhs = { value = 2 },
+                rhs = {
+                    _tag = "ast.Exp.Cast",
+                    exp = { _tag = "ast.Exp.Var" },
+                    target = { _tag = "ast.Type.Name", name = "integer" },
+                }
+            })
+        end)
+
+        it("can be nested", function()
+            assert_expression_ast([[ 1 as integer as any ]], {
+                _tag = "ast.Exp.Cast",
                 target = { _tag = "ast.Type.Name", name = "any" },
                 exp = {
                     _tag = "ast.Exp.Cast",
                     target = { _tag = "ast.Type.Name", name = "integer" },
+                    exp = { value = 1 },
+                },
+            })
+        end)
+    end)
+
+    describe("Operator precedence /", function()
+
+        it("Boolean operators", function()
+            assert_expression_ast([[not 1 or 2 and 3 and 4]], {
+                op = "or",
+                lhs = { op = "not", exp = { value = 1 } },
+                rhs = {
+                    op = "and",
+                    lhs = {
+                        op = "and",
+                        lhs = { value = 2 },
+                        rhs = { value = 3 }
+                    },
+                    rhs = { value = 4}
+                },
+            })
+        end)
+
+        it("Relational operators are left associative", function()
+            assert_expression_ast([[1 == 2 == 3]], {
+                op = "==",
+                lhs = {
+                    op = "==",
+                    lhs = { value = 1 },
+                    rhs = { value = 2 },
+                },
+                rhs = { value = 3 }
+            })
+        end)
+
+        it("Bitwise operators have the right precedence", function()
+            assert_expression_ast([[~~1 ~ 2 << 3 >> 4 | 5 & 6]], {
+                op = "|",
+                lhs = {
+                    op = "~",
+                    lhs = { op = "~", exp = { op = "~", exp = { value = 1 } } },
+                    rhs = {
+                        op = ">>",
+                        lhs = {
+                            op = "<<",
+                            lhs = { value = 2 },
+                            rhs = { value = 3 },
+                        },
+                    },
+                },
+                rhs = {
+                    op = "&",
+                    lhs = { value = 5 },
+                    rhs = { value = 6 },
+                },
+            })
+        end)
+
+        it("Arithmetic operators have the right precedence", function()
+            assert_expression_ast([[- -1 / 2 + 3 * # "a"]], {
+                op = "+",
+                lhs = {
+                    op = "/",
+                    lhs = { op = "-", exp = { op = "-", exp = { value = 1 } } },
+                    rhs = { value = 2 },
+                },
+                rhs = {
+                    op = "*",
+                    lhs = { value = 3 },
+                    rhs = { op = "#", exp = { value = "a" } },
+                },
+            })
+        end)
+
+        it("Concatenation is right-associative and lower precedence than prefix ops", function()
+            assert_expression_ast([[-1 .. -2 .. -3]], {
+                op = "..",
+                lhs = { op = "-", exp = { value = 1 } },
+                rhs = {
+                    op = "..",
+                    lhs = { op = "-", exp = { value = 2 } },
+                    rhs = { op = "-", exp = { value = 3 } },
+                },
+            })
+        end)
+
+        it("Exponentiation is right-associative and higher precedence than prefix ops", function()
+            assert_expression_ast([[-1 ^ -2 ^ 3 * 4]], {
+                op = "*",
+                lhs = {
+                    op = "-",
                     exp = {
-                        _tag = "ast.Exp.Integer"
-                    }}})
+                        op = "^",
+                        lhs = { value = 1 },
+                        rhs = {
+                            op = "-",
+                            exp = {
+                                op = "^",
+                                lhs = { value = 2 },
+                                rhs = { value = 3 },
+                            },
+                        },
+                    },
+                },
+                rhs = { value = 4 },
+            })
+        end)
     end)
-
-    it("does not allow parentheses in the LHS of an assignment", function()
-        assert_statements_syntax_error([[ local (x) = 42 ]],
-            "Expected a name before '('")
-        assert_statements_syntax_error([[ (x) = 42 ]],
-            "This expression is not an lvalue")
-    end)
-
-    it("parse errors for module declaration", function()
-        assert_program_syntax_error_unwrapped([[]],
-            "empty modules are not allowed")
-    end)
-
-    it("check if module variable is not declared", function()
-        assert_program_syntax_error_unwrapped([[
-            local function f()
-                local x = 2.5
-            end
-            return m
-        ]],
-        "must begin with a module declaration")
-    end)
-
-    it("forbid return of more than one variable", function()
-        assert_program_syntax_error_unwrapped([[
-            local m: module = {}
-            return m, m
-        ]],
-        "final return statement must return a single value")
-    end)
-
-    it("forbid return of any variable of type other then module", function()
-        assert_program_syntax_error_unwrapped([[
-            local m: module = {}
-            local i: integer = 2
-            function m.f()
-                local x = 2.5
-            end
-            return i
-        ]],
-        "must return exactly the module variable 'm'")
-    end)
-
-    it("uses specific error labels for some errors", function()
-
-        assert_program_syntax_error([[
-            local function () : int
-            end
-        ]], "Expected a name before '('")
-
-        assert_program_syntax_error([[
-            function m.foo ): int
-            end
-        ]], "Expected '(' before ')'")
-
-        assert_program_syntax_error([[
-            function m.foo ( : int
-            end
-        ]], "Expected ')' before ':'")
-
-        assert_program_syntax_error([[
-            function m.foo () :
-                local x = 3
-            end
-        ]], "Unexpected 'local' while trying to parse a type")
-
-        assert_program_syntax_error([[
-            function m.foo () : int
-              local x = 3
-              return x
-        ]], "Expected 'end' before 'return', to close the 'function' at line 2")
-
-        assert_program_syntax_error([[
-            function m.foo(x, y) : int
-            end
-        ]], "Parameter 'x' is missing a type annotation")
-
-        assert_program_syntax_error([[
-            local x 3
-        ]], "Unexpected number while trying to parse a statement")
-
-        assert_program_syntax_error([[
-            local x =
-        ]], "Unexpected 'return' while trying to parse an expression")
-
-        assert_program_syntax_error([[
-            record
-        ]], "Expected a name before 'return'")
-
-        assert_program_syntax_error([[
-            typealias
-        ]], "Expected a name before 'return'")
-
-        assert_program_syntax_error([[
-            typealias point
-        ]], "Expected '=' before 'return'")
-
-        assert_program_syntax_error([[
-            typealias point =
-        ]], "Unexpected 'return' while trying to parse a type")
-
-        assert_program_syntax_error([[
-            record A
-                x : int
-        ]], "Expected 'end' before 'return', to close the 'record' at line 2")
-
-        assert_program_syntax_error([[
-            function m.foo (a:int, ) : int
-            end
-        ]], "Expected a name before ')'")
-
-        assert_program_syntax_error([[
-            function m.foo (a: ) : int
-            end
-        ]], "Unexpected ')' while trying to parse a type")
-
-        assert_type_syntax_error([[ {int ]],
-            "Expected '}'")
-
-        assert_type_syntax_error([[ {a: float ]],
-            "Expected '}'")
-
-        assert_type_syntax_error([[
-            {a: }
-        ]], "Unexpected '}' while trying to parse a type")
-
-        assert_type_syntax_error([[ (a,,,) -> b ]],
-            "Unexpected ',' while trying to parse a type")
-
-        assert_type_syntax_error([[ (a, b -> b  ]],
-            "Expected ')'")
-
-        assert_type_syntax_error([[ (a, b) -> = nil ]],
-            "Unexpected '=' while trying to parse a type")
-
-        assert_program_syntax_error([[
-            record A
-                x  int
-            end
-        ]], "Expected ':' before 'int'")
-
-        assert_program_syntax_error([[
-            record A
-                x : function
-            end
-        ]], "Unexpected 'function' while trying to parse a type")
-
-        assert_program_syntax_error([[
-            function m.f ( x : int) : string
-                do
-                return "42"
-        ]], "Expected 'end' before 'return', to close the 'do' at line 3")
-
-        assert_statements_syntax_error([[
-            while do
-                x = x - 1
-            end
-        ]], "Unexpected 'do' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            while x > 3
-                x = x - 1
-            end
-        ]], "Expected 'do' before 'x'")
-
-        assert_statements_syntax_error([[
-            while x > 3 do
-                x = x - 1
-                return 42
-            return 41
-        ]], "Expected 'end' before 'return', to close the 'while' at line 3")
-
-        assert_statements_syntax_error([[
-            repeat
-                x = x - 1
-            end
-        ]], "Expected 'until' before 'end', to close the 'repeat' at line 3")
-
-        assert_statements_syntax_error([[
-            repeat
-                x = x - 1
-            until
-        ]], "Unexpected 'end' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            if then
-                x = x - 1
-            end
-        ]], "Unexpected 'then' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            if x > 10
-                x = x - 1
-            end
-        ]], "Expected 'then' before 'x'")
-
-        assert_statements_syntax_error([[
-            if x > 10 then
-                x = x - 1
-                return 42
-            return 41
-        ]], "Expected 'end' before 'return', to close the 'if' at line 3")
-
-        assert_statements_syntax_error([[
-            for = 1, 10 do
-            end
-        ]], "Expected a name before '='")
-
-        assert_statements_syntax_error([[
-            for x  1, 10 do
-            end
-        ]], "Unexpected number while trying to parse a for loop")
-
-        assert_statements_syntax_error([[
-            for x = , 10 do
-            end
-        ]], "Unexpected ',' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            for x = 1 10 do
-            end
-        ]], "Expected ',' before number")
-
-        assert_statements_syntax_error([[
-            for x = 1, do
-            end
-        ]], "Unexpected 'do' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            for x = 1, 10, do
-            end
-        ]], "Unexpected 'do' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            for x = 1, 10, 1
-            end
-        ]], "Expected 'do' before 'end'")
-
-        assert_statements_syntax_error([[
-            for x = 1, 10, 1 do
-                return 42
-            return 41
-        ]], "Expected 'end' before 'return', to close the 'for' at line 3")
-
-        assert_statements_syntax_error([[
-            for k, in ipairs(t) do
-                k = 1
-            end
-        ]], "Expected a name before 'in'")
-
-        assert_statements_syntax_error([[
-            for k v in ipairs(t) do
-                v = 1
-            end
-        ]], "Unexpected 'v' while trying to parse a for loop")
-
-        assert_statements_syntax_error([[
-            for in ipairs(t) do
-                local v = 1
-            end
-        ]], "Expected a name before 'in'")
-
-        assert_statements_syntax_error([[
-            for k, v in ipairs(t)
-                k = 1
-            end
-        ]], "Expected 'do' before 'k'")
-
-        assert_statements_syntax_error([[
-            local = 3
-        ]], "Expected a name before '='")
-
-        assert_statements_syntax_error([[
-            local x =
-        ]], "Unexpected 'end' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            x =
-        ]], "Unexpected 'end' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            if x > 1 then
-                x = x - 1
-            elseif then
-            end
-        ]], "Unexpected 'then' while trying to parse an expression")
-
-        assert_statements_syntax_error([[
-            if x > 1 then
-                x = x - 1
-            elseif x > 0
-            end
-        ]], "Expected 'then' before 'end'")
-
-        assert_expression_syntax_error([[ 1 + ]],
-            "Unexpected 'end' while trying to parse an expression")
-
-        assert_expression_syntax_error([[ obj:() ]],
-            "Expected a name before '('")
-
-        assert_expression_syntax_error([[ obj:f + 1 ]],
-            "Expected '(' before '+'")
-
-        assert_expression_syntax_error([[ y[] ]],
-            "Unexpected ']' while trying to parse an expression")
-
-        assert_expression_syntax_error([[ y[1 ]],
-            "Expected ']' before 'end'")
-
-        assert_expression_syntax_error([[ y.() ]],
-            "Expected a name before '('")
-
-        assert_expression_syntax_error([[ () ]],
-            "Unexpected ')' while trying to parse an expression")
-
-        assert_expression_syntax_error([[ (42 ]],
-            "Expected ')' before 'end'")
-
-        assert_expression_syntax_error([[ f(42 ]],
-            "Expected ')' before 'end'")
-
-        assert_expression_syntax_error([[ f(42,) ]],
-            "Unexpected ')' while trying to parse an expression")
-
-        assert_expression_syntax_error([[ y{42 ]],
-            "Expected '}' before 'end'")
-
-        assert_expression_syntax_error([[ y{42,,} ]],
-            "Unexpected ',' while trying to parse an expression")
-
-        assert_expression_syntax_error([[ foo as ]],
-            "Unexpected 'end' while trying to parse a type")
-    end)
-
-    it("catches break statements outside loops", function()
-        assert_program_syntax_error([[
-            local function fn()
-                break
-            end
-        ]], "break statement outside of a loop")
-    end)
-
-    it("catches break statements outside loops but inside other statements", function()
-        assert_program_syntax_error([[
-            local function fn(x:boolean)
-                do
-                    if x then
-                        break
-                    else
-                        break
-                    end
-                end
-            end
-        ]], "break statement outside of a loop")
-    end)
-
 end)

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -52,7 +52,7 @@ describe("Pallene to Lua translator / #translator", function ()
             local m = {}
             local function f(): integer
         ]],
-        "Unexpected end of the file while trying to parse a statement")
+        "unexpected end of the file while trying to parse a statement")
     end)
 
     it("Unknown type (semantic error)", function ()


### PR DESCRIPTION
Many of the AST tests were not pulling their own weight and were prone to breaking after unrelated changes to the compiler. To keep the test suite more manageable, I decided to delete them.

One kind of test I deleted were test cases asserting that the AST has a specified shape. For a large number of these tests, there are other test cases in the execution tests that effectively test the same thing. I kept only the tests where examining the AST is specially helpful, like the ones for operator precedence.

Another kind of test I deleted were the ones for simple errors like missing tokens or unexpected token. Most of these tests were added in the old implementation, to test the error labels generated by our LPegLabel parser. However, the new parser no longer uses LPegLabel, rendering most of these tests obsolete. I kept a handful of "interesting" tests, which I could get a nice "it" description, and then deleted the rest.

In addition to deleting tests, I also reordered them to help ensure that the test suite is covering all the cases. The test are now ordered in the same order as the parser.lua and it's easier to see if there is a missing test case.

I reindented the AST in a style that is more consistent with the rest of our code base, with 4 spaces for indentation. Previously, there were multiple styles being used to indent the tables.

Finally, I also renamed the "describe" and "it" blocks in more idiomatic Busted style.

Edit: And also rephase all the errors to consistently start with lowercase. This is what Lua and GCC do.