### PR TITLE
Stop using coroutines for try-catch

### DIFF
--- a/pallene-dev-1.rockspec
+++ b/pallene-dev-1.rockspec
@@ -38,6 +38,7 @@ build = {
       ["pallene.uninitialized"] =  "pallene/uninitialized.lua",
       ["pallene.util"] =           "pallene/util.lua",
       ["pallene.translator"] =     "pallene/translator.lua",
+      ["pallene.trycatch"] =       "pallene/trycatch.lua",
    },
    install = {
       bin = {

--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -46,14 +46,6 @@ local util = require "pallene.util"
 
 local checker = {}
 
-local CheckerError = util.Class()
-function CheckerError:init(msg)
-    self.msg = msg
-end
-function CheckerError:__tostring()
-    return tostring(self.msg)
-end
-
 local Checker = util.Class()
 
 -- Type-check a Pallene module
@@ -67,8 +59,8 @@ function checker.check(prog_ast)
         prog_ast = ret
         return prog_ast, {}
     else
-        if getmetatable(ret.err) == CheckerError then
-            local err_msg = ret.err.msg
+        if ret.tag == "checker" then
+            local err_msg = ret.msg
             return false, { err_msg }
         else
             -- Internal error; re-throw
@@ -79,7 +71,7 @@ end
 
 local function type_error(loc, fmt, ...)
     local msg = "type error: " .. loc:format_error(fmt, ...)
-    error(CheckerError.new(msg))
+    trycatch.error("checker", msg)
 end
 
 local function check_type_is_condition(exp, fmt, ...)

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -1,5 +1,4 @@
 -- Copyright (c) 2020, The Pallene Developers
-        -- funcs = { is_local, module, name, method, ret_types, value }
 -- Pallene is licensed under the MIT license.
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -983,14 +983,6 @@ end
 -- Syntax errors
 --
 
-local SyntaxError = util.Class()
-function SyntaxError:init(msg)
-    self.msg = msg
-end
-function SyntaxError:__tostring()
-    return tostring(self.msg)
-end
-
 function Parser:describe_token_name(name)
     if     name == "EOF"    then return "end of the file"
     elseif name == "NUMBER" then return "number"
@@ -1012,7 +1004,7 @@ end
 
 function Parser:syntax_error(loc, fmt, ...)
     local msg = "syntax error: " .. loc:format_error(fmt, ...)
-    error(SyntaxError.new(msg), 2)
+    trycatch.error("syntax", msg)
 end
 
 function Parser:forced_syntax_error(expected_name)
@@ -1052,8 +1044,8 @@ function parser.parse(lexer)
         local prog_ast = ret
         return prog_ast, {}
     else
-        if getmetatable(ret.err) == SyntaxError then
-            local err_msg = ret.err.msg
+        if ret.tag == "syntax" then
+            local err_msg = ret.msg
             return false, { err_msg }
         else
             -- Internal error; re-throw

--- a/pallene/trycatch.lua
+++ b/pallene/trycatch.lua
@@ -1,0 +1,52 @@
+-- Copyright (c) 2020, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
+local trycatch = {}
+
+local util = require "pallene.util"
+
+-- Getting good stack traces can be tricky if we want to be able to re-raise an exception, which
+-- happens when we have a try-catch pattern that only wants to catch some of the exceptions. If we
+-- don't do anything, then it will show the stack trace from the point where the exception is
+-- re-raised instead of the original stack trace. Another solution that is sometimes recommended is
+-- to call debug.traceback and then include that inside the error string. However, the problem is
+-- that Lua will still add the stack trace for the time that the exception is re-raised, resulting
+-- in two stack traces being shown.
+--
+-- Our workaround is to use a custom exception datatype. When the error object is not a string, Lua
+-- does not automatically add the second stack trace to the end. It only calls tostring, which gives
+-- us more control on what is displayed. This exception datatype also keeps track of the original
+-- stack trace, meaning that it can be re-raised without messing up the stack.
+--
+-- Example usage:
+--
+--    local ok, err = trycatch.pcall(function() ...  end)
+--    if not ok then
+--        error(err)
+--    end
+
+local Exception = util.Class()
+
+function Exception:init(err, stack_trace)
+    self.err = err
+    self.stack_trace = stack_trace
+end
+
+function Exception:__tostring()
+    return tostring(self.err) .. self.stack_trace
+end
+
+---
+
+local function msg_handler(msg)
+    local stack_trace = debug.traceback("", 2)
+    return Exception.new(msg, stack_trace)
+end
+
+function trycatch.pcall(fn, ...)
+    return xpcall(fn, msg_handler, ...)
+end
+
+return trycatch

--- a/pallene/trycatch.lua
+++ b/pallene/trycatch.lua
@@ -47,11 +47,11 @@ local Exception = util.Class()
 function Exception:init(tag, msg, level)
     self.tag = tag
     self.msg = msg
-    self.stack_trace = debug.traceback("", level)
+    self.stack_trace = debug.traceback(tostring(msg), level)
 end
 
 function Exception:__tostring()
-    return tostring(self.msg) .. self.stack_trace
+    return self.stack_trace
 end
 
 ---

--- a/spec/trycatch_spec.lua
+++ b/spec/trycatch_spec.lua
@@ -1,0 +1,99 @@
+-- Copyright (c) 2021, The Pallene Developers
+-- Pallene is licensed under the MIT license.
+-- Please refer to the LICENSE and AUTHORS files for details
+-- SPDX-License-Identifier: MIT
+
+local trycatch = require "pallene.trycatch"
+
+local function boom(n, cb)
+    if n == 1 then
+        cb()
+    else
+        boom(n-1, cb)
+    end
+end
+
+describe("Try/Catch", function()
+
+    it("works on code without exceptionss", function()
+        local ok, ret = trycatch.pcall(function() return 20 end)
+        assert.is_true(ok)
+        assert.equal(20, ret)
+    end)
+
+    it("can try-catch tagged exceptions", function()
+        local ok, ret = trycatch.pcall(function()
+            boom(2, function()
+                trycatch.error("xyz", "hello")
+            end)
+        end)
+        assert.is_false(ok)
+        assert.equal("xyz", ret.tag)
+        assert.equal("hello", ret.msg)
+    end)
+
+    it("can try-catch untagged exceptions", function()
+        local ok, ret = trycatch.pcall(function()
+            boom(2, function()
+                error("world")
+            end)
+        end)
+        assert.is_false(ok)
+        assert.equal(false, ret.tag)
+        assert.matches("world", ret.msg)
+    end)
+
+    describe("the trace ends at the right level", function()
+
+        it("with tagged exceptions (implicit level)", function()
+            local ok, ret = trycatch.pcall(function()
+                boom(2, function()
+                    trycatch.error("xyz", "hello")
+                end)
+            end)
+            assert.is_false(ok)
+            local stack = tostring(ret)
+            assert.match("trycatch_spec.lua:%d+: in local 'cb'", stack)
+        end)
+
+        it("with tagged exceptions (explicit level)", function()
+            local ok, ret = trycatch.pcall(function()
+                local function ZZZ()
+                    trycatch.error("xyz", "hello",2)
+                end
+                boom(2, function()
+                    ZZZ()
+                end)
+            end)
+            assert.is_false(ok)
+            local stack = tostring(ret)
+            assert.Not.match("ZZZ", stack)
+            assert.match("trycatch_spec.lua:%d+: in local 'cb'", stack)
+        end)
+
+        it("with Lua crashes", function()
+            local ok, ret = trycatch.pcall(function()
+                boom(2, function()
+                    return "a" .. nil
+                end)
+            end)
+            assert.is_false(ok)
+            local stack = tostring(ret)
+            assert.match("attempt to concatenate a nil value", stack)
+            assert.match("trycatch_spec.lua:%d+: in local 'cb'", stack)
+        end)
+
+        it("when calling 'error()'", function()
+            local ok, ret = trycatch.pcall(function()
+                boom(2, function()
+                    error("boom")
+                end)
+            end)
+            assert.is_false(ok)
+            local stack = tostring(ret)
+            assert.match("in function 'error'", stack)
+            assert.match("trycatch_spec.lua:%d+: in local 'cb'", stack)
+        end)
+    end)
+
+end)


### PR DESCRIPTION
We we using coroutines to implement the try-catch because back then, when I tried doing it with pcall it ruined the stack traces. Well, now I figured out how to get proper stack traces with pcall and we no longer need this bizarre workaround using  coroutines.

As a bonus, it now prints a single stack trace. Previously it printed two stack traces and two line numbers. The following examples show the stack trace after I introduce a crash inside the parser.lua

*BEFORE*

```
lua: ./pallene/parser.lua:1055: ./pallene/parser.lua:832: attempt to concatenate a nil value
stack traceback:
	./pallene/parser.lua:832: in method 'SimpleExp'
	./pallene/parser.lua:875: in method 'CastExp'
	./pallene/parser.lua:932: in method 'SubExp'
	./pallene/parser.lua:942: in function <./pallene/parser.lua:925>
	(...tail calls...)
	./pallene/parser.lua:601: in method 'Stat'
	./pallene/parser.lua:491: in method 'StatList'
	./pallene/parser.lua:505: in method 'Block'
	./pallene/parser.lua:553: in function <./pallene/parser.lua:508>
	(...tail calls...)
	./pallene/parser.lua:239: in method 'Toplevel'
	./pallene/parser.lua:168: in function <./pallene/parser.lua:126>
	(...tail calls...)
stack traceback:
	[C]: in function 'error'
	./pallene/parser.lua:1055: in function 'pallene.parser.parse'
	./pallene/driver.lua:63: in function 'pallene.driver.compile_internal'
	./pallene/driver.lua:109: in local 'f'
	./pallene/driver.lua:209: in function 'pallene.driver.compile'
	./pallenec:48: in local 'compile'
	./pallenec:130: in main chunk
	[C]: in ?
```

*AFTER*

```
lua: ./pallene/parser.lua:833: attempt to concatenate a nil value
stack traceback:
	./pallene/parser.lua:833: in method 'SimpleExp'
	./pallene/parser.lua:876: in method 'CastExp'
	./pallene/parser.lua:933: in method 'SubExp'
	./pallene/parser.lua:943: in function <./pallene/parser.lua:926>
	(...tail calls...)
	./pallene/parser.lua:602: in method 'Stat'
	./pallene/parser.lua:492: in method 'StatList'
	./pallene/parser.lua:506: in method 'Block'
	./pallene/parser.lua:554: in function <./pallene/parser.lua:509>
	(...tail calls...)
	./pallene/parser.lua:240: in method 'Toplevel'
	./pallene/parser.lua:169: in function <./pallene/parser.lua:127>
	(...tail calls...)
	[C]: in function 'xpcall'
	./pallene/trycatch.lua:49: in function 'pallene.trycatch.pcall'
	./pallene/parser.lua:1049: in function 'pallene.parser.parse'
	./pallene/driver.lua:63: in function 'pallene.driver.compile_internal'
	./pallene/driver.lua:109: in local 'f'
	./pallene/driver.lua:209: in function 'pallene.driver.compile'
	./pallenec:48: in local 'compile'
	./pallenec:130: in main chunk
	[C]: in ?
```