### PR TITLE
Linter: check if copyright headers are present

### DIFF
--- a/lint-project
+++ b/lint-project
@@ -13,7 +13,7 @@ error() {
 }
 
 echo "=== Lua Lint ==="
-luacheck pallene/ spec/ "$@" || exit 1
+luacheck pallene/ spec/ examples/ "$@" || exit 1
 echo
 
 echo "=== Other checks ==="

--- a/lint-project
+++ b/lint-project
@@ -1,19 +1,38 @@
-#!/bin/bash
+#!/bin/sh
 
-srcdirs=(pallene/ spec/ examples/)
-
-# Lint our Lua code
-luacheck "${srcdirs[@]}" "$@" || exit 1
-
-# Also check if there is tab-based indentation. Luacheck doesn't do this.
 tab='	'
-if
-    grep --recursive \
-        --include='*.c'   \
-        --include='*.lua' \
-        --include='*.pln' \
-        "^$tab" "${srcdirs[@]}"
-then
-    echo "Detected tab-based indentation"
+ok=yes
+
+red='\033[1;31m'
+green='\033[1;32m'
+reset='\033[0m'
+
+error() {
+    printf "${red}ERROR${reset} %s\n" "$*"
+    ok=no
+}
+
+echo "=== Lua Lint ==="
+luacheck pallene/ spec/ "$@" || exit 1
+echo
+
+echo "=== Other checks ==="
+for file in \
+    pallene/*.lua spec/*.lua \
+    examples/*/*.lua examples/*/*.pln \
+    runtime/*.c runtime/*.h
+do
+    if grep "^$tab" "$file"; then
+        error "File $file has tab-based indentation"
+    fi
+
+    if ! grep --quiet 'SPDX-License-Identifier' "$file"; then
+        error "File $file is missing a copyright header"
+    fi
+done
+
+if [ "$ok" != yes ]; then
     exit 1
 fi
+
+printf "${green}OK${reset}\n"

--- a/spec/benchmarks_spec.lua
+++ b/spec/benchmarks_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 --
 -- In this test file we run all our benchmarks with a small N, to ensure that they aren't broken by
 -- updates to the compiler.

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local driver = require 'pallene.driver'
 local util = require 'pallene.util'
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = require "pallene.util"
 local execution_tests = require "spec.execution_tests"
 

--- a/spec/coder_test_operators.lua
+++ b/spec/coder_test_operators.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 -- Used by the test scripts in coder_spec, to check that Pallene operations
 -- compute the same results as their Lua analogues.
 

--- a/spec/examples_spec.lua
+++ b/spec/examples_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = require "pallene.util"
 
 local function assert_example(example, expected_output)

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = require "pallene.util"
 
 --

--- a/spec/lexer_spec.lua
+++ b/spec/lexer_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local Lexer = require 'pallene.Lexer'
 
 -- Find out how the lexer lexes a given string.

--- a/spec/location_spec.lua
+++ b/spec/location_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local Location = require "pallene.Location"
 
 local function check_get_line_number(text, line_numbers)

--- a/spec/pallenec_spec.lua
+++ b/spec/pallenec_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = require "pallene.util"
 
 describe("pallenec", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local driver = require 'pallene.driver'
 local util = require 'pallene.util'
 

--- a/spec/print_ir_spec.lua
+++ b/spec/print_ir_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = require "pallene.util"
 local execution_tests = require "spec.execution_tests"
 

--- a/spec/symtab_spec.lua
+++ b/spec/symtab_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local symtab = require 'pallene.symtab'
 
 describe("Pallene symbol table", function()

--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 -- The expected translations contain spaces, which is what the translator is expected to do when
 -- removing type annotations. Please do not delete them, otherwise the tests will fail.
 

--- a/spec/typedecl_spec.lua
+++ b/spec/typedecl_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local typedecl = require "pallene.typedecl"
 
 describe("Typedecl", function()

--- a/spec/types_spec.lua
+++ b/spec/types_spec.lua
@@ -1,4 +1,7 @@
-
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
 
 local types = require "pallene.types"
 

--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local driver = require 'pallene.driver'
 
 local function run_uninitialized(code)

--- a/spec/util_spec.lua
+++ b/spec/util_spec.lua
@@ -1,3 +1,8 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
 local util = require "pallene.util"
 
 


### PR DESCRIPTION
When we create new source code files, we sometimes forget to add a copyright header. Now the linter should catch that mistake if it happens. Closes #400.