### PR TITLE
Standardize the naming convention in the ir.Cmd

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1447,7 +1447,7 @@ gen_cmd["Break"] = function(self, _cmd, _func)
 end
 
 gen_cmd["If"] = function(self, cmd, func)
-    local condition = self:c_value(cmd.src)
+    local condition = self:c_value(cmd.src_condition)
     local then_ = self:generate_cmd(func, cmd.then_)
     local else_ = self:generate_cmd(func, cmd.else_)
 

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1132,7 +1132,7 @@ end
 
 gen_cmd["NewArr"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
-    local n   = self:c_value(cmd.size_hint)
+    local n   = self:c_value(cmd.src_size)
     return (util.render([[ $dst = pallene_createtable(L, $n, 0); ]], {
         dst = dst, n = n,
     }))
@@ -1183,7 +1183,7 @@ end
 
 gen_cmd["NewTable"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dst)
-    local n   = self:c_value(cmd.size_hint)
+    local n   = self:c_value(cmd.src_size)
     return (util.render([[ $dst = pallene_createtable(L, 0, $n); ]], {
         dst = dst,
         n = n,
@@ -1447,7 +1447,7 @@ gen_cmd["Break"] = function(self, _cmd, _func)
 end
 
 gen_cmd["If"] = function(self, cmd, func)
-    local condition = self:c_value(cmd.condition)
+    local condition = self:c_value(cmd.src)
     local then_ = self:generate_cmd(func, cmd.then_)
     local else_ = self:generate_cmd(func, cmd.else_)
 
@@ -1516,9 +1516,9 @@ gen_cmd["For"] = function(self, cmd, func)
     ]], {
         macro = macro,
         x     = self:c_var(cmd.loop_var),
-        start = self:c_value(cmd.start),
-        limit = self:c_value(cmd.limit),
-        step  = self:c_value(cmd.step),
+        start = self:c_value(cmd.src_start),
+        limit = self:c_value(cmd.src_limit),
+        step  = self:c_value(cmd.src_step),
         body  = self:generate_cmd(func, cmd.body)
     }))
 end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1496,7 +1496,7 @@ gen_cmd["Loop"] = function(self, cmd, func)
 end
 
 gen_cmd["For"] = function(self, cmd, func)
-    local typ = func.vars[cmd.loop_var].typ
+    local typ = func.vars[cmd.dst].typ
 
     local macro
     if     typ._tag == "types.T.Integer" then
@@ -1515,7 +1515,7 @@ gen_cmd["For"] = function(self, cmd, func)
         ${macro}_END
     ]], {
         macro = macro,
-        x     = self:c_var(cmd.loop_var),
+        x     = self:c_var(cmd.dst),
         start = self:c_value(cmd.src_start),
         limit = self:c_value(cmd.src_limit),
         step  = self:c_value(cmd.src_step),

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -177,7 +177,7 @@ local ir_cmd_constructors = {
     Loop    = {"body"},
 
     If      = {"loc", "src", "then_", "else_"},
-    For     = {"loc", "loop_var", "src_start", "src_limit", "src_step", "body"},
+    For     = {"loc", "dst", "src_start", "src_limit", "src_step", "body"},
 
     -- Garbage Collection (appears after memory allocations)
     CheckGC = {},

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -132,13 +132,13 @@ local ir_cmd_constructors = {
     IsNil      = {"loc", "dst", "src"},
 
     -- Arrays
-    NewArr     = {"loc", "dst", "size_hint"},
+    NewArr     = {"loc", "dst", "src_size"},
 
     GetArr     = {"loc", "dst_typ", "dst", "src_arr", "src_i"},
     SetArr     = {"loc", "src_typ",        "src_arr", "src_i", "src_v"},
 
     -- Tables
-    NewTable   = {"loc", "dst", "size_hint"},
+    NewTable   = {"loc", "dst", "src_size"},
 
     GetTable   = {"loc", "dst_typ", "dst", "src_tab", "src_k"},
     SetTable   = {"loc", "src_typ",        "src_tab", "src_k", "src_v"},
@@ -174,8 +174,8 @@ local ir_cmd_constructors = {
     Break   = {},
     Loop    = {"body"},
 
-    If      = {"loc", "condition", "then_", "else_"},
-    For     = {"loc", "loop_var", "start", "limit", "step", "body"},
+    If      = {"loc", "src", "then_", "else_"},
+    For     = {"loc", "loop_var", "src_start", "src_limit", "src_step", "body"},
 
     -- Garbage Collection (appears after memory allocations)
     CheckGC = {},
@@ -187,8 +187,8 @@ local  src_fields = {
     "src", "src1", "src2",
     "src_arr", "src_tab", "src_rec", "src_i", "src_k", "src_v",
     "src_f",
-    "size_hint",
-    "condition", "start", "limit", "step" }
+    "src_size",
+    "src_start", "src_limit", "src_step" }
 local srcs_fields = { "srcs" }
 
 function ir.get_srcs(cmd)
@@ -361,7 +361,7 @@ function ir.clean(cmd)
         end
 
     elseif tag == "ir.Cmd.If" then
-        local v = cmd.condition
+        local v = cmd.src
         cmd.then_ = ir.clean(cmd.then_)
         cmd.else_ = ir.clean(cmd.else_)
         local t_empty = (cmd.then_._tag == "ir.Cmd.Nop")

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -176,7 +176,7 @@ local ir_cmd_constructors = {
     Break   = {},
     Loop    = {"body"},
 
-    If      = {"loc", "src", "then_", "else_"},
+    If      = {"loc", "src_condition", "then_", "else_"},
     For     = {"loc", "dst", "src_start", "src_limit", "src_step", "body"},
 
     -- Garbage Collection (appears after memory allocations)
@@ -333,7 +333,7 @@ function ir.clean(cmd)
         end
 
     elseif tag == "ir.Cmd.If" then
-        local v = cmd.src
+        local v = cmd.src_condition
         cmd.then_ = ir.clean(cmd.then_)
         cmd.else_ = ir.clean(cmd.else_)
         local t_empty = (cmd.then_._tag == "ir.Cmd.Nop")

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -138,7 +138,7 @@ local function Cmd(cmd)
             body = Cmd(cmd.body)
         })
     elseif tag == "ir.Cmd.If" then
-        local cond  = Val(cmd.src)
+        local cond  = Val(cmd.src_condition)
         local then_ = Cmd(cmd.then_)
         local else_ = Cmd(cmd.else_)
 

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -180,7 +180,7 @@ local function Cmd(cmd)
                 $body
             }
         ]], {
-            v = Var(cmd.loop_var),
+            v = Var(cmd.dst),
             a = Val(cmd.src_start),
             b = Val(cmd.src_limit),
             c = Val(cmd.src_step),

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -138,7 +138,7 @@ local function Cmd(cmd)
             body = Cmd(cmd.body)
         })
     elseif tag == "ir.Cmd.If" then
-        local cond  = Val(cmd.condition)
+        local cond  = Val(cmd.src)
         local then_ = Cmd(cmd.then_)
         local else_ = Cmd(cmd.else_)
 
@@ -181,9 +181,9 @@ local function Cmd(cmd)
             }
         ]], {
             v = Var(cmd.loop_var),
-            a = Val(cmd.start),
-            b = Val(cmd.limit),
-            c = Val(cmd.step),
+            a = Val(cmd.src_start),
+            b = Val(cmd.src_limit),
+            c = Val(cmd.src_step),
             body = Cmd(cmd.body),
         })
     end

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -109,7 +109,7 @@ local function test(cmd, uninit, loop)
         loop.is_infinite = false
         merge(loop.uninit, uninit)
 
-        uninit[cmd.loop_var] = nil
+        uninit[cmd.dst] = nil
         test(cmd.body, uninit, loop)
 
         if loop.is_infinite then


### PR DESCRIPTION
I renamed some fields to enforce the convention that all the fields with `ir.Value` are named `src` and all the fields with a variable ID are named `dst`.

Then I took advantage of this convention in the `ir.get_srcs` and `it.get_dsts`, so that we no longer need to write out all the field names. We also got rid of the "global" order of precedence for the field names. Now, the `ir.get_srcs` knows which field names to access for each kind of Cmd, and it accesses them in the same order that they appear in the constructor.