### PR TITLE
Remove obsolete "import" token

### DIFF
--- a/pallene/Lexer.lua
+++ b/pallene/Lexer.lua
@@ -49,7 +49,7 @@ local is_keyword = {}
 do
     local strs = [[
         and break do else elseif end for false function goto if in local nil not or repeat return
-        then true until while   as import record typealias
+        then true until while   as record typealias
     ]]
     for s in string.gmatch(strs, "%S+") do
         is_keyword[s] = true
@@ -71,7 +71,7 @@ local Lexer = util.Class()
 
 function Lexer:init(file_name, input)
     self.file_name = file_name  -- Source code file name
-    self.input     = input      -- Source code string
+    self.input     = input      -- Source code string (entire file)
     self.pos       = 1          -- Absolute position in the input
     self.line      = 1          -- Line number for error messages
     self.col       = 1          -- Column number for error messages

--- a/spec/lexer_spec.lua
+++ b/spec/lexer_spec.lua
@@ -47,7 +47,7 @@ describe("Pallene lexer", function()
         assert_lex("if",     {"if"},     {})
         assert_lex("else",   {"else"},   {})
         assert_lex("elseif", {"elseif"}, {})
-        assert_lex("import", {"import"}, {})
+        assert_lex("record", {"record"}, {}) -- (contains "or")
     end)
 
     it("does not generate semantic values for keywords", function()

--- a/spec/lexer_spec.lua
+++ b/spec/lexer_spec.lua
@@ -39,14 +39,17 @@ end
 describe("Pallene lexer", function()
 
     it("can lex some keywords", function()
-        assert_lex("and", {"and"}, {})
+        assert_lex("and",      {"and"},      {})
+        assert_lex("else",     {"else"},     {})
+        assert_lex("if",       {"if"},       {})
         assert_lex("function", {"function"}, {})
     end)
 
-    it("can lex keywords that contain other keywords", function()
-        assert_lex("if",     {"if"},     {})
-        assert_lex("else",   {"else"},   {})
+    it("can lex keywords that start with other keywords", function()
         assert_lex("elseif", {"elseif"}, {})
+    end)
+
+    it("can lex keywodds that contain other keywords", function()
         assert_lex("record", {"record"}, {}) -- (contains "or")
     end)
 


### PR DESCRIPTION
The current plan is to use `local foo = require` instead of `import`.

The diff might be slightly easier to read by looking at one commit at a time.