### PR TITLE
Compilation error for duplicate record fields

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -260,6 +260,9 @@ function Checker:check_program(prog_ast)
             local field_types = {}
             for _, field_decl in ipairs(tl_node.field_decls) do
                 local field_name = field_decl.name
+                if field_types[field_name] then
+                    type_error(tl_node.loc, "duplicate field name '%s' in record type", field_name)
+                end
                 table.insert(field_names, field_name)
                 field_types[field_name] = self:from_ast_type(field_decl.type)
             end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -691,6 +691,8 @@ function RecordCoder:init(owner, record_typ)
     local prim_index = {}
     for _, field_name in ipairs(record_typ.field_names) do
         local typ = record_typ.field_types[field_name]
+        assert(not gc_index[field_name]) -- ensure that field names are not repeated
+        assert(not prim_index[field_name])
         if types.is_gc(typ) then
             gc_count = gc_count + 1
             gc_index[field_name] = gc_count

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -138,6 +138,19 @@ describe("Typealias", function()
 
 end)
 
+describe("Record declaration", function()
+
+    it("must not have repeated field names", function()
+        assert_error([[
+            record P
+                x: integer
+                x: float
+            end
+        ]], "duplicate field name 'x' in record type")
+    end)
+
+end)
+
 describe("Function declaration", function()
 
     it("must set a field in a module (1/2)", function()


### PR DESCRIPTION
Now we raise a compilation error if a record has a field name that appears more than once.

Fixes #381