### PR TITLE
Disallow func statements with multiple '.'

### DIFF
--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -45,7 +45,7 @@ declare_type("Stat", {
     Call   = {"loc", "call_exp"},
     Return = {"loc", "exps"},
     Break  = {"loc"},
-    Func   = {"loc", "is_local", "root", "fields", "method", "ret_types", "value"},
+    Func   = {"loc", "is_local", "module", "name", "method", "ret_types", "value"},
     LetRec = {"loc", "decls", "func_stats"}, -- For mutual recursion (see parser.lua)
 })
 

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -433,12 +433,12 @@ function Parser:find_letrecs(stats)
             local func_names = {}
             for _, stat in ipairs(funcs) do
                 assert(stat._tag == "ast.Stat.Func")
-                if #stat.fields == 0 and not stat.method then
-                    if not forw_names[stat.root] then
+                if not stat.module then
+                    if not forw_names[stat.name] then
                         self:syntax_error(stat.loc,
-                            "function '%s' was not forward declared", stat.root)
+                            "function '%s' was not forward declared", stat.name)
                     end
-                    func_names[stat.root] = true
+                    func_names[stat.name] = true
                 end
             end
 
@@ -502,16 +502,26 @@ function Parser:FuncStat(is_local)
 
     local fields = {}
     while self:try(".") do
-        local field = self:e("NAME")
-        table.insert(fields, field.value)
+        table.insert(fields, self:e("NAME"))
     end
+
+   	local module, name
+   	if #fields == 0 then
+        module = false
+        name   = root.value
+   	elseif #fields == 1 then
+        module = root.value
+        name   = fields[1].value
+   	else
+        self:syntax_error(fields[2].loc, "more than one dot in the function name is not allowed")
+   	end
 
     local method = false
     if self:try(":") then
         method = self:e("NAME").value
     end
 
-    if is_local and #fields > 0 then
+    if is_local and module then
         self:syntax_error(root.loc, "local function name has a '.'")
     end
     if is_local and method then
@@ -539,7 +549,7 @@ function Parser:FuncStat(is_local)
     end
 
     return ast.Stat.Func(
-        start.loc, is_local, root.value, fields, method, return_types,
+        start.loc, is_local, module, name, method, return_types,
         ast.Exp.Lambda(start.loc, params, block))
 end
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -127,7 +127,7 @@ function ToIR:register_function(stat)
 
     local f_id = self:register_lambda(stat.value, stat.name)
 
-    if not stat.is_local then
+    if stat.module then
         ir.add_exported_function(self.module, f_id)
     end
 end

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -119,16 +119,13 @@ end
 function ToIR:register_function(stat)
     assert(stat._tag == "ast.Stat.Func")
     if stat.is_local then
-        assert(#stat.fields == 0)
+        assert(not stat.module)
         assert(not stat.method)
     else
-        assert(#stat.fields <= 1)
         assert(not stat.method)
     end
 
-    local exp = stat.value
-    local name = stat.fields[1] or stat.root
-    local f_id = self:register_lambda(exp, name)
+    local f_id = self:register_lambda(stat.value, stat.name)
 
     if not stat.is_local then
         ir.add_exported_function(self.module, f_id)

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -181,12 +181,6 @@ describe("Function declaration", function()
         ]], "attempting to assign a function to an external module")
     end)
 
-    it("must have a namespace that is a single level deep", function()
-        assert_error([[
-            function m.f.g() end
-        ]], "more than one dot in the function name is not allowed")
-    end)
-
     it("does not allow global functions", function()
         assert_error([[
             function f(): integer

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -91,13 +91,20 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
         compile([[
             function m.f(): integer return 10 end
             local function g(): integer return 11 end
+            local h
+            function h(): integer return 12 end
         ]])
 
-        it("does not export local functions", function()
-            run_test([[
-                assert(type(test.f) == "function")
-                assert(type(test.g) == "nil")
-            ]])
+        it("exports public functions", function()
+            run_test([[ assert(type(test.f) == "function") ]])
+        end)
+
+        it("does not export local functions (no forward decl)", function()
+            run_test([[ assert(type(test.g) == "nil") ]])
+        end)
+
+        it("does not export local functions (with forward decl)", function()
+            run_test([[ assert(type(test.h) == "nil") ]])
         end)
     end)
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -393,6 +393,13 @@ describe("Parser /", function()
             ]], "expected a name before '('")
         end)
 
+        it("disallow multiple levels of '.'", function()
+            assert_toplevel_error([[
+                function m.f.g()
+                end
+            ]], "more than one dot in the function name is not allowed")
+        end)
+
         it("disallow complex names for local functions (1/2)", function()
             assert_toplevel_error([[
                 local function foo.bar()
@@ -433,8 +440,8 @@ describe("Parser /", function()
                         _tag = "ast.Stat.LetRec",
                         decls = {},
                         func_stats = {
-                            { root = "m", fields = {"f"} },
-                            { root = "m", fields = {"g"} },
+                            { module = "m", name = "f" },
+                            { module = "m", name = "g" },
                         },
                     },
                     {
@@ -444,9 +451,9 @@ describe("Parser /", function()
                             { name = "y" },
                         },
                         func_stats = {
-                            { root = "x" },
-                            { root = "m", fields = {"h"} },
-                            { root = "y" },
+                            { module = false, name = "x" },
+                            { module = "m",   name = "h" },
+                            { module = false, name = "y" },
                         },
                     }
                 },
@@ -467,23 +474,25 @@ describe("Parser /", function()
                         _tag = "ast.Stat.LetRec",
                         decls = {},
                         func_stats = {
-                            { root = "m", fields = {"f"} },
-                            { root = "m", fields = {"g"} },
+                            { module = "m", name = "f" },
+                            { module = "m", name = "g" },
                         },
                     },
                     {
                         _tag = "ast.Stat.Func",
-                        root = "x",
+                        module = false,
+                        name = "x",
                     },
                     {
                         _tag = "ast.Stat.Func",
-                        root = "y",
+                        module = false,
+                        name = "y",
                     },
                     {
                         _tag = "ast.Stat.LetRec",
                         decls = {},
                         func_stats = {
-                            { root = "m", fields = {"h"} },
+                            { module = "m", name = "h" },
                         },
                     }
                 },


### PR DESCRIPTION
Because function statements in Pallene can only be used to initialize module functions, there is no use for "deep statements" like `function m.a.b.c.d()`. To simplify this, I'm changing the AST to only allow a single '.'.  I'm also replacing the "root" and "fields" by  "module" and "name". This way, in both cases you can get the funciton name using `.name`.

There is also a bug fix. I corrected how we check if a function is exported. Previously we used to check if the function statement had a "local" modifier, but that is no longer the right way to do it now that forward declarations exist.