### PR TITLE
Convert tabs to spaces

### DIFF
--- a/examples/rectangle/rectangle.pln
+++ b/examples/rectangle/rectangle.pln
@@ -8,8 +8,8 @@ local m: module = {}
 typealias rectangle = { width: float, height: float }
 
 function m.find_area(r: rectangle): float
-	local result = r.width * r.height
-	return result
+    local result = r.width * r.height
+    return result
 end
 
 return m

--- a/lint-project
+++ b/lint-project
@@ -1,2 +1,19 @@
-#!/bin/sh
-luacheck pallene/ spec/ examples/ "$@"
+#!/bin/bash
+
+srcdirs=(pallene/ spec/ examples/)
+
+# Lint our Lua code
+luacheck "${srcdirs[@]}" "$@" || exit 1
+
+# Also check if there is tab-based indentation. Luacheck doesn't do this.
+tab='	'
+if
+    grep --recursive \
+        --include='*.c'   \
+        --include='*.lua' \
+        --include='*.pln' \
+        "^$tab" "${srcdirs[@]}"
+then
+    echo "Detected tab-based indentation"
+    exit 1
+fi

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -128,7 +128,7 @@ declare_type("Value", {
 local ir_cmd_constructors = {
     -- [IMPORTANT] Please use this naming convention:
     --  - "src" fields contain an "ir.Value".
-	--  - "dst" fields contain a local variable ID.
+    --  - "dst" fields contain a local variable ID.
 
     -- Variables
     Move       = {"loc", "dst", "src"},

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -417,7 +417,7 @@ function Parser:find_letrecs(stats)
             if not (stat and stat._tag == "ast.Stat.Functions") then break end
             if next(stat.declared_names) then break end
             for _, func in ipairs(stat.funcs) do
-	            table.insert(funcs, func)
+                table.insert(funcs, func)
             end
             i = i + 1
         end
@@ -510,8 +510,8 @@ function Parser:FuncStat(is_local)
     if self:try(".") then
         field = self:e("NAME").value
         if self:try(".") then
-	        self:syntax_error(self.prev.loc,
-	            "more than one dot in the function name is not allowed")
+            self:syntax_error(self.prev.loc,
+                "more than one dot in the function name is not allowed")
         end
     end
 


### PR DESCRIPTION
I accidentally indented a couple of things using tabs. This commit replaces them all by spaces and it adds a linter check to prevent this from happening again.