### PR TITLE
Implemented non-mutating closures

### DIFF
--- a/closure-tests
+++ b/closure-tests
@@ -1,0 +1,123 @@
+-- compose f.g
+
+local function twice(x)
+    return x * 2
+end
+
+local function square(x)
+    return x * x
+end
+
+local function compose(f, g)
+    return function(y)
+        return f(g(y))
+    end
+end
+
+local function test_comp()
+    assert(compose(twice, square)(10) == 200)
+    assert(compose(square, twice)(10) == 400)
+end
+
+test_comp()
+
+-- lambda lists
+local function cons(data, next_)
+    return function(op)
+        if op == 'get' then return data end
+        if op == 'next' then return next_ end
+    end
+end
+
+local function car(node)
+    return node('get')
+end
+
+local function cdr(node)
+    return node('next')
+end
+
+local function test_list()
+    local x = cons(1, cons(2, nil))
+    assert(car(x) == 1)
+    assert(car(cdr(x)) == 2)
+    assert(cdr(cdr(x)) == nil)
+end
+
+test_list()
+
+-- mutating an upvalue that was passed to the surrounding function
+-- as a parameter
+
+local function wrap(x)
+    local set = function(y)
+        x = y
+    end
+
+    local get = function()
+        return x
+    end
+
+    return set, get
+end
+
+local function test_wrap()
+    local set, get = wrap(10)
+    assert(get() == 10)
+    set(100)
+    assert(get() == 100)
+end
+
+test_wrap()
+
+-- taking a function expression as an argument
+
+local function make_filter(filter)
+    return function(xs)
+        local res = {}
+        for _, x in ipairs(xs) do
+            if filter(x) then
+                res[#res + 1] = x
+            end
+        end
+        return res
+    end
+end
+
+
+local function test_filter()
+    local filter = make_filter(function (x)
+        return x % 2 == 0
+    end)
+    local evens = filter({ 1, 2, 3, 4, 5 })
+    assert(#evens == 2)
+    assert(evens[1] == 2 and evens[2] == 4)
+end
+
+test_filter()
+
+-- mutating an upvalue captured from an arbitrarily higher scope
+
+local function mut(var)
+    local nest1 = function()
+        local nest2 = function()
+            local nest3 = function()
+                var = var + 10
+                return var
+            end
+            return nest3()
+        end
+        return nest2()
+    end
+
+    -- add `var` to assert that it's value has changed
+    -- both in the scope of nest3 and in the scope of the
+    -- function where it belongs
+    return var + nest1()
+end
+
+local function test_mut()
+    local x = mut(100)
+    assert(x == 220)
+end
+

--- a/pallene/gc.lua
+++ b/pallene/gc.lua
@@ -47,6 +47,7 @@ function gc.compute_stack_slots(func)
     local last_use          = {} -- { var_id => integer }
     local first_definition  = {} -- { var_id => integer }
 
+    -- Upvalues can always be reached by the GC via their closures.
     for i, cmd in ipairs(flat_cmds) do
         for _, val in ipairs(ir.get_srcs(cmd)) do
             if val._tag == "ir.Value.LocalVar" then

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -20,6 +20,10 @@ local function Var(id)
     return "x"..id
 end
 
+local function Upval(id)
+    return "uv"..id
+end
+
 local function Fun(id)
     if id == 1 then
         return "main"
@@ -40,6 +44,7 @@ local function Val(val)
     elseif tag == "ir.Value.Float"    then return C.float(val.value)
     elseif tag == "ir.Value.String"   then return C.string(val.value)
     elseif tag == "ir.Value.LocalVar" then return Var(val.id)
+    elseif tag == "ir.Value.Upvalue"  then return Upval(val.id)
     elseif tag == "ir.Value.Function" then return Fun(val.id)
     else
         typedecl.tag_error(tag)

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2473,6 +2473,29 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                     return x + 1
                 end
             end
+
+            function m.add(x: integer, y: integer): integer
+                local addX: integer -> integer = function(z)
+                    return z + x
+                end
+                return addX(y)
+            end
+
+            function m.make_adder(y: integer): integer -> integer
+                return function(x)
+                    return x + y
+                end
+            end
+
+            function m.add3(x: integer, y: integer, z: integer): integer
+                local add: integer -> integer = function(a)
+                    local f: integer -> integer = function(b)
+                        return b + z
+                    end
+                    return a + f(y)
+                end
+                return add(x)
+            end
         ]])
 
         it("works correctly with non-capturing closures", function ()
@@ -2486,6 +2509,20 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
             ]])
         end)
 
+        it("capturing closures work as expected", function()
+            run_test([[assert(test.add(10, 20) == 30)]])
+        end)
+
+        it("Intermediate closures can capture upvalues to pass them down to nested closures", function()
+            run_test([[assert(test.add3(10, 20, 30) == 60)]])
+        end)
+
+        it("can return a capturing closure", function()
+            run_test([[
+                local add10 = test.make_adder(10)
+                assert(add10(20) == 30)
+            ]])
+        end)
     end)
 
     describe("tostring builtin", function ()


### PR DESCRIPTION
This PR adds support for closures that capture, but do not re-assign to their up-values.

- `ir.Function` now has a `captured_vars` (`{ integer -> ir.VarDecl }`)  and a `id_of_upvalue` (`{ integer -> integer }`) field.
    - `captured_vars` maps a local var id (which is really an upvalue) to it's `decl`
    - `id_of_upvalue` maps the local id of the upvalue to it's local id in the surrounding function.
    
- Here is why I thought the above was necessary:
    1. In `to_ir`, If we tried to assign consecutive local var ids to the arguments and the upvalues, we would have to preprocess the number of upvalues and reserve that many id slots in `loc_id_of_decl` and `ir.Function.vars` before we start registering the local variables.
    2. But since we're registering local variables and upvalues on the go, we may encounter an upvalue for the first time while having assigned some local var IDs already. So naturally we assign the next free local var id (`#local_vars + 1`) to the current upvalue.
    3. This means upvalues may not have consecutive IDs after parameters in the generated C code.
    4. To prevent multiple *declarations* of upvalues in the C code (once as a parameter, and once as a local variable), we make sure `captured_vars[id]` is `nil` before emitting the declaration code for `vars[id]`. (Because upvalues are not present one aftr the other following the parameter list).
    5. When capturing an upvalue (by adding it to `ccl->upvalue`), we need to know the current location of an upvalue in the C stack (it's var id), the `id_of_upvalue` helps with that.

- In `to_ir`, now whenever an identifier is encountered, the order of lookup is:
    1. Local var
    2. Captured var
    3. Global var
    
- In `coder`, some adjustments had to be made in the lua entry point code gen (to add code for capturing the vars), gen_cmd for `NewClosure` (to capture the upvalues) and the pallene entry point (to add the upvalues to the param list.)