### PR TITLE
Implement mutating closures

### DIFF
--- a/benchmarks/fannkuchredux/lua.lua
+++ b/benchmarks/fannkuchredux/lua.lua
@@ -1,4 +1,4 @@
-local m;m = {}
+local m = {}
 
 function m.fannkuch(N)
 

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -266,9 +266,6 @@ function Converter:visit_stat(stat)
     elseif tag == "ast.Stat.Call" then
         stat.call_exp = self:convert_exp(stat.call_exp)
 
-    elseif  tag == "ast.Stat.Func" then
-        self:visit_func(stat)
-
     elseif  tag == "ast.Stat.Break" then
         -- empty
     else

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -64,9 +64,9 @@ end
 function Converter:init()
     self.update_ref_of_decl      = {} -- { ast.Decl => list of NodeUpdate }
 
-    -- The `func_depth_of_decl` is maps a decl to the depth of the function where it appears
+    -- The `func_depth_of_decl` maps a decl to the depth of the function where it appears.
     -- This helps distinguish between mutated variables that are locals and globals from those
-    -- that are captured upvalues and need to be AST transformed.
+    -- that are captured upvalues and need to be transformed to a different kind of node.
     self.func_depth_of_decl      = {} -- { ast.Decl => integer }
     self.update_init_exp_of_decl = {} -- { ast.Decl => NodeUpdate }
     self.mutated_decls           = {} -- list of ast.Decl
@@ -288,8 +288,8 @@ function Converter:visit_stat(stat)
     end
 end
 
--- This function takes an `ast.Var.*` node and a callback that should replace the reference to the
--- var at the call site with a transformed AST node, provided the new type as an argument. 
+-- This function takes an `ast.Var` node and a callback that should replace the reference to the
+-- var at the call site with a transformed AST node, provided the new AST node as an argument. 
 -- If it is found out  later that `var` is being captured and mutated somewhere then `update_fn`
 -- is called to transform it to an `ast.Var.Dot` Node.
 --

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -2,11 +2,8 @@ local util     = require "pallene.util"
 local typedecl = require "pallene.typedecl"
 local types    = require "pallene.types"
 local ast      = require "pallene.ast"
-local checker  = require "pallene.checker"
 
 local converter = {}
-
-local Converter = util.Class()
 
 --
 --  ASSIGNMENT CONVERSION
@@ -16,11 +13,11 @@ local Converter = util.Class()
 -- are 'boxed' inside records. For example, consider this code:
 -- ```
 -- function m.foo()
---	   local x: integer = 10
+--     local x: integer = 10
 --     local set_x: (integer) -> () = function (y)
---	   		x = y
--- 	   end
--- 	   local get_x: () -> integer = function () return x end
+--          x = y
+--     end
+--     local get_x: () -> integer = function () return x end
 -- end
 --```
 -- The AST representation of the above snippet, will be converted in this pass to
@@ -33,261 +30,274 @@ local Converter = util.Class()
 -- function m.foo()
 --     local x: $T = { value = 10 }
 --     local set_x: (integer) -> () = function (y)
---	   		x.value = y
--- 	   end
--- 	   local get_x: () -> integer = function () return x.value end
+--          x.value = y
+--     end
+--     local get_x: () -> integer = function () return x.value end
 -- end
 -- ```
 
+local Converter = util.Class()
 
 function converter.convert(prog_ast)
-	return Converter.new():visit_prog(prog_ast)
+    return Converter.new():visit_prog(prog_ast)
 end
 
 
 local function FuncInfo()
-	return {
-		mutated_decls  = {}, -- list of ast.Decl
-		captured_decls = {} -- { ast.Decl }
-	}
+    return {
+        mutated_decls  = {}, -- list of ast.Decl
+        captured_decls = {} -- { ast.Decl }
+    }
 end
 
 function Converter:init()
-	self.func_stack = {} -- list of FuncInfo
-	local func_info = FuncInfo()
-	table.insert(self.func_stack, func_info)
+    self.func_stack = {} -- list of FuncInfo
+    local func_info = FuncInfo()
+    table.insert(self.func_stack, func_info)
 
-	self.ref_to_decl        = {} -- list of ast.Var.Name
-	self.func_depth_of_decl = {} -- { ast.Decl.Decl => integer }
-	self.init_exp_of_decl   = {} -- { ast.Decl.Decl => ast.Exp }
-	self.box_records 	    = {} -- list of ast.Toplevel.Record
+    self.ref_to_decl        = {} -- list of ast.Var.Name
+    self.func_depth_of_decl = {} -- { ast.Decl.Decl => integer }
+    self.init_exp_of_decl   = {} -- { ast.Decl.Decl => ast.Exp }
+    self.box_records        = {} -- list of ast.Toplevel.Record
 
-	-- used to assign unique names to subsequently generated record types
-	self.typ_counter = 0
+    -- used to assign unique names to subsequently generated record types
+    self.typ_counter = 0
 end
 
 -- generates a unique type name each time
 function Converter:type_name(var_name)
-	self.typ_counter = self.typ_counter + 1
-	return "$T_"..var_name.."_"..self.typ_counter
+    self.typ_counter = self.typ_counter + 1
+    return "$T_"..var_name.."_"..self.typ_counter
 end
 
 function Converter:add_box_type(loc, typ)
-	local dummy_node = ast.Toplevel.Record(loc, types.tostring(typ), {})
-	dummy_node._type = typ
-	table.insert(self.box_records, dummy_node)
+    local dummy_node = ast.Toplevel.Record(loc, types.tostring(typ), {})
+    dummy_node._type = typ
+    table.insert(self.box_records, dummy_node)
 end
 
 function Converter:register_decl(decl)
-	if not self.ref_to_decl[decl] then
-		self.ref_to_decl[decl]        = {}
-		self.func_depth_of_decl[decl] = #self.func_stack
-	end 
+    if not self.ref_to_decl[decl] then
+        self.ref_to_decl[decl]        = {}
+        self.func_depth_of_decl[decl] = #self.func_stack
+    end 
 end
 
 function Converter:visit_prog(prog_ast)
-	assert(prog_ast._tag == "ast.Program.Program")
-	for _, tl_node in ipairs(prog_ast.tls) do
-		if tl_node._tag == "ast.Toplevel.Stats" then
-			for _, stat in ipairs(tl_node.stats) do
-				self:visit_stat(stat)
-			end
-		else
-			-- skip record declarations and type aliases
-			assert(typedecl.match_tag(tl_node._tag, "ast.Toplevel"))
-		end
-	end
+    assert(prog_ast._tag == "ast.Program.Program")
+    for _, tl_node in ipairs(prog_ast.tls) do
+        if tl_node._tag == "ast.Toplevel.Stats" then
+            for _, stat in ipairs(tl_node.stats) do
+                self:visit_stat(stat)
+            end
+        else
+            -- skip record declarations and type aliases
+            assert(typedecl.match_tag(tl_node._tag, "ast.Toplevel"))
+        end
+    end
 
-	-- add the box types to the AST
-	for _, node in ipairs(self.box_records) do
-		table.insert(prog_ast.tls, node)
-	end
+    -- add the upvalue box record types to the AST
+    for _, node in ipairs(self.box_records) do
+        table.insert(prog_ast.tls, node)
+    end
 
-	return prog_ast
+    return prog_ast
 end
 
 function Converter:visit_stats(stats)
-	for _, stat in ipairs(stats) do
-		self:visit_stat(stat)
-	end
+    for _, stat in ipairs(stats) do
+        self:visit_stat(stat)
+    end
 end
 
 -- Goes over all the ast.Decls inside the function that have been captured by some nested
 -- function, transforms the decl node itself and all the references made to it.
-function Converter:exit_lambda(lambda)
-	local func_info = self.func_stack[#self.func_stack]
-	for _, decl in ipairs(func_info.mutated_decls) do
-		if func_info.captured_decls[decl] then
-			-- 1. Create a record type `$T` to hold this captured var.
-			-- 2. Transform the ast.Decl node from `local x = value` to `local x: $T =  { value = value }`
-			-- 3. Go over all the references ever made to this variable and transform them from `ast.Var.Name`
-			-- 	  to ast.Var.Dot
-			local typ = types.T.Record(self:type_name(decl.name), { "value" } , { value = decl._type } )
-			self:add_box_type(decl.loc, typ)
-			decl._type = typ
+function Converter:exit_lambda()
+    local func_info = self.func_stack[#self.func_stack]
+    for _, decl in ipairs(func_info.mutated_decls) do
+        if func_info.captured_decls[decl] then
+            assert(not decl._exported_as)
 
-			local init_exp = self.init_exp_of_decl[decl]
-			
-			if init_exp then
-				local value_exp = util.copy_table(init_exp)
-				util.empty_table(init_exp)
+            -- 1. Create a record type `$T` to hold this captured var.
+            -- 2. Transform the ast.Decl node from `local x = value` to `local x: $T =  { value = value }`
+            -- 3. Go over all the references ever made to this variable and transform them from `ast.Var.Name`
+            --    to ast.Var.Dot
+            local typ = types.T.Record(self:type_name(decl.name), { "value" } , { value = decl._type } )
+            self:add_box_type(decl.loc, typ)
+            decl._type = typ
 
-				init_exp._tag   = "ast.Exp.InitList"
-				init_exp._type  = typ
-				init_exp.fields = {}
-				init_exp.fields[1] = { name = "value", exp = value_exp }
-			end
+            local init_exp = self.init_exp_of_decl[decl]
 
-			for _, ref in ipairs(self.ref_to_decl[decl]) do
-				assert(ref._tag == "ast.Var.Name")
-				local var = util.copy_table(ref)
-				ref._tag = "ast.Var.Dot"
-				ref.exp  =  ast.Exp.Var(ref.loc, var)
-				ref.name = "value"
+            if init_exp then
+                local value_exp = util.copy_table(init_exp)
+                util.empty_table(init_exp)
 
-				ref.exp._type = typ
-			end
-		end
-	end
+                init_exp._tag   = "ast.Exp.InitList"
+                init_exp._type  = typ
+                init_exp.fields = {}
+                init_exp.fields[1] = { name = "value", exp = value_exp }
+            else
+                error("upvalues that are not initialized upon declaration cannot be captured.")
+            end
 
-	assert(#self.func_stack > 1)
-	table.remove(self.func_stack)
+            for _, ref in ipairs(self.ref_to_decl[decl]) do
+                assert(ref._tag == "ast.Var.Name")
+                local var = util.copy_table(ref)
+                ref._tag = "ast.Var.Dot"
+                ref.exp  =  ast.Exp.Var(ref.loc, var)
+                ref.name = "value"
+
+                ref.exp._type = typ
+            end
+        end
+    end
+
+    assert(#self.func_stack > 1)
+    table.remove(self.func_stack)
 end
 
 function Converter:visit_lambda(lambda)
-	local func_info = FuncInfo()
-	table.insert(self.func_stack, func_info)
+    local func_info = FuncInfo()
+    table.insert(self.func_stack, func_info)
 
-	self:visit_stats(lambda.body.stats)
-	self:exit_lambda(lambda)
+    for _, arg in ipairs(lambda.arg_decls) do
+        self:register_decl(arg)
+    end
+
+    self:visit_stats(lambda.body.stats)
+    self:exit_lambda()
 end
 
 function Converter:visit_func(func)
-	assert(func._tag == "ast.Stat.Func")
-	local lambda = func.value
-	assert(lambda and lambda._tag == "ast.Exp.Lambda")
-	self:visit_lambda(lambda)
+    assert(func._tag == "ast.FuncStat.FuncStat")
+    local lambda = func.value
+    assert(lambda and lambda._tag == "ast.Exp.Lambda")
+    self:visit_lambda(lambda)
 end
 
 function Converter:convert_exps_of_stat(stat)
-	local exps = assert(stat.exps)
-	for i, exp in ipairs(exps) do
-		exps[i] = self:convert_exp(exp)
-	end
+    local exps = assert(stat.exps)
+    for i, exp in ipairs(exps) do
+        exps[i] = self:convert_exp(exp)
+    end
 end
 
 function Converter:visit_stat(stat)
-	local tag = stat._tag
-	if tag == "ast.Stat.LetRec" then
-		for _, func in ipairs(stat.func_stats) do
-			self:visit_func(func)
-		end
-	
-	elseif tag == "ast.Stat.Return" then
-		self:convert_exps_of_stat(stat)
-	
-	elseif tag == "ast.Stat.Decl" then
-		for _, decl in ipairs(stat.decls) do
-			self:register_decl(decl)
-		end
+    local tag = stat._tag
+    if tag == "ast.Stat.Functions" then
+        for _, func in ipairs(stat.funcs) do
+            self:visit_func(func)
+        end
+    
+    elseif tag == "ast.Stat.Return" then
+        self:convert_exps_of_stat(stat)
+    
+    elseif tag == "ast.Stat.Decl" then
+        for _, decl in ipairs(stat.decls) do
+            self:register_decl(decl)
+        end
 
-		for i, exp in ipairs(stat.exps) do
-			stat.exps[i] = self:convert_exp(exp)
-			self.init_exp_of_decl[stat.decls[i]] = exp
-		end
+        for i, exp in ipairs(stat.exps) do
+            stat.exps[i] = self:convert_exp(exp)
+            -- do not register extra values on RHS
+            if i <= #stat.decls then
+                self.init_exp_of_decl[stat.decls[i]] = exp
+            end
+        end
 
-	elseif tag == "ast.Stat.Block" then
-		self:visit_stats(stat.stats)
+    elseif tag == "ast.Stat.Block" then
+        self:visit_stats(stat.stats)
 
-	elseif tag == "ast.Stat.While" or tag == "ast.Stat.Repeat" then
-		stat.condition = self:convert_exp(stat.condition)
-		self:visit_stats(stat.block.stats)
+    elseif tag == "ast.Stat.While" or tag == "ast.Stat.Repeat" then
+        self:visit_stats(stat.block.stats)
+        stat.condition = self:convert_exp(stat.condition)
 
-	elseif tag == "ast.Stat.If" then
-		stat.condition = self:convert_exp(stat.condition)
-		self:visit_stats(stat.then_.stats)
-		if stat.else_ then
-			self:visit_stat(stat.else_)
-		end
-	
-	elseif tag == "ast.Stat.ForNum" then
-		stat.start = self:convert_exp(stat.start)
-		stat.limit = self:convert_exp(stat.limit)
-		stat.step  = self:convert_exp(stat.step)
+    elseif tag == "ast.Stat.If" then
+        stat.condition = self:convert_exp(stat.condition)
+        self:visit_stats(stat.then_.stats)
+        if stat.else_ then
+            self:visit_stat(stat.else_)
+        end
+    
+    elseif tag == "ast.Stat.ForNum" then
+        stat.start = self:convert_exp(stat.start)
+        stat.limit = self:convert_exp(stat.limit)
+        stat.step  = self:convert_exp(stat.step)
 
-		self:visit_stats(stat.block.stats)
-		self:register_decl(stat.decl)
+        self:register_decl(stat.decl)
+        self:visit_stats(stat.block.stats)
 
-	elseif tag == "ast.Stat.ForIn" then
-		for _, decl in ipairs(stat.decls) do
-			self:register_decl(decl)
-		end
+    elseif tag == "ast.Stat.ForIn" then
+        for _, decl in ipairs(stat.decls) do
+            self:register_decl(decl)
+        end
 
-		self:convert_exps_of_stat(stat)
-		self:visit_stats(stat.block.stats)
+        self:convert_exps_of_stat(stat)
+        self:visit_stats(stat.block.stats)
 
-	elseif tag == "ast.Stat.Assign" then
-		for i, var in ipairs(stat.vars) do
-			stat.vars[i] = self:convert_var(var)
-			
-			if var._tag == "ast.Var.Name" then
-				if var._def._tag == "checker.Def.Variable" then
-					local decl = assert(var._def.decl)
-					local depth = self.func_depth_of_decl[decl]
-					local func_info = self.func_stack[depth]
-					table.insert(func_info.mutated_decls, decl) 
-				end
-			end
-		end
+    elseif tag == "ast.Stat.Assign" then
+        for i, var in ipairs(stat.vars) do
+            stat.vars[i] = self:convert_var(var)
+            
+            if var._tag == "ast.Var.Name" and not var._exported_as then
+                if var._def._tag == "checker.Def.Variable" then
+                    local decl = assert(var._def.decl)
+                    local depth = self.func_depth_of_decl[decl]
+                    local func_info = self.func_stack[depth]
+                    table.insert(func_info.mutated_decls, decl) 
+                end
+            end
+        end
 
-		self:convert_exps_of_stat(stat)
+        self:convert_exps_of_stat(stat)
 
-	elseif tag == "ast.Stat.Decl" then
-		for _, decl in ipairs(stat.decls) do
-			self:register_decl(decl)
-		end
+    elseif tag == "ast.Stat.Decl" then
+        for _, decl in ipairs(stat.decls) do
+            self:register_decl(decl)
+        end
 
-		self:convert_exps_of_stat(stat)
+        self:convert_exps_of_stat(stat)
 
-	elseif tag == "ast.Stat.Call" then
-		stat.call_exp = self:convert_exp(stat.call_exp)
+    elseif tag == "ast.Stat.Call" then
+        stat.call_exp = self:convert_exp(stat.call_exp)
 
-	elseif  tag == "ast.Stat.Func" then
-		self:visit_func(stat)
+    elseif  tag == "ast.Stat.Func" then
+        self:visit_func(stat)
 
-	elseif  tag == "ast.Stat.Break" then
-		-- empty
-	else
-		typedecl.tag_error(tag)
-	end
+    elseif  tag == "ast.Stat.Break" then
+        -- empty
+    else
+        typedecl.tag_error(tag)
+    end
 end
 
 
 function Converter:convert_var(var)
-	local vtag = var._tag
-	if vtag == "ast.Var.Name" then
-		if var._def._tag == "checker.Def.Variable" then
-			local decl = assert(var._def.decl)
-			assert(self.ref_to_decl[decl])
-			local depth = self.func_depth_of_decl[decl]
-			-- depth == 1 when the decl is that of a global
-			if depth < #self.func_stack and depth > 1 then
-				local func_info = self.func_stack[depth]
-				func_info.captured_decls[decl] = true
-			end
-			table.insert(self.ref_to_decl[decl], var)
-		end
+    local vtag = var._tag
 
-	elseif vtag == "ast.Var.Dot" then
-		var.exp = self:convert_exp(var.exp)
-	
-	elseif vtag == "ast.Var.Bracket" then
-		var.t = self:convert_exp(var.t)
-		var.k = self:convert_exp(var.k)
-	
-	end
+    if vtag == "ast.Var.Name" and not var._exported_as then
+        if var._def._tag == "checker.Def.Variable" then
+            local decl = assert(var._def.decl)
+            assert(self.ref_to_decl[decl], decl.name)
+            local depth = self.func_depth_of_decl[decl]
+            -- depth == 1 when the decl is that of a global
+            if depth < #self.func_stack and depth > 1 then
+                local func_info = self.func_stack[depth]
+                func_info.captured_decls[decl] = true
+            end
+            table.insert(self.ref_to_decl[decl], var)
+        end
 
-	return var
+    elseif vtag == "ast.Var.Dot" then
+        var.exp = self:convert_exp(var.exp)
+    
+    elseif vtag == "ast.Var.Bracket" then
+        var.t = self:convert_exp(var.t)
+        var.k = self:convert_exp(var.k)
+    
+    end
+
+    return var
 end
 
 -- If necessary, transforms `exp` or one of it's subexpression nodes in case they 
@@ -298,40 +308,40 @@ end
 -- be called like so:
 -- `exp = self:convert_exp(exp)`
 function Converter:convert_exp(exp)
-	local tag = exp._tag
+    local tag = exp._tag
 
-	if tag == "ast.Exp.InitList" then
-		for _, field in ipairs(exp.fields) do
-			field.exp = self:convert_exp(field.exp)
-		end
+    if tag == "ast.Exp.InitList" then
+        for _, field in ipairs(exp.fields) do
+            field.exp = self:convert_exp(field.exp)
+        end
 
-	elseif tag == "ast.Exp.Lambda" then
-		self:visit_lambda(exp)
+    elseif tag == "ast.Exp.Lambda" then
+        self:visit_lambda(exp)
 
-	elseif tag == "ast.Exp.CallFunc" or tag == "ast.Exp.CallMethod" then
-		exp.exp = self:convert_exp(exp.exp)
-		for i = 1, #exp.args do
-			exp.args[i] = self:convert_exp(exp.args[i])
-		end
+    elseif tag == "ast.Exp.CallFunc" or tag == "ast.Exp.CallMethod" then
+        exp.exp = self:convert_exp(exp.exp)
+        for i = 1, #exp.args do
+            exp.args[i] = self:convert_exp(exp.args[i])
+        end
 
-	elseif tag == "ast.Exp.Var" then
-		exp.var = self:convert_var(exp.var)
+    elseif tag == "ast.Exp.Var" then
+        exp.var = self:convert_var(exp.var)
 
-	elseif tag == "ast.Exp.Unop" 
-		or tag == "ast.Exp.Cast" 
-		or tag == "ast.Exp.ToFloat" 
-		or tag == "ast.Exp.Paren" then
-		exp.exp = self:convert_exp(exp.exp)
+    elseif tag == "ast.Exp.Unop" 
+        or tag == "ast.Exp.Cast" 
+        or tag == "ast.Exp.ToFloat" 
+        or tag == "ast.Exp.Paren" then
+        exp.exp = self:convert_exp(exp.exp)
 
-	elseif tag == "ast.Exp.Binop" then
-		exp.lhs = self:convert_exp(exp.lhs)
-		exp.rhs = self:convert_exp(exp.rhs)
+    elseif tag == "ast.Exp.Binop" then
+        exp.lhs = self:convert_exp(exp.lhs)
+        exp.rhs = self:convert_exp(exp.rhs)
 
-	elseif not typedecl.match_tag(tag, "ast.Exp") then
-		typedecl.tag_error(tag)
-	end
+    elseif not typedecl.match_tag(tag, "ast.Exp") then
+        typedecl.tag_error(tag)
+    end
 
-	return exp
+    return exp
 end
 
 return converter

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -1,0 +1,228 @@
+local util     = require "pallene.util"
+local typedecl = require "pallene.typedecl"
+
+local converter = {}
+
+local Converter = util.Class()
+
+--
+--  ASSIGNMENT CONVERSION
+-- ======================
+-- This Compiler pass handles mutable captured variables inside nested closures by
+-- transforming AST Nodes that reference or re-assign to them. All captured variables
+-- are 'boxed' inside records. For example, consider this code:
+-- ```
+-- function m.foo()
+--	   local x: integer = 10
+--     local set_x: (integer) -> () = function (y)
+--	   		x = y
+-- 	   end
+-- 	   local get_x: () -> integer = function () return x end
+-- end
+--```
+-- The AST representation of the above snippet, will be converted in this pass to
+-- something like the following:
+-- ```
+-- record $T
+--     value: integer
+-- end
+--
+-- function m.foo()
+--     local x: $T = { value = 10 }
+--     local set_x: (integer) -> () = function (y)
+--	   		x.value = y
+-- 	   end
+-- 	   local get_x: () -> integer = function () return x.value end
+-- end
+-- ```
+
+
+function converter.convert(prog_ast)
+	return Converter.new():visit_prog(prog_ast)
+end
+
+function Converter:init()
+	self.ref_to_decl    = {} -- list of ast.Var.Name
+	self.captured_decls = {} -- list of ast.Decl.Decl
+end
+
+function Converter:register_decl(decl)
+	if not self.ref_to_decl[decl] then
+		self.ref_to_decl[decl] = {}
+	end 
+end
+
+function Converter:visit_prog(prog_ast)
+	assert(prog_ast._tag == "ast.Program.Program")
+	for _, tl_node in ipairs(prog_ast.tls) do
+		if tl_node._tag == "ast.Toplevel.Stats" then
+			for _, stat in ipairs(tl_node.stats) do
+				self:visit_stat(stat)
+			end
+		else
+			-- skip record declarations and type aliases
+			assert(typedecl.match_tag(tl_node._tag, "ast.Toplevel"))
+		end
+	end
+
+	return prog_ast
+end
+
+function Converter:visit_stats(stats)
+	for _, stat in ipairs(stats) do
+		self:visit_stat(stat)
+	end
+end
+
+function Converter:visit_func(func)
+	assert(func._tag == "ast.Stat.Func")
+	local lambda = func.value
+	assert(lambda and lambda._tag == "ast.Exp.Lambda")
+	self:visit_stats(lambda.body.stats)
+end
+
+function Converter:convert_exps_of_stat(stat)
+	local exps = assert(stat.exps)
+	for i, exp in ipairs(exps) do
+		exps[i] = self:convert_exp(exp)
+	end
+end
+
+function Converter:visit_stat(stat)
+	local tag = stat._tag
+	if tag == "ast.Stat.LetRec" then
+		for _, func in ipairs(stat.func_stats) do
+			self:visit_func(func)
+		end
+	
+	elseif tag == "ast.Stat.Return" then
+		self:convert_exps_of_stat(stat)
+	
+	elseif tag == "ast.Stat.Decl" then
+		for _, decl in ipairs(stat.decls) do
+			self:register_decl(decl)
+		end
+
+		self:convert_exps_of_stat(stat)
+
+	elseif tag == "ast.Stat.Block" then
+		self:visit_stats(stat.stats)
+
+	elseif tag == "ast.Stat.While" or tag == "ast.Stat.Repeat" then
+		stat.condition = self:convert_exp(stat.condition)
+		self:visit_stats(stat.block.stats)
+
+	elseif tag == "ast.Stat.If" then
+		stat.condition = self:convert_exp(stat.condition)
+		self:visit_stats(stat.then_.stats)
+		if stat.else_ then
+			self:visit_stat(stat.else_)
+		end
+	
+	elseif tag == "ast.Stat.ForNum" then
+		stat.start = self:convert_exp(stat.start)
+		stat.limit = self:convert_exp(stat.limit)
+		stat.step  = self:convert_exp(stat.step)
+
+		self:visit_stats(stat.block.stats)
+		self:register_decl(stat.decl)
+
+	elseif tag == "ast.Stat.ForIn" then
+		for _, decl in ipairs(stat.decls) do
+			self:register_decl(decl)
+		end
+
+		self:convert_exps_of_stat(stat)
+		self:visit_stats(stat.block.stats)
+
+	elseif tag == "ast.Stat.Assign" then
+		for i, var in ipairs(stat.vars) do
+			stat.vars[i] = self:convert_var(var)
+		end
+
+		self:convert_exps_of_stat(stat)
+
+	elseif tag == "ast.Stat.Decl" then
+		for _, decl in ipairs(stat.decls) do
+			self:register_decl(decl)
+		end
+
+		self:convert_exps_of_stat(stat)
+
+	elseif tag == "ast.Stat.Call" then
+		stat.call_exp = self:convert_exp(stat.call_exp)
+
+	elseif  tag == "ast.Stat.Func" then
+		self:visit_func(stat)
+
+	elseif  tag == "ast.Stat.Break" then
+		-- empty
+	else
+		typedecl.tag_error(tag)
+	end
+end
+
+
+function Converter:convert_var(var)
+	local vtag = var._tag
+	if vtag == "ast.Var.Name" then
+		if var._def._tag == "checker.Def.Variable" then
+			local decl = assert(var._def.decl)
+			self:register_decl(decl)
+			table.insert(self.ref_to_decl[decl], var)
+		end
+	elseif vtag == "ast.Var.Dot" then
+		var.exp = self:convert_exp(var.exp)
+	elseif vtag == "ast.Var.Bracket" then
+		var.t = self:convert_exp(var.t)
+		var.k = self:convert_exp(var.k)
+	end
+
+	return var
+end
+
+-- If necessary, transforms `exp` or one of it's subexpression nodes in case they 
+-- reference a mutable upvalue.
+-- Recursively visits all sub-expressions and applies an `ast.Var.Name => ast.Var.Dot`
+-- transformation wherever necessary, returning the new transformed node.
+-- Note that for the transformed node to be updated at the call site, this method must
+-- be called like so:
+-- `exp = self:convert_exp(exp)`
+function Converter:convert_exp(exp)
+	local tag = exp._tag
+
+	if tag == "ast.Exp.InitList" then
+		for _, field in ipairs(exp.fields) do
+			field.exp = self:convert_exp(field.exp)
+		end
+
+	elseif tag == "ast.Exp.Lambda" then
+		self:visit_stats(exp.body.stats)
+
+	elseif tag == "ast.Exp.CallFunc" or tag == "ast.Exp.CallMethod" then
+		exp.exp = self:convert_exp(exp.exp)
+		for i = 1, #exp.args do
+			exp.args[i] = self:convert_exp(exp.args[i])
+		end
+
+	elseif tag == "ast.Exp.Var" then
+		exp.var = self:convert_var(exp.var)
+
+	elseif tag == "ast.Exp.Unop" 
+		or tag == "ast.Exp.Cast" 
+		or tag == "ast.Exp.ToFloat" 
+		or tag == "ast.Exp.Paren" then
+		exp.exp = self:convert_exp(exp.exp)
+
+	elseif tag == "ast.Exp.Binop" then
+		exp.lhs = self:convert_exp(exp.lhs)
+		exp.rhs = self:convert_exp(exp.rhs)
+
+	elseif not typedecl.match_tag(tag, "ast.Exp") then
+		typedecl.tag_error(tag)
+	end
+
+	return exp
+end
+
+return converter

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -302,7 +302,7 @@ function Converter:visit_var(var, update_fn)
     if vtag == "ast.Var.Name" and not var._exported_as then
         if var._def._tag == "checker.Def.Variable" then
             local decl = assert(var._def.decl)
-            assert(self.update_ref_of_decl[decl], decl.name)
+            assert(self.update_ref_of_decl[decl])
             local depth = self.func_depth_of_decl[decl]
             -- depth == 1 when the decl is that of a global
             if depth < self.func_depth and depth > 1 then

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util     = require "pallene.util"
 local typedecl = require "pallene.typedecl"
 local types    = require "pallene.types"

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -124,6 +124,7 @@ function Converter:exit_lambda(lambda)
 			-- 	  to ast.Var.Dot
 			local typ = types.T.Record(self:type_name(decl.name), { "value" } , { value = decl._type } )
 			self:add_box_type(decl.loc, typ)
+			decl._type = typ
 
 			local init_exp = self.init_exp_of_decl[decl]
 			

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -1,5 +1,8 @@
 local util     = require "pallene.util"
 local typedecl = require "pallene.typedecl"
+local types    = require "pallene.types"
+local ast      = require "pallene.ast"
+local checker  = require "pallene.checker"
 
 local converter = {}
 
@@ -41,14 +44,44 @@ function converter.convert(prog_ast)
 	return Converter.new():visit_prog(prog_ast)
 end
 
+
+local function FuncInfo()
+	return {
+		mutated_decls  = {}, -- list of ast.Decl
+		captured_decls = {} -- { ast.Decl }
+	}
+end
+
 function Converter:init()
-	self.ref_to_decl    = {} -- list of ast.Var.Name
-	self.captured_decls = {} -- list of ast.Decl.Decl
+	self.func_stack = {} -- list of FuncInfo
+	local func_info = FuncInfo()
+	table.insert(self.func_stack, func_info)
+
+	self.ref_to_decl        = {} -- list of ast.Var.Name
+	self.func_depth_of_decl = {} -- { ast.Decl.Decl => integer }
+	self.init_exp_of_decl   = {} -- { ast.Decl.Decl => ast.Exp }
+	self.box_records 	    = {} -- list of ast.Toplevel.Record
+
+	-- used to assign unique names to subsequently generated record types
+	self.typ_counter = 0
+end
+
+-- generates a unique type name each time
+function Converter:type_name(var_name)
+	self.typ_counter = self.typ_counter + 1
+	return "$T_"..var_name.."_"..self.typ_counter
+end
+
+function Converter:add_box_type(loc, typ)
+	local dummy_node = ast.Toplevel.Record(loc, types.tostring(typ), {})
+	dummy_node._type = typ
+	table.insert(self.box_records, dummy_node)
 end
 
 function Converter:register_decl(decl)
 	if not self.ref_to_decl[decl] then
-		self.ref_to_decl[decl] = {}
+		self.ref_to_decl[decl]        = {}
+		self.func_depth_of_decl[decl] = #self.func_stack
 	end 
 end
 
@@ -65,6 +98,11 @@ function Converter:visit_prog(prog_ast)
 		end
 	end
 
+	-- add the box types to the AST
+	for _, node in ipairs(self.box_records) do
+		table.insert(prog_ast.tls, node)
+	end
+
 	return prog_ast
 end
 
@@ -74,11 +112,60 @@ function Converter:visit_stats(stats)
 	end
 end
 
+-- Goes over all the ast.Decls inside the function that have been captured by some nested
+-- function, transforms the decl node itself and all the references made to it.
+function Converter:exit_lambda(lambda)
+	local func_info = self.func_stack[#self.func_stack]
+	for _, decl in ipairs(func_info.mutated_decls) do
+		if func_info.captured_decls[decl] then
+			-- 1. Create a record type `$T` to hold this captured var.
+			-- 2. Transform the ast.Decl node from `local x = value` to `local x: $T =  { value = value }`
+			-- 3. Go over all the references ever made to this variable and transform them from `ast.Var.Name`
+			-- 	  to ast.Var.Dot
+			local typ = types.T.Record(self:type_name(decl.name), { "value" } , { value = decl._type } )
+			self:add_box_type(decl.loc, typ)
+
+			local init_exp = self.init_exp_of_decl[decl]
+			
+			if init_exp then
+				local value_exp = util.copy_table(init_exp)
+				util.empty_table(init_exp)
+
+				init_exp._tag   = "ast.Exp.InitList"
+				init_exp._type  = typ
+				init_exp.fields = {}
+				init_exp.fields[1] = { name = "value", exp = value_exp }
+			end
+
+			for _, ref in ipairs(self.ref_to_decl[decl]) do
+				assert(ref._tag == "ast.Var.Name")
+				local var = util.copy_table(ref)
+				ref._tag = "ast.Var.Dot"
+				ref.exp  =  ast.Exp.Var(ref.loc, var)
+				ref.name = "value"
+
+				ref.exp._type = typ
+			end
+		end
+	end
+
+	assert(#self.func_stack > 1)
+	table.remove(self.func_stack)
+end
+
+function Converter:visit_lambda(lambda)
+	local func_info = FuncInfo()
+	table.insert(self.func_stack, func_info)
+
+	self:visit_stats(lambda.body.stats)
+	self:exit_lambda(lambda)
+end
+
 function Converter:visit_func(func)
 	assert(func._tag == "ast.Stat.Func")
 	local lambda = func.value
 	assert(lambda and lambda._tag == "ast.Exp.Lambda")
-	self:visit_stats(lambda.body.stats)
+	self:visit_lambda(lambda)
 end
 
 function Converter:convert_exps_of_stat(stat)
@@ -103,7 +190,10 @@ function Converter:visit_stat(stat)
 			self:register_decl(decl)
 		end
 
-		self:convert_exps_of_stat(stat)
+		for i, exp in ipairs(stat.exps) do
+			stat.exps[i] = self:convert_exp(exp)
+			self.init_exp_of_decl[stat.decls[i]] = exp
+		end
 
 	elseif tag == "ast.Stat.Block" then
 		self:visit_stats(stat.stats)
@@ -138,6 +228,15 @@ function Converter:visit_stat(stat)
 	elseif tag == "ast.Stat.Assign" then
 		for i, var in ipairs(stat.vars) do
 			stat.vars[i] = self:convert_var(var)
+			
+			if var._tag == "ast.Var.Name" then
+				if var._def._tag == "checker.Def.Variable" then
+					local decl = assert(var._def.decl)
+					local depth = self.func_depth_of_decl[decl]
+					local func_info = self.func_stack[depth]
+					table.insert(func_info.mutated_decls, decl) 
+				end
+			end
 		end
 
 		self:convert_exps_of_stat(stat)
@@ -168,14 +267,23 @@ function Converter:convert_var(var)
 	if vtag == "ast.Var.Name" then
 		if var._def._tag == "checker.Def.Variable" then
 			local decl = assert(var._def.decl)
-			self:register_decl(decl)
+			assert(self.ref_to_decl[decl])
+			local depth = self.func_depth_of_decl[decl]
+			-- depth == 1 when the decl is that of a global
+			if depth < #self.func_stack and depth > 1 then
+				local func_info = self.func_stack[depth]
+				func_info.captured_decls[decl] = true
+			end
 			table.insert(self.ref_to_decl[decl], var)
 		end
+
 	elseif vtag == "ast.Var.Dot" then
 		var.exp = self:convert_exp(var.exp)
+	
 	elseif vtag == "ast.Var.Bracket" then
 		var.t = self:convert_exp(var.t)
 		var.k = self:convert_exp(var.k)
+	
 	end
 
 	return var
@@ -197,7 +305,7 @@ function Converter:convert_exp(exp)
 		end
 
 	elseif tag == "ast.Exp.Lambda" then
-		self:visit_stats(exp.body.stats)
+		self:visit_lambda(exp)
 
 	elseif tag == "ast.Exp.CallFunc" or tag == "ast.Exp.CallMethod" then
 		exp.exp = self:convert_exp(exp.exp)

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -5,6 +5,7 @@
 
 local c_compiler = require "pallene.c_compiler"
 local checker = require "pallene.checker"
+local assignment_conversion = require "pallene.assignment_conversion"
 local constant_propagation = require "pallene.constant_propagation"
 local coder = require "pallene.coder"
 local Lexer = require "pallene.Lexer"
@@ -41,7 +42,7 @@ end
 
 -- List of available compiler passes, used by `pallenec --dump`.
 -- If a new compiler pass is created, please add it to this list.
-driver.list_of_compiler_passes = {"lexer", "ast", "checker", "ir", "uninitialized", "constant_propagation"}
+driver.list_of_compiler_passes = {"lexer", "ast", "checker", "assignment_conversion", "ir", "uninitialized", "constant_propagation"}
 
 --
 -- Run AST and IR passes, up-to and including the specified pass. This is meant for unit tests.
@@ -66,6 +67,11 @@ function driver.compile_internal(filename, input, stop_after, opt_level)
 
     prog_ast, errs = checker.check(prog_ast)
     if stop_after == "checker" or not prog_ast then
+        return prog_ast, errs
+    end
+
+    prog_ast, errs = assignment_conversion.convert(prog_ast)
+    if stop_after == "assignment_conversion" or not prog_ast then
         return prog_ast, errs
     end
 

--- a/pallene/util.lua
+++ b/pallene/util.lua
@@ -107,6 +107,22 @@ function util.outputs_of_execute(cmd)
     return ok, err, out_content, err_content
 end
 
+
+function util.copy_table(t)
+    local new_t = {}
+    for k, v in pairs(t) do
+        new_t[k] = v
+    end
+    return setmetatable(new_t, getmetatable(t))
+end
+
+function util.empty_table(t)
+    for k, _ in pairs(t) do
+        t[k] = nil
+    end
+end
+
+
 --
 -- OOP
 --

--- a/pallene/util.lua
+++ b/pallene/util.lua
@@ -107,22 +107,6 @@ function util.outputs_of_execute(cmd)
     return ok, err, out_content, err_content
 end
 
-
-function util.copy_table(t)
-    local new_t = {}
-    for k, v in pairs(t) do
-        new_t[k] = v
-    end
-    return setmetatable(new_t, getmetatable(t))
-end
-
-function util.empty_table(t)
-    for k, _ in pairs(t) do
-        t[k] = nil
-    end
-end
-
-
 --
 -- OOP
 --

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2496,6 +2496,19 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 end
                 return add(x)
             end
+
+            function m.wrap(x: integer): (integer -> (), () -> integer)
+                local n: integer = x
+                local set: integer -> () = function (y)
+                    n = y
+                end 
+
+                local get: () -> integer = function()
+                    return n
+                end
+
+                return set, get
+            end
         ]])
 
         it("works correctly with non-capturing closures", function ()
@@ -2521,6 +2534,16 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
             run_test([[
                 local add10 = test.make_adder(10)
                 assert(add10(20) == 30)
+            ]])
+        end)
+
+
+        it("Mutating and capturing closures work as expected", function()
+            run_test([[
+                local set, get = test.wrap(10)
+                assert(get() == 10)
+                set(100)
+                assert(get() == 100)
             ]])
         end)
     end)


### PR DESCRIPTION
This PR introduces support for closures that can mutate their captured upvalues. (As log as they are 1. Not a function parameter and 2. initialized immediately upon declaration in their original scope).

The following notable changes have been made:
- Fixed a bug that crept in with the PR where we introduced non-mutating closures. Closures did not receive the global `G` userdata. This was fixed with a minor change in the IR instruction `NewClosure` in `coder.lua`.
- Added a new compiler pass, `assignment_conversion.lua`. A short brief overview of how this pass works has been added as a comment to the top of the file. Basically, it walks over the AST and for every function node:
    - Walk over it's body, and for each declared variable, maintain a list of all the places where it has been referenced in some way.
    - If it is later found that the decl is being mutated, then add it to a set to indicate that fact.
    - Before exiting the function, for each decl that has been mutated *and* captured by a nested closure, transform it's declaration node from `ast.Exp.*` to `ast.Exp.Initlist` and assign it a newly generated record type. Then, go to every place where this decl has been reference and change all `ast.Var.Name` references to `ast.Var.Dot`.

Function parameters and variables that are not initialized at their declaration site cannot be captured as of this PR.