### PR TITLE
Introduce `SetUpvalue` instruction in the IR

### DIFF
--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -166,7 +166,8 @@ local ir_cmd_constructors = {
     SetField   = {"loc", "rec_typ",        "src_rec", "field_name", "src_v"},
 
     -- Functions
-    NewClosure = {"loc", "dst", "srcs", "f_id"},
+    NewClosure = {"loc", "dst", "f_id"},
+    SetUpvalue = {"loc", "dst", "src", "f_id"},
 
     -- (dst is false if the return value is void, or unused)
     CallStatic  = {"loc", "f_typ", "dsts", "src_f", "srcs"},

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -886,12 +886,10 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
         local func = self.module.functions[f_id]
         self:convert_func(exp)
 
-        local upvalues = {}
+        table.insert(cmds, ir.Cmd.NewClosure(exp.loc, dst, f_id))
         for _, upval_info in ipairs(func.captured_vars) do
-            table.insert(upvalues, upval_info.value)
+            table.insert(cmds, ir.Cmd.SetUpvalue(exp.loc, dst, upval_info.value, f_id))
         end
-
-        table.insert(cmds, ir.Cmd.NewClosure(exp.loc, dst, upvalues, f_id))
 
     elseif tag == "ast.Exp.ExtraRet" then
         assert(self.dsts_of_call[exp.call_exp])


### PR DESCRIPTION
Prior to this, a list of to-be-captured upvalues was passed to the `ir.Cmd.NewClosure` instruction.
Now, a `SetUpvalue` command is introduced, and the labor of adding the upvalues to the CClosure is represented in the IR.

However, this also means that we will be extracting the ccl out of the TValue every single time.
I believe there is some room for optimization here, but I wonder if we should do that after #413 is taken care of.