### PR TITLE
Implement upvalues that aren't initialized upon declaration.

### DIFF
--- a/pallene/ast.lua
+++ b/pallene/ast.lua
@@ -60,22 +60,23 @@ declare_type("Var", {
 })
 
 declare_type("Exp", {
-    Nil        = {"loc"},
-    Bool       = {"loc", "value"},
-    Integer    = {"loc", "value"},
-    Float      = {"loc", "value"},
-    String     = {"loc", "value"},
-    InitList   = {"loc", "fields"},
-    Lambda     = {"loc", "arg_decls", "body"},
-    CallFunc   = {"loc", "exp", "args"},
-    CallMethod = {"loc", "exp", "method", "args"},
-    Var        = {"loc", "var"},
-    Unop       = {"loc", "op", "exp"},
-    Binop      = {"loc", "lhs", "op", "rhs"},
-    Cast       = {"loc", "exp", "target"},
-    Paren      = {"loc", "exp"},
-    ExtraRet   = {"loc", "call_exp", "i"}, -- Inserted by checker.lua
-    ToFloat    = {"loc", "exp"},           -- Inserted by checker.lua
+    Nil           = {"loc"},
+    Bool          = {"loc", "value"},
+    Integer       = {"loc", "value"},
+    Float         = {"loc", "value"},
+    String        = {"loc", "value"},
+    InitList      = {"loc", "fields"},
+    Lambda        = {"loc", "arg_decls", "body"},
+    CallFunc      = {"loc", "exp", "args"},
+    CallMethod    = {"loc", "exp", "method", "args"},
+    Var           = {"loc", "var"},
+    Unop          = {"loc", "op", "exp"},
+    Binop         = {"loc", "lhs", "op", "rhs"},
+    Cast          = {"loc", "exp", "target"},
+    Paren         = {"loc", "exp"},
+    ExtraRet      = {"loc", "call_exp", "i"}, -- Inserted by checker.lua
+    ToFloat       = {"loc", "exp"},           -- Inserted by checker.lua
+    UpvalueRecord = {"loc"},                  -- Inserted by assignment_conversion.lua
 })
 
 declare_type("Field", {

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -849,6 +849,12 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             typedecl.tag_error(typ._tag)
         end
 
+    elseif tag == "ast.Exp.UpvalueRecord" then
+        local typ = exp._type
+        assert(typ._tag == "types.T.Record")
+        table.insert(cmds, ir.Cmd.NewRecord(loc, typ, dst))
+        table.insert(cmds, ir.Cmd.CheckGC())
+
     elseif tag == "ast.Exp.Lambda" then
         local f_id = self:register_lambda(exp, "$lambda")
         local func = self.module.functions[f_id]

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2523,6 +2523,20 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                     return x, y
                 end
             end
+
+            function m.make_counter(start_at_0: boolean): (() -> integer)
+                local x: integer
+                if start_at_0 then
+                    x = 0
+                else
+                    x = 1
+                end
+
+                return function()
+                    x = x + 1
+                    return x - 1
+                end
+            end
         ]])
 
         it("works correctly with non-capturing closures", function ()
@@ -2576,6 +2590,19 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 assert(x == 2 and y == 1)
                 x, y = swap()
                 assert(x == 1 and y == 2)
+            ]])
+        end)
+
+        it("Can captured upvalues that aren't initialized upon declaration", function()
+            run_test([[
+                local count = test.make_counter(false)
+                assert(count() == 1)
+                assert(count() == 2)
+
+                local count2 = test.make_counter(true)
+                assert(count2() == 0)
+                assert(count2() == 1)
+                assert(count2() == 2)
             ]])
         end)
     end)


### PR DESCRIPTION
Using a new `ast.Exp.UpvalueRecord`, the IR can now have records that aren't initialized upon declaration.
This dummy node is added to the corresponding `ast.Decl` of uninitialized upvalues in the `assignment_conversion` pass.