### PR TITLE
Split G into U and K

### DIFF
--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -396,7 +396,7 @@ function Converter:visit_var(var, update_fn)
             assert(self.update_ref_of_decl[decl])
             local depth = self.func_depth_of_decl[decl]
             -- depth == 1 when the decl is that of a global
-            if depth < self.func_depth and depth > 1 then
+            if depth < self.func_depth then
                 self.captured_decls[decl] = true
             end
             table.insert(self.update_ref_of_decl[decl], NodeUpdate(var, update_fn))


### PR DESCRIPTION
Prior to this, G was a userdata table from which all globals were accessed.
After this PR, it will be renamed to `K` to represent the global constants table, and all toplevel `local` and module variables will be captured as upvalues instead.