### PR TITLE
Get rid of types.T.Void

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -470,9 +470,7 @@ function Checker:check_stat(stat, is_toplevel)
         local rhs = stat.exps
         self:expand_function_returns(rhs)
 
-        if not rhs[1] then
-            type_error(stat.loc, "missing right-hand side in for-in loop")
-        end
+        assert(rhs[1])
 
         if not rhs[2] then
             type_error(rhs[1].loc, "missing state variable in for-in loop")

--- a/pallene/types.lua
+++ b/pallene/types.lua
@@ -13,7 +13,6 @@ end
 
 declare_type("T", {
     Any      = {},
-    Void     = {}, -- For functions with 0 returns
     Nil      = {},
     Boolean  = {},
     Integer  = {},
@@ -31,8 +30,7 @@ declare_type("T", {
 
 function types.is_gc(t)
     local tag = t._tag
-    if     tag == "types.T.Void" or
-           tag == "types.T.Nil" or
+    if     tag == "types.T.Nil" or
            tag == "types.T.Boolean" or
            tag == "types.T.Integer" or
            tag == "types.T.Float"
@@ -60,8 +58,7 @@ function types.is_condition(t)
     then
         return true
 
-    elseif tag == "types.T.Void" or
-           tag == "types.T.Nil" or
+    elseif tag == "types.T.Nil" or
            tag == "types.T.Integer" or
            tag == "types.T.Float" or
            tag == "types.T.String" or
@@ -85,8 +82,7 @@ function types.is_indexable(t)
     then
         return true
 
-    elseif tag == "types.T.Void" or
-           tag == "types.T.Nil" or
+    elseif tag == "types.T.Nil" or
            tag == "types.T.Boolean" or
            tag == "types.T.Integer" or
            tag == "types.T.Float" or
@@ -135,7 +131,6 @@ local function equivalent(t1, t2, is_gradual)
         return false
 
     elseif tag1 == "types.T.Any" or
-           tag1 == "types.T.Void" or
            tag1 == "types.T.Nil" or
            tag1 == "types.T.Boolean" or
            tag1 == "types.T.Integer" or
@@ -224,7 +219,6 @@ end
 function types.tostring(t)
     local tag = t._tag
     if     tag == "types.T.Any"         then return "any"
-    elseif tag == "types.T.Void"        then return "void"
     elseif tag == "types.T.Nil"         then return "nil"
     elseif tag == "types.T.Boolean"     then return "boolean"
     elseif tag == "types.T.Integer"     then return "integer"

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -213,6 +213,14 @@ describe("Local variable declaration", function()
         ]], "uninitialized variable 'x' needs a type annotation")
     end)
 
+    it("checks that the RHS has enough values", function()
+        assert_error([[
+            function m.fn()
+                local x, y = 1
+            end
+        ]], "right-hand side produces only 1 value(s)")
+    end)
+
     it("checks that initializers match the type annotation", function()
         assert_error([[
             local x: string = false
@@ -291,18 +299,6 @@ describe("Numeric for-loop", function()
 end)
 
 describe("For-in loop", function()
-
-    -- TODO https://github.com/pallene-lang/pallene/issues/378
-    pending("must have a right-hand side", function()
-        assert_error([[
-            local function voidfn()
-            end
-            function m.fn()
-                for k, v in voidfn() do
-                end
-            end
-        ]], "missing right-hand side in for-in loop")
-    end)
 
     it("must have a RHS with 3 values (missing state variable)", function()
         assert_error([[
@@ -420,6 +416,16 @@ describe("Assignment statement", function()
                 io.write = m.f
             end
         ]], "LHS of assignment is not a mutable variable")
+    end)
+
+    it("catches too few values in RHS", function()
+        assert_error([[
+            function m.f()
+                local x = 1
+                local y =2
+                x, y = 10
+            end
+        ]], "RHS of assignment has 1 value(s), expected 2")
     end)
 
 end)
@@ -833,7 +839,7 @@ describe("Function call", function()
             local function g()
                 local x = 1 + f()
             end
-        ]], "void instead of a number")
+        ]], "calling a void function where a value is expected")
     end)
 
 end)


### PR DESCRIPTION
These types that aren't actual types are a constant source of trouble, because when combined with
type inference there are some situations where they can survive all the way to the coder without
raising an error.

My solution to get rid of them is to only allow void functions in a function call statement, and ban
them from expressions.

Fixes #378