### PR TITLE
Avoid creating closures for lambdas in luaopen.

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1691,19 +1691,10 @@ function Coder:generate_module()
         table.insert(out, self:pallene_entry_point_definition(f_id))
     end
 
-    table.insert(out, section_comment("Exports"))
     for f_id = 1, #self.module.functions do
-        if f_id == 1 or self.upvalue_of_function[f_id] then
-            table.insert(out, self:lua_entry_point_definition(f_id))
-        end
+        table.insert(out, self:lua_entry_point_definition(f_id))
     end
 
-    table.insert(out, section_comment("Lambdas"))
-    for f_id = 1, #self.module.functions do
-        if self.module.lambdas[f_id] then
-            table.insert(out, self:lua_entry_point_definition(f_id))
-        end
-    end
 
     table.insert(out, self:generate_luaopen_function())
 

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -62,8 +62,8 @@ function ir.Function(loc, name, typ)
     }
 end
 
----
---- Mutate modules
+--
+-- Mutate modules
 --
 
 function ir.add_record_type(module, typ)
@@ -71,13 +71,9 @@ function ir.add_record_type(module, typ)
     return #module.record_types
 end
 
-function ir.add_function(module, loc, name, typ, is_lambda)
+function ir.add_function(module, loc, name, typ)
     table.insert(module.functions, ir.Function(loc, name, typ))
-    local f_id = #module.functions
-    if is_lambda then
-        module.lambdas[f_id] = true
-    end
-    return f_id
+    return #module.functions
 end
 
 function ir.add_global(module, name, typ)

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -33,7 +33,6 @@ function ir.Module()
         globals            = {}, -- list of ir.VarDecl
         exported_functions = {}, -- list of function ids
         exported_globals   = {}, -- list of variable ids
-        lambdas            = {}, -- { function id }
     }
 end
 

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -33,6 +33,7 @@ function ir.Module()
         globals            = {}, -- list of ir.VarDecl
         exported_functions = {}, -- list of function ids
         exported_globals   = {}, -- list of variable ids
+        lambdas            = {}, -- { function id }
     }
 end
 
@@ -70,9 +71,13 @@ function ir.add_record_type(module, typ)
     return #module.record_types
 end
 
-function ir.add_function(module, loc, name, typ)
+function ir.add_function(module, loc, name, typ, is_lambda)
     table.insert(module.functions, ir.Function(loc, name, typ))
-    return #module.functions
+    local f_id = #module.functions
+    if is_lambda then
+        module.lambdas[f_id] = true
+    end
+    return f_id
 end
 
 function ir.add_global(module, name, typ)

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -145,12 +145,9 @@ function ToIR:resolve_variable(decl)
     return var
 end
 
-function ToIR:register_lambda(exp, name, is_hof)
+function ToIR:register_lambda(exp, name)
     assert(exp._tag == "ast.Exp.Lambda")
     local f_id = ir.add_function(self.module, exp.loc, name, exp._type)
-    if is_hof then
-        self.module.lambdas[f_id] = true
-    end
     self.fun_id_of_exp[exp] = f_id
     return f_id
 end
@@ -859,7 +856,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
         table.insert(cmds, ir.Cmd.CheckGC())
 
     elseif tag == "ast.Exp.Lambda" then
-        local f_id = self:register_lambda(exp, "$lambda", true, true)
+        local f_id = self:register_lambda(exp, "$lambda")
         local func = self.module.functions[f_id]
         self:convert_func(exp)
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -145,9 +145,9 @@ function ToIR:resolve_variable(decl)
     return var
 end
 
-function ToIR:register_lambda(exp, name)
+function ToIR:register_lambda(exp, name, is_lambda)
     assert(exp._tag == "ast.Exp.Lambda")
-    local f_id = ir.add_function(self.module, exp.loc, name, exp._type)
+    local f_id = ir.add_function(self.module, exp.loc, name, exp._type, is_lambda)
     self.fun_id_of_exp[exp] = f_id
     return f_id
 end
@@ -856,7 +856,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
         table.insert(cmds, ir.Cmd.CheckGC())
 
     elseif tag == "ast.Exp.Lambda" then
-        local f_id = self:register_lambda(exp, "$lambda")
+        local f_id = self:register_lambda(exp, "$lambda", true)
         local func = self.module.functions[f_id]
         self:convert_func(exp)
         ir.add_exported_function(self.module, f_id)

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -859,7 +859,6 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
         local f_id = self:register_lambda(exp, "$lambda", true)
         local func = self.module.functions[f_id]
         self:convert_func(exp)
-        ir.add_exported_function(self.module, f_id)
 
         local upvalues = {}
         for _, upval_info in ipairs(func.captured_vars) do

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -145,9 +145,12 @@ function ToIR:resolve_variable(decl)
     return var
 end
 
-function ToIR:register_lambda(exp, name, is_lambda)
+function ToIR:register_lambda(exp, name, is_hof)
     assert(exp._tag == "ast.Exp.Lambda")
-    local f_id = ir.add_function(self.module, exp.loc, name, exp._type, is_lambda)
+    local f_id = ir.add_function(self.module, exp.loc, name, exp._type)
+    if is_hof then
+        self.module.lambdas[f_id] = true
+    end
     self.fun_id_of_exp[exp] = f_id
     return f_id
 end
@@ -856,7 +859,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
         table.insert(cmds, ir.Cmd.CheckGC())
 
     elseif tag == "ast.Exp.Lambda" then
-        local f_id = self:register_lambda(exp, "$lambda", true)
+        local f_id = self:register_lambda(exp, "$lambda", true, true)
         local func = self.module.functions[f_id]
         self:convert_func(exp)
 


### PR DESCRIPTION
This fixes #409 
The current fix is having a set of function IDs that represent lambdas in an `ir.Module`, and then checking to see if a certain function is a lambda before creating a closure for it in luaopen.
It works, but would it be cleaner if we chose to not include the lambdas in `exported_functions` instead?
