### PR TITLE
Add a location to Stat.Block

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -555,10 +555,9 @@ function Checker:check_stat(stat, is_toplevel)
         stat.call_exp = self:check_exp_synthesize(stat.call_exp)
 
     elseif tag == "ast.Stat.Return" then
-        local ret_types = self.ret_types_stack[#self.ret_types_stack]
-        if not ret_types then
-            type_error(stat.loc, "return statement is not allowed outside a function") -- TODO
-        end
+        -- We know that the return statement can only appear inside a function because the parser
+        -- restricts the allowed toplevel statements
+        local ret_types = assert(self.ret_types_stack[#self.ret_types_stack])
 
         self:expand_function_returns(stat.exps)
         if #stat.exps ~= #ret_types then

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -491,7 +491,8 @@ function Parser:StatList()
 end
 
 function Parser:Block()
-    return ast.Stat.Block(false, self:StatList())
+    assert(self.prev) -- typically a "do", "then", etc
+    return ast.Stat.Block(self.prev.loc, self:StatList())
 end
 
 function Parser:FuncStat(is_local)
@@ -583,7 +584,7 @@ function Parser:Stat(is_toplevel)
         if self:try("else") then
             e_body = self:Block()
         else
-            e_body = ast.Stat.Block(false, {})
+            e_body = ast.Stat.Block(self.next.loc, {})
         end
 
         self:e("end", if_start)

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -414,12 +414,6 @@ end)
 
 describe("Return statement", function()
 
-    it("must be inside a function", function()
-        assert_error([[
-            do return 10 end
-        ]], "return statement is not allowed outside a function")
-    end)
-
     it("detects too few return values", function()
         assert_error([[
             function m.f(): integer

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -414,8 +414,7 @@ end)
 
 describe("Return statement", function()
 
-    -- TODO https://github.com/pallene-lang/pallene/issues/379
-    pending("must be inside a function", function()
+    it("must be inside a function", function()
         assert_error([[
             do return 10 end
         ]], "return statement is not allowed outside a function")


### PR DESCRIPTION
Some compilation errors would try to use these locations to show an error message. If the location was not there, it could crash the compiler. To avoid this we now try to add a location to every statement in the AST.

We also removed the typechecker error for return statements outside a function (which was the error that was triggering this bug in the first place). Since the parser does not allow return statements outside a function, we don't need special treatment for that in the typechecker. An assert suffices for now.
