### PR TITLE
Pass a single parameter representing upvalues to Pallene entry point.

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -386,9 +386,9 @@ function Coder:pallene_entry_point_declaration(f_id)
 
     local args = {} -- { {ctype, name , comment} }
     table.insert(args, {"lua_State *" , "L",    ""})
-    table.insert(args, {"Udata *"     , "G",    ""})
     table.insert(args, {"StackValue *", "base", ""})
-    table.insert(args, {"TValue*", "U", C.comment("upvalues")})
+    table.insert(args, {"Udata *"     , "G",    ""})
+    table.insert(args, {"TValue * restrict ", "U", C.comment("upvalues")})
 
     for i = 1, #arg_types do
         local v_id = ir.arg_var(func, i)
@@ -480,8 +480,8 @@ function Coder:call_pallene_function(dsts, has_upvalue, f_id, base, xs)
 
     local args = {}
     table.insert(args, "L")
-    table.insert(args, "G")
     table.insert(args, base)
+    table.insert(args, "G")
     table.insert(args, has_upvalue and "func->upvalue" or "NULL")
     for _, x in ipairs(xs) do
         table.insert(args, x)

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -53,7 +53,7 @@ function Coder:init(module, modname, filename)
     self.modname = modname
     self.filename = filename
 
-    self.current_func = nil
+    self.current_func = false
 
     self.upvalues = {} -- { coder.Upvalue }
     self.upvalue_of_metatable = {} -- typ  => integer
@@ -313,6 +313,9 @@ end
 function Coder:c_upval(u_id)
     assert(self.current_func)
     local typ = self.current_func.captured_vars[u_id].decl.typ
+    -- Since upvalue boxes do not have metatables, type checking them at runtime is not possible.
+    -- Moreover, since upvalues are only passed around internally by Pallene, it is ok to assume that
+    -- their types will be correct. So we directly cast it using `lua_value` without a tag check.
     return lua_value(typ, string.format("&U[%d]", u_id))
 end
 

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -466,9 +466,12 @@ function Coder:pallene_entry_point_definition(f_id)
         local typ, c_name = self:prepare_captured_var(u_id, upval.decl)
         local decl = C.declaration(ctype(typ), c_name)..";";
         local src  = string.format("&U[%d]", u_id)
+        -- Since upvalue boxes do not have metatables, type checking them at runtime is not possible.
+        -- Moreover, since upvalues are only passed around internally by Pallene, it is ok to assume that
+        -- their types will be correct. So we use the `unchecked_get_slot` here instead.
         local init = unchecked_get_slot(typ, c_name, src)..C.comment(upval.decl.name)
-        table.insert(prologue, decl);
-        table.insert(prologue, init);
+        table.insert(prologue, decl)
+        table.insert(prologue, init)
     end
 
     local body = self:generate_cmd(func, func.body)


### PR DESCRIPTION
A small change to the calling convention.
Instead of the Lua entry point taking upvalues from `func->upvalue` and passing them to the Pallene entry point as arguments, now it only passes a `TValue*` and the Pallene entry point extracts out the upvalues.
So Instead of:
```c
Udata* uv1 = uvalue(&func->upvalue[1]);
int uv2 = uvalue(&func->upvalue[2]);
function_0x(L, G, uv1, uv2, args...);
```
We now have:
```c
function_0x(L, G, func->upvalue, args...);
```

Meanwhile the corresponding Pallene entry point would look like so:
```c
static void function_0x(lua_State* L, Udata* G, TValue* U, params...) {
    Udata* uv1 = uvalue(&func->upvalue[1]);
    int uv2 = ivalue(&func->upvalue[2]);
    // stuff
}
```

As described in #413.