### PR TITLE
Limit the maximum number of function parameters / arguments.

### DIFF
--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -22,6 +22,7 @@ function Parser:init(lexer)
     self.region_depth = 0     -- Are we inside a type annotation?
     self.type_regions = {}    -- Sequence of pairs. Ranges of type annotations in program.
     self.comment_regions = {} -- Sequence of pairs. Ranges of comments in the program.
+    self.max_params = 200
     self:_advance(); self:_advance()
 end
 
@@ -783,6 +784,10 @@ function Parser:FuncArgs()
         local open = self:e("(")
         local exps = self:peek(")") and {} or self:ExpList1()
         local _    = self:e(")", open)
+        if #exps > self.max_params then
+            self:syntax_error(exps[self.max_params + 1].loc,
+                "too many arguments (limit is %d)", self.max_params)
+        end
         return exps
     end
 end
@@ -790,6 +795,10 @@ end
 function Parser:FuncParams()
     local oparen = self:e("(")
     local params = self:DeclList()
+    if #params > self.max_params then
+        self:syntax_error(params[self.max_params + 1].loc,
+            "too many parameters (limit is %d)", self.max_params)
+    end
     local _ = self:e(")", oparen)
     return params
 end

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -419,6 +419,19 @@ describe("Parser /", function()
             ]], "local function name has a ':'")
         end)
 
+        it("disallow too many function parameters", function ()
+           local params = ''
+           for i = 1, 200 do
+              params = params..'a'..i..', '
+           end
+           params = params..'a201'
+           assert_toplevel_error(string.format([[
+                function m.f(%s)
+                    return 1
+                end
+           ]], params), "too many parameters (limit is 200)")
+        end)
+
         it("must have argument type annotations (argument)", function()
             assert_toplevel_error([[
                 local function foo(x): integer
@@ -553,6 +566,17 @@ describe("Parser /", function()
             assert_statements_error([[
                 (f)
             ]], "this expression in a statement position is not a function call")
+        end)
+
+        it("disallows too many arguments", function ()
+           local args = ''
+           for i = 1, 200 do
+              args = args .. i .. ', '
+           end
+           args = args ..'201'
+            assert_statements_error(string.format([[
+                f(%s)
+            ]], args), "too many arguments (limit is 200)")
         end)
 
         it("are the only expression allowed as a statement (2/2)", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -420,16 +420,16 @@ describe("Parser /", function()
         end)
 
         it("disallow too many function parameters", function ()
-           local params = ''
-           for i = 1, 200 do
-              params = params..'a'..i..', '
-           end
-           params = params..'a201'
-           assert_toplevel_error(string.format([[
-                function m.f(%s)
+            local t_params = {}
+            for i = 1, 201 do
+                t_params[i] = "a"..i..": integer"
+            end
+            local params = table.concat(t_params, ", ")
+            assert_toplevel_error([[
+                function m.f(]]..params..[[): integer
                     return 1
                 end
-           ]], params), "too many parameters (limit is 200)")
+            ]], "too many parameters (limit is 200)")
         end)
 
         it("must have argument type annotations (argument)", function()
@@ -569,14 +569,14 @@ describe("Parser /", function()
         end)
 
         it("disallows too many arguments", function ()
-           local args = ''
-           for i = 1, 200 do
-              args = args .. i .. ', '
-           end
-           args = args ..'201'
-            assert_statements_error(string.format([[
-                f(%s)
-            ]], args), "too many arguments (limit is 200)")
+            local t_args = {}
+            for i = 1, 201 do
+                t_args[i] = i
+            end
+            local args = table.concat(t_args, ", ")
+            assert_statements_error([[
+                f(]]..args..[[)
+            ]], "too many arguments (limit is 200)")
         end)
 
         it("are the only expression allowed as a statement (2/2)", function()


### PR DESCRIPTION
Fixes #410 
The error message is similar to that thrown by Lua.
I'm not sure if it would be better to have a long snippet with too many parameters instead of pragmatically generating a string in the test cases.