### PR TITLE
Fixed bug with missing 'func'

### DIFF
--- a/pallene/checker.lua
+++ b/pallene/checker.lua
@@ -1080,11 +1080,11 @@ function Checker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
 
     elseif tag == "ast.Exp.Lambda" then
 
-        -- These assertions are always true in the current version of Pallene, which does not allow
-        -- nested function expressions. Once we add function expressions to the parser then we
-        -- should convert these assertions into proper calls to type_error.
-        assert(expected_type._tag == "types.T.Function", "function expressions not implemented yet")
-        assert(#expected_type.arg_types == #exp.arg_decls, "function expressions not implemented yet")
+        if expected_type._tag ~= "types.T.Function" then
+            type_error(exp.loc, "incorrect type hint for lambda")
+        elseif #expected_type.arg_types ~= #exp.arg_decls then
+            type_error(exp.loc, "expected %d parameter(s) but found %d", #expected_type.arg_types, #exp.arg_decls)
+        end
 
         table.insert(self.ret_types_stack, expected_type.ret_types)
         self.symbol_table:with_block(function()

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -493,7 +493,6 @@ function Coder:call_pallene_function(dsts, f_id, base, xs, cclosure)
     -- we can simply pass NULL as it's `upvalues` parameter as it will be unused anyway.
     local upvals
     if n_upvalues >= 1 then
-        assert(cclosure)
         upvals = cclosure.."->upvalue"
     else
         upvals = "NULL"
@@ -1411,15 +1410,9 @@ gen_cmd["CallStatic"] = function(self, cmd, func)
 
     local parts = {}
 
-    -- If the function being called is a module function, then it has a cclosure
-    -- assosciated with it. Toplevel local functions cannot be called with `CallStatic`
-    -- as of now.
-    local upvalues = false
-    if self.upvalue_of_function[cmd.f_id] then
-        local cclosure = self:function_upvalue_slot(cmd.f_id)
-        upvalues = string.format("clCvalue(%s)->upvalue", cclosure)
-    end
-    table.insert(parts, self:call_pallene_function(dsts, cmd.f_id, top, xs, upvalues))
+    local f_id = cmd.src_f.id
+    local cclosure = string.format("clCvalue(%s)", self:function_upvalue_slot(f_id))
+    table.insert(parts, self:call_pallene_function(dsts, f_id, top, xs, cclosure))
     table.insert(parts, self:restorestack())
     return table.concat(parts, "\n")
 end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -479,7 +479,7 @@ function Coder:pallene_entry_point_definition(f_id)
     }))
 end
 
-function Coder:call_pallene_function(dsts, f_id, base, xs, cclosure)
+function Coder:call_pallene_function(dsts, f_id, base, cclosure, xs)
 
     local func       = self.module.functions[f_id]
     local n_upvalues = #func.captured_vars
@@ -591,7 +591,7 @@ function Coder:lua_entry_point_definition(f_id)
         table.insert(ret_decls, C.declaration(ctype(typ), ret)..";")
     end
 
-    local call_pallene = self:call_pallene_function(ret_vars, f_id, "L->top", arg_vars, "func")
+    local call_pallene = self:call_pallene_function(ret_vars, f_id, "L->top", "func", arg_vars)
 
 
     local push_results = {}
@@ -1412,7 +1412,7 @@ gen_cmd["CallStatic"] = function(self, cmd, func)
 
     local f_id = cmd.src_f.id
     local cclosure = string.format("clCvalue(%s)", self:function_upvalue_slot(f_id))
-    table.insert(parts, self:call_pallene_function(dsts, f_id, top, xs, cclosure))
+    table.insert(parts, self:call_pallene_function(dsts, f_id, top, cclosure, xs))
     table.insert(parts, self:restorestack())
     return table.concat(parts, "\n")
 end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1398,8 +1398,12 @@ gen_cmd["CallStatic"] = function(self, cmd, func)
     local top = self:stack_top_at(func, cmd)
 
     local parts = {}
-    table.insert(parts, self:call_pallene_function(dsts, #func.captured_vars >= 1,
-        cmd.f_id, top, xs))
+
+    -- CallStatic is used in pallene-pallene calls. Any calls to higher order functions or
+    -- closures is always done using CallDyn at the moment, meaning CallStatic will never call
+    -- a closure with upvalues.
+    assert(#self.module.functions[cmd.f_id].captured_vars == 0)
+    table.insert(parts, self:call_pallene_function(dsts, false, cmd.f_id, top, xs))
     table.insert(parts, self:restorestack())
     return table.concat(parts, "\n")
 end

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -169,7 +169,7 @@ local ir_cmd_constructors = {
     NewClosure = {"loc", "dst", "srcs", "f_id"},
 
     -- (dst is false if the return value is void, or unused)
-    CallStatic  = {"loc", "f_typ", "dsts",  "f_id", "srcs"},
+    CallStatic  = {"loc", "f_typ", "dsts", "src_f", "srcs"},
     CallDyn     = {"loc", "f_typ", "dsts", "src_f", "srcs"},
 
     -- Builtin operations

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -217,7 +217,7 @@ local function Cmd(cmd)
     elseif tag == "ir.Cmd.NewRecord"  then rhs = "new ".. cmd.rec_typ.name .."()"
     elseif tag == "ir.Cmd.GetField"   then rhs = Field(cmd.src_rec, cmd.field_name)
     elseif tag == "ir.Cmd.SetField"   then rhs = Val(cmd.src_v)
-    elseif tag == "ir.Cmd.CallStatic" then rhs = Call(Fun(cmd.f_id),  Vals(cmd.srcs))
+    elseif tag == "ir.Cmd.CallStatic" then rhs = Call(Fun(cmd.src_f.id),  Vals(cmd.srcs))
     elseif tag == "ir.Cmd.CallDyn"    then rhs = Call(Val(cmd.src_f), Vals(cmd.srcs))
     else
         local tagname = assert(typedecl.match_tag(cmd._tag, "ir.Cmd"))

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -217,7 +217,7 @@ local function Cmd(cmd)
     elseif tag == "ir.Cmd.NewRecord"  then rhs = "new ".. cmd.rec_typ.name .."()"
     elseif tag == "ir.Cmd.GetField"   then rhs = Field(cmd.src_rec, cmd.field_name)
     elseif tag == "ir.Cmd.SetField"   then rhs = Val(cmd.src_v)
-    elseif tag == "ir.Cmd.CallStatic" then rhs = Call(Fun(cmd.src_f.id),  Vals(cmd.srcs))
+    elseif tag == "ir.Cmd.CallStatic" then rhs = Call(Val(cmd.src_f), Vals(cmd.srcs))
     elseif tag == "ir.Cmd.CallDyn"    then rhs = Call(Val(cmd.src_f), Vals(cmd.srcs))
     else
         local tagname = assert(typedecl.match_tag(cmd._tag, "ir.Cmd"))

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -921,9 +921,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
 
         -- Evaluate the function call expression
         local f_val
-        if  def and (
-                def._tag == "checker.Def.Builtin" or
-                def._tag == "checker.Def.Function") then
+        if  def and def._tag == "checker.Def.Builtin" then
             f_val = false
         else
             f_val = self:exp_to_value(cmds, exp.exp)
@@ -963,9 +961,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             end
 
         elseif def and def._tag == "checker.Def.Function" then
-            local f_id = assert(self.fun_id_of_exp[def.func.value])
-            table.insert(cmds, ir.Cmd.CallStatic(loc, f_typ, dsts, f_id, xs))
-
+            table.insert(cmds, ir.Cmd.CallStatic(loc, f_typ, dsts, f_val, xs))
         else
             table.insert(cmds, ir.Cmd.CallDyn(loc, f_typ, dsts, f_val, xs))
         end

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -627,6 +627,16 @@ describe("Lambda", function()
         ]], "missing type hint for lambda")
     end)
 
+    it("type hints are checked properly", function()
+        assert_error([[
+            local f: (integer) -> integer = function() return 1 end
+        ]], "expected 1 parameter(s) but found 0")
+
+        assert_error([[
+            local f: any = function() return 1 end
+        ]], "incorrect type hint for lambda")
+    end)
+
 end)
 
 describe("Unary operator", function()

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -631,7 +631,9 @@ describe("Lambda", function()
         assert_error([[
             local f: (integer) -> integer = function() return 1 end
         ]], "expected 1 parameter(s) but found 0")
+    end)
 
+    it("non-function type hints are reported as errors", function ()
         assert_error([[
             local f: any = function() return 1 end
         ]], "incorrect type hint for lambda")

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2542,6 +2542,12 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                     return x - 1
                 end
             end
+
+            function m.count_from(n: integer): () -> (integer, any)
+                return function()
+                    return n + 1, m.count_from(n + 1)
+                end
+            end
         ]])
 
         it("works correctly with non-capturing closures", function ()
@@ -2598,7 +2604,7 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
             ]])
         end)
 
-        it("Can captured upvalues that aren't initialized upon declaration", function()
+        it("Can capture upvalues that aren't initialized upon declaration", function()
             run_test([[
                 local count = test.make_counter(false)
                 assert(count() == 1)
@@ -2610,6 +2616,17 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
                 assert(count2() == 2)
             ]])
         end)
+
+        it("Can capture a surrounding function", function ()
+            run_test([[
+                local n, next = 0, test.count_from(0)
+                n, next = next()
+                assert(n == 1)
+                n, next = next()
+                assert(n == 2)
+            ]])
+        end)
+
     end)
 
     describe("tostring builtin", function ()


### PR DESCRIPTION
Fixes #448 
`CallStatic` is always used in pallene-to-pallene calls. It is worth noting that currently all calls to closures that may have upvalues is always done via CallDyn, so we can safely pass `NULL` in every CallStatic for the `TValue* U` parameter.

