### PR TITLE
Cleanup the multiple_definitions_error

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -528,11 +528,12 @@ function Checker:check_stat(stat, is_toplevel)
                 if not is_toplevel then
                     type_error(var.loc, "module fields can only be set at the toplevel")
                 end
-                local qvar = ast.Var.Name(var.loc, var.name)
-                qvar._type = false -- will be set by the initializer
-                qvar._def = checker.Def.Variable(qvar)
-                qvar._exported_as= var.name
-                stat.vars[i] = qvar
+                local name = var.name
+                var = ast.Var.Name(var.loc, name)
+                var._type = false -- will be set by the initializer
+                var._def = checker.Def.Variable(var)
+                var._exported_as = name
+                stat.vars[i] = var
             else
                 -- Regular assignment
                 stat.vars[i] = self:check_var(stat.vars[i])

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -150,7 +150,7 @@ function ToIR:convert_toplevel(prog_ast)
                 local stag = stat._tag
                 if     stag == "ast.Stat.Assign" then
                     for _, var in ipairs(stat.vars) do
-                        if var._is_exported then
+                        if var._exported_as then
                             assert(var._type)
                             local g_id = ir.add_global(self.module, var.name, var._type)
                             self.glb_id_of_var[var] = g_id


### PR DESCRIPTION
If we use the symbol table as the single source of truth, we don't need to special-case the multiple assignments.