### PR TITLE
Run CI on push event, not pull-request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@
 
 name: Github Actions CI
 
-on: [ pull_request ]
+on: [ push ]
 
 jobs:
     lint:


### PR DESCRIPTION
The pull-request CI runs the tests in the feature branch. On the other hand, if we use the push
event then it runs on the resulting merge commit that we would get after merging.

If we want to be able to cache dependencies, as discussed in issue #420, we will need to use the
"push" event. I'm not 100% sure yet if we can simply use push instead of pull-request, or if we will
need to use both. If we can get away with only push event, I think that would be better because it
would be less time to run the CI. Let's try that to see if it works.