### PR TITLE
Implemented mutable parameter capturing.

### DIFF
--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -147,8 +147,8 @@ function Converter:apply_transformations()
                 { "value" } ,
                 { value = decl._type }
             )
-            self:add_box_type(decl.loc, typ)
 
+            local type_node = self:add_box_type(decl.loc, typ)
             local init_exp_update = self.update_init_exp_of_decl[decl]
 
             if init_exp_update then
@@ -177,17 +177,18 @@ function Converter:apply_transformations()
                 --- end
                 local param = ast.Exp.Var(decl.loc, ast.Var.Name(decl.loc, decl.name))
                 param.var._def = checker.Def.Variable(decl)
-                param.var._type = decl._type
+                param.var._type = assert(decl._type)
                 param._type = decl._type
-                local decl_lhs = ast.Decl.Decl(decl.loc, "$"..decl.name, typ)
+
+                local decl_lhs = ast.Decl.Decl(decl.loc, "$"..decl.name, type_node)
                 local decl_rhs = ast.Exp.InitList(decl.loc, {{ name = "value", exp = param }})
                 decl_rhs._type = typ
                 decl_lhs._type = typ
 
-                local new_node = ast.Stat.Decl(decl.loc, { decl_lhs }, { decl_rhs })
+                local stat = ast.Stat.Decl(decl.loc, { decl_lhs }, { decl_rhs })
 
                 local lambda = self.lambda_of_param[decl]
-                table.insert(lambda.body.stats, 1, new_node)
+                table.insert(lambda.body.stats, 1, stat)
                 proxy_decl_of_param[decl] = decl_lhs
 
             else

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -201,15 +201,15 @@ function Converter:apply_transformations()
                 error("upvalues that are not initialized upon declaration cannot be captured.")
             end
 
-            --- Update all references made to a mutable upvalue. Replace all `ast.Var` nodes
+            --- Update all references made to the mutable upvalue. Replace all `ast.Var` nodes
             --- with `ast.Dot` nodes.
             for _, node_update in ipairs(self.update_ref_of_decl[decl]) do
                 local old_var = node_update.node
                 local loc     = old_var.loc
                 local update  = node_update.update_fn
 
-                local proxy_decl = proxy_var_of_param[decl]
                 local dot_exp
+                local proxy_decl = proxy_var_of_param[decl]
                 if proxy_decl then
                     -- references to captured parameters get replaced by references to `value` field of
                     -- their proxy variables.

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -162,8 +162,8 @@ end
 -- Goes over all the ast.Decls inside the AST that have been captured by some nested
 -- function, transforms the decl node itself and all the references made to it.
 function Converter:apply_transformations()
-    local proxy_decl_of_param       = {} -- { ast.Decl => ast.Decl }
-    local proxy_stats_of_lambda     = {} -- { ast.Lambda => list of ast.Stat.Decl }
+    local proxy_var_of_param       = {} -- { ast.Decl => ast.Decl }
+    local proxy_stats_of_lambda    = {} -- { ast.Lambda => list of ast.Stat.Decl }
 
     for _, decl in ipairs(self.mutated_decls) do
         if self.captured_decls[decl] then
@@ -223,13 +223,13 @@ function Converter:apply_transformations()
                     proxy_stats_of_lambda[lambda] = {}
                 end
                 table.insert(proxy_stats_of_lambda[lambda], stat)
-                proxy_decl_of_param[decl] = decl_lhs
+                proxy_var_of_param[decl] = decl_lhs
 
             else
                 error("upvalues that are not initialized upon declaration cannot be captured.")
             end
 
-            self:update_refs_of_captured_var(decl, typ, proxy_decl_of_param[decl])
+            self:update_refs_of_captured_var(decl, typ, proxy_var_of_param[decl])
         end
     end
 

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2509,6 +2509,13 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
 
                 return set, get
             end
+
+            function m.counter(x: integer): (() -> integer)
+                return function ()
+                    x = x + 1
+                    return x
+                end
+            end
         ]])
 
         it("works correctly with non-capturing closures", function ()
@@ -2544,6 +2551,14 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 assert(get() == 10)
                 set(100)
                 assert(get() == 100)
+            ]])
+        end)
+
+        it("Capturing parameters and mutating them works", function()
+            run_test([[
+                local tick = test.counter(1)
+                assert(tick() == 2)
+                assert(tick() == 3)
             ]])
         end)
     end)

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2516,6 +2516,13 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                     return x
                 end
             end
+
+            function m.swapper(x: integer, y: integer): (() -> (integer, integer))
+                return function ()
+                    x, y = y, x
+                    return x, y
+                end
+            end
         ]])
 
         it("works correctly with non-capturing closures", function ()
@@ -2559,6 +2566,16 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 local tick = test.counter(1)
                 assert(tick() == 2)
                 assert(tick() == 3)
+            ]])
+        end)
+
+        it("Can capture multiple parameters", function()
+            run_test([[
+                local swap = test.swapper(1, 2)
+                local x, y = swap()
+                assert(x == 2 and y == 1)
+                x, y = swap()
+                assert(x == 1 and y == 2)
             ]])
         end)
     end)


### PR DESCRIPTION
Parameters can now be captured and mutated in closures.
Changes are primarily in `assignment_conversion.lua`.

For each parameter, we keep track of which lambda it belongs in (by using a `lambda_of_param` map).
At the end of the AST traversal, if it is seen that a parameter has been captured, then we take it's corresponding lambda and insert a 'proxy' declaration in it's `body`.

Next, we replace all references made to the parameter with this proxy declaration's `.value` field.

```
function foo(param)
  local $param = { value = param }
end
```