### PR TITLE
Split `G` into `K` and ` U`.

### DIFF
--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -356,10 +356,6 @@ function Converter:visit_stat(stat)
                     -- should have been reported by the type checker at this point.
                     if not var._exported_as then
                         self.mutated_decls[decl] = true
-                        local update_init = function (new_exp)
-                            stat.exps[i] = new_exp
-                        end
-                        self.update_init_exp_of_decl[decl] = NodeUpdate(stat.exps[i], update_init)
                     end
                 end
             end

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -144,7 +144,7 @@ function Converter:apply_transformations()
 
     for decl in pairs(self.mutated_decls) do
         if self.captured_decls[decl] then
-            assert(not decl._exported_as)
+            assert(decl._tag == "ast.Decl.Decl" or decl._tag == "ast.Var.Name")
 
             -- 1. Create a record type `$T` to hold this captured var.
             -- 2. Transform  node from `local x = value` to `local x: $T =  { value = value }`
@@ -345,16 +345,28 @@ function Converter:visit_stat(stat)
 
     elseif tag == "ast.Stat.Assign" then
         for i, var in ipairs(stat.vars) do
+            if var._tag == "ast.Var.Name" then
+                if var._def._tag == "checker.Def.Variable" then
+                    local decl = assert(var._def.decl)
+                    self:register_decl(decl)
+
+                    -- `m.var = <exp>` statements are only allowed at the toplevel.
+                    -- Furthermore, each module variable can only be assigned to once, so mutable
+                    -- capturing is not possible. Any attempts to re-assign to a module variable
+                    -- should have been reported by the type checker at this point.
+                    if not var._exported_as then
+                        self.mutated_decls[decl] = true
+                        local update_init = function (new_exp)
+                            stat.exps[i] = new_exp
+                        end
+                        self.update_init_exp_of_decl[decl] = NodeUpdate(stat.exps[i], update_init)
+                    end
+                end
+            end
+
             self:visit_var(var, function (new_var)
                 stat.vars[i] = new_var
             end)
-
-            if var._tag == "ast.Var.Name" and not var._exported_as then
-                if var._def._tag == "checker.Def.Variable" then
-                    local decl = assert(var._def.decl)
-                    self.mutated_decls[decl] = true
-                end
-            end
         end
 
         for _, exp in ipairs(stat.exps) do
@@ -395,8 +407,8 @@ function Converter:visit_var(var, update_fn)
         if var._def._tag == "checker.Def.Variable" then
             local decl = assert(var._def.decl)
             assert(self.update_ref_of_decl[decl])
+
             local depth = self.func_depth_of_decl[decl]
-            -- depth == 1 when the decl is that of a global
             if depth < self.func_depth then
                 self.captured_decls[decl] = true
             end

--- a/pallene/assignment_conversion.lua
+++ b/pallene/assignment_conversion.lua
@@ -354,7 +354,9 @@ function Converter:visit_stat(stat)
                     -- Furthermore, each module variable can only be assigned to once, so mutable
                     -- capturing is not possible. Any attempts to re-assign to a module variable
                     -- should have been reported by the type checker at this point.
-                    if not var._exported_as then
+                    if var._exported_as then
+                        assert(self.func_depth == 1)
+                    else
                         self.mutated_decls[decl] = true
                     end
                 end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -658,14 +658,6 @@ function Coder:init_upvalues()
         end
     end
 
-    -- Functions
-
-    local closures = {}
-    for _, f_id in ipairs(self.module.exported_functions) do
-        table.insert(closures, f_id)
-    end
-
-    table.sort(closures) -- For determinism
 end
 
 local function upvalue_slot(ix)

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -55,7 +55,7 @@ function Coder:init(module, modname, filename)
 
     self.current_func = false
 
-    self.upvalues = {} -- { coder.Constant }
+    self.constants = {} -- { coder.Constant }
     self.k_slot_of_metatable = {} -- typ  => integer
     self.k_slot_of_string    = {} -- str  => integer
     self:init_upvalues()
@@ -638,8 +638,8 @@ function Coder:init_upvalues()
     -- Metatables
     for _, typ in ipairs(self.module.record_types) do
         if not typ.is_upvalue_box then
-            table.insert(self.upvalues, coder.Constant.Metatable(typ))
-            self.k_slot_of_metatable[typ] = #self.upvalues
+            table.insert(self.constants, coder.Constant.Metatable(typ))
+            self.k_slot_of_metatable[typ] = #self.constants
         end
     end
 
@@ -650,8 +650,8 @@ function Coder:init_upvalues()
                 if v._tag == "ir.Value.String" then
                     local str = v.value
                     if not self.k_slot_of_string[str] then
-                        table.insert(self.upvalues, coder.Constant.String(str))
-                        self.k_slot_of_string[str] = #self.upvalues
+                        table.insert(self.constants, coder.Constant.String(str))
+                        self.k_slot_of_string[str] = #self.constants
                     end
                 end
             end
@@ -1666,7 +1666,7 @@ end
 function Coder:generate_luaopen_function()
 
     local init_constants = {}
-    for ix, upv in ipairs(self.upvalues) do
+    for ix, upv in ipairs(self.constants) do
         local tag = upv._tag
         local is_upvalue_box = false
 
@@ -1733,7 +1733,7 @@ function Coder:generate_luaopen_function()
         }
     ]], {
         name = "luaopen_" .. self.modname,
-        n_upvalues = C.integer(#self.upvalues),
+        n_upvalues = C.integer(#self.constants),
         init_constants = table.concat(init_constants, "\n"),
         init_initializers = init_initializers,
     }))

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1392,9 +1392,6 @@ gen_cmd["CallStatic"] = function(self, cmd, func)
     elseif f_val._tag == "ir.Value.LocalVar" then
         f_id = assert(func.f_id_of_local[f_val.id])
         cclosure = string.format("clCvalue(&%s)", self:c_value(f_val))
-    elseif f_val._tag == "ir.Value.Function" then
-        f_id = f_val.id
-        cclosure = string.format("clCvalue(%s)", self:function_upvalue_slot(f_id))
     else
         typedecl.tag_error(f_val._tag)
     end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -92,7 +92,10 @@ local function lua_value(typ, src_slot)
     elseif tag == "types.T.Any"      then tmpl = "*($src)"
     else typedecl.tag_error(tag)
     end
-    return (util.render(tmpl, {src = src_slot}))
+
+    local res = util.render(tmpl, {src = src_slot})
+    -- Clean up *(&x)
+    return string.match(res, "^%*%(%&(.*)%)$") or res
 end
 
 local function unchecked_get_slot(typ, dst, src)
@@ -384,7 +387,7 @@ function Coder:pallene_entry_point_declaration(f_id)
     local args = {} -- { {ctype, name , comment} }
     table.insert(args, {"lua_State *" , "L",    ""})
     table.insert(args, {"StackValue *", "base", ""})
-    table.insert(args, {"Udata *"     , "K",    ""})
+    table.insert(args, {"Udata * restrict "     , "K",    ""})
     table.insert(args, {"TValue * restrict ", "U", C.comment("upvalues")})
 
     for i = 1, #arg_types do

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -6,7 +6,7 @@
 local c_compiler = require "pallene.c_compiler"
 local checker = require "pallene.checker"
 local assignment_conversion = require "pallene.assignment_conversion"
-local constant_propagation = require "pallene.constant_propagation"
+-- local constant_propagation = require "pallene.constant_propagation"
 local coder = require "pallene.coder"
 local Lexer = require "pallene.Lexer"
 local parser = require "pallene.parser"
@@ -52,7 +52,7 @@ driver.list_of_compiler_passes = {"lexer", "ast", "checker", "assignment_convers
 --
 -- @opt_level is used here to enable or disable Pallene optimizations. Follows GCC convention of
 -- level "0" being no optimization. Currently, every other level will enable Pallene optimizations.
-function driver.compile_internal(filename, input, stop_after, opt_level)
+function driver.compile_internal(filename, input, stop_after, _opt_level)
     stop_after = stop_after or "optimize"
 
     local lexer = Lexer.new(filename, input)
@@ -86,12 +86,16 @@ function driver.compile_internal(filename, input, stop_after, opt_level)
         return module, errs
     end
 
-    if opt_level > 0 then
-        module, errs = constant_propagation.run(module)
-        if stop_after == "constant_propagation" or not module then
-            return module, errs
-        end
-    end
+    -- After some changes to the representation of global and module variables,
+    -- the constant propagation pass is no longer functional. This pass remains
+    -- unused until a fix is in place.
+    --
+    -- if opt_level > 0 then
+    --     module, errs = constant_propagation.run(module)
+    --     if stop_after == "constant_propagation" or not module then
+    --         return module, errs
+    --     end
+    -- end
 
     if stop_after == "optimize" or not module then
         return module, {}

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -28,11 +28,12 @@ end
 
 function ir.Module()
     return {
-        record_types       = {}, -- list of Type
-        functions          = {}, -- list of ir.Function
-        globals            = {}, -- list of ir.VarDecl
-        exported_functions = {}, -- list of function ids
-        exported_globals   = {}, -- list of variable ids
+        record_types       = {},  -- list of Type
+        functions          = {},  -- list of ir.Function
+        globals            = {},  -- list of ir.VarDecl
+        exported_functions = {},  -- list of function ids
+        exported_globals   = {},  -- list of variable ids
+        loc_id_of_exports  = nil, -- integer
     }
 end
 
@@ -86,8 +87,8 @@ function ir.add_exported_function(module, f_id)
     table.insert(module.exported_functions, f_id)
 end
 
-function ir.add_exported_global(module, g_id)
-    table.insert(module.exported_globals, g_id)
+function ir.add_exported_global(module, loc_id)
+    table.insert(module.exported_globals, loc_id)
 end
 
 --
@@ -134,8 +135,6 @@ local ir_cmd_constructors = {
 
     -- Variables
     Move       = {"loc", "dst", "src"},
-    GetGlobal  = {"loc", "dst", "global_id"},
-    SetGlobal  = {"loc",        "global_id", "src"},
 
     -- Primitive Values
     Unop       = {"loc", "dst", "op", "src"},

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -124,7 +124,6 @@ declare_type("Value", {
     String     = {"value"},
     LocalVar   = {"id"},
     Upvalue    = {"id"},
-    Function   = {"id"},
 })
 
 -- declare_type("Cmd"

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -45,7 +45,6 @@ local function Val(val)
     elseif tag == "ir.Value.String"   then return C.string(val.value)
     elseif tag == "ir.Value.LocalVar" then return Var(val.id)
     elseif tag == "ir.Value.Upvalue"  then return Upval(val.id)
-    elseif tag == "ir.Value.Function" then return Fun(val.id)
     else
         typedecl.tag_error(tag)
     end
@@ -196,8 +195,7 @@ local function Cmd(cmd)
     -- Leaf commands (single line)
 
     local lhs
-    if     tag == "ir.Cmd.SetGlobal" then lhs = Global(cmd.global_id)
-    elseif tag == "ir.Cmd.SetArr"    then lhs = Bracket(cmd.src_arr, cmd.src_i)
+    if     tag == "ir.Cmd.SetArr"    then lhs = Bracket(cmd.src_arr, cmd.src_i)
     elseif tag == "ir.Cmd.SetTable"  then lhs = Bracket(cmd.src_tab, cmd.src_k)
     elseif tag == "ir.Cmd.SetField"  then lhs = Field(cmd.src_rec, cmd.field_name)
     else
@@ -207,7 +205,6 @@ local function Cmd(cmd)
     local rhs
     if     tag == "ir.Cmd.Move"       then rhs = Val(cmd.src)
     elseif tag == "ir.Cmd.GetGlobal"  then rhs = Global(cmd.global_id)
-    elseif tag == "ir.Cmd.SetGlobal"  then rhs = Val(cmd.src)
     elseif tag == "ir.Cmd.Unop"       then rhs = Unop(cmd.op, cmd.src)
     elseif tag == "ir.Cmd.Binop"      then rhs = Binop(cmd.op, cmd.src1, cmd.src2)
     elseif tag == "ir.Cmd.GetArr"     then rhs = Bracket(cmd.src_arr, cmd.src_i)

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -78,12 +78,14 @@ function ToIR:init()
     self.module = ir.Module()
     self.rec_id_of_typ  = {} -- { types.T  => integer }
     self.fun_id_of_exp  = {} -- { ast.Exp  => integer }
-    self.glb_id_of_decl = {} -- { ast.Decl => integer } -- non-exported globals
-    self.glb_id_of_var  = {} -- { ast.Var  => integer } -- exported global
     self.func_stack     = {} -- list of function to_ir.FuncInfo
     self.call_exps      = {} -- { ast.Exp.CallFunc }
     self.dsts_of_call   = {} -- { ast.Exp => { var_id } }
     self.toplevel_funcs = {} -- { ast.FuncStat.FuncStat }
+
+    -- Map's an exported function's ID to it's local variable ID
+    -- in the `$init` function.
+    self.loc_id_of_exported_func = {} -- { integer => integer }
 end
 
 function ToIR:enter_function(f_id)
@@ -126,18 +128,11 @@ end
 -- If `decl` resolves to an upvalue, then it registers the upvalue in the intermediate
 -- and current function.
 function ToIR:resolve_variable(decl)
-    if decl._tag == "ast.Var.Name" then
-        local glb_id = assert(self.glb_id_of_var[decl])
-        return to_ir.Var.GlobalVar(glb_id)
-    end
+    assert(decl._tag == "ast.Decl.Decl"
+        or decl._tag == "ast.FuncStat.FuncStat"
+        or decl._tag == "ast.Var.Name")
 
-    assert(decl._tag == "ast.Decl.Decl" or decl._tag == "ast.FuncStat.FuncStat")
     assert(decl.name)
-
-    local glb_id = self.glb_id_of_decl[decl]
-    if glb_id then
-        return to_ir.Var.GlobalVar(glb_id)
-    end
 
     local stack_id, var
     for i = 1, #self.func_stack do
@@ -200,11 +195,13 @@ end
 function ToIR:convert_toplevel(prog_ast)
 
     -- Create the $init function (it must have ID = 1)
-    ir.add_function(self.module, false, "$init", types.T.Function({}, {}))
+    ir.add_function(self.module, false, "$init", types.T.Function({}, {types.T.Table({})}))
 
     -- Initialize the module-level variables
     self:enter_function(1)
     local cmds = {}
+
+    local n_exports = 0
     for _, tl_node in ipairs(prog_ast) do
         local tag = tl_node._tag
         if tag == "ast.Toplevel.Stats" then
@@ -214,17 +211,11 @@ function ToIR:convert_toplevel(prog_ast)
                     for _, var in ipairs(stat.vars) do
                         if var._exported_as then
                             assert(var._type)
-                            local g_id = ir.add_global(self.module, var.name, var._type)
-                            self.glb_id_of_var[var] = g_id
-                            ir.add_exported_global(self.module, g_id)
+                            local loc_id = ir.add_local(self.func, var.name, var._type)
+                            self.loc_id_of_decl[var] = loc_id
+                            ir.add_exported_global(self.module, loc_id)
+                            n_exports = n_exports + 1
                         end
-                    end
-
-                elseif stag == "ast.Stat.Decl" then
-                    for _, decl in ipairs(stat.decls) do
-                        assert(decl._type)
-                        local g_id = ir.add_global(self.module, decl.name, decl._type)
-                        self.glb_id_of_decl[decl] = g_id
                     end
 
                 elseif stag == "ast.Stat.Functions" then
@@ -233,6 +224,7 @@ function ToIR:convert_toplevel(prog_ast)
                         local f_id = self:register_lambda(func.value, func.name)
                         self.toplevel_funcs[func] = true
                         if func.module then
+                            n_exports = n_exports + 1
                             ir.add_exported_function(self.module, f_id)
                         end
                     end
@@ -257,6 +249,40 @@ function ToIR:convert_toplevel(prog_ast)
             -- skip
         end
     end
+
+    -- Initialize the module exports as a lua table
+    local exports_type  = types.T.Table({})
+    self.module.loc_id_of_exports = ir.add_local(self.func, "$exports", exports_type)
+    table.insert(cmds, ir.Cmd.NewTable(self.func.loc,  self.module.loc_id_of_exports, ir.Value.Integer(n_exports)))
+    table.insert(cmds, ir.Cmd.CheckGC())
+
+    -- export the functions
+    for _, f_id in ipairs(self.module.exported_functions) do
+        local func   = self.module.functions[f_id]
+        local loc_id = assert(self.loc_id_of_exported_func[f_id])
+
+        local tv = ir.Value.LocalVar( self.module.loc_id_of_exports)
+        local kv = ir.Value.String(func.name)
+        local fv = ir.Value.LocalVar(loc_id)
+        local src_typ = func.typ
+        table.insert(cmds, ir.Cmd.SetTable(func.loc, src_typ, tv, kv, fv))
+    end
+
+    -- export module variables
+    for _, loc_id in ipairs(self.module.exported_globals) do
+        local var  = self.func.vars[loc_id]
+        local name = assert(var.name)
+
+        local tv = ir.Value.LocalVar(self.module.loc_id_of_exports)
+        local kv = ir.Value.String(name)
+        local fv = ir.Value.LocalVar(loc_id)
+        local src_typ = var.typ
+        table.insert(cmds, ir.Cmd.SetTable(var.loc, src_typ, tv, kv, fv))
+    end
+
+    local v_exports = ir.Value.LocalVar(self.module.loc_id_of_exports)
+    table.insert(cmds, ir.Cmd.Return(self.func.loc, { v_exports }))
+
     self:exit_function(cmds)
 
     return self.module
@@ -510,8 +536,6 @@ function ToIR:convert_stat(cmds, stat)
                 local var_info = self:resolve_variable(var._def.decl)
                 if var_info._tag == "to_ir.Var.LocalVar" then
                     table.insert(lhss, to_ir.LHS.Local(var_info.id))
-                elseif var_info._tag == "to_ir.Var.GlobalVar" then
-                    table.insert(lhss, to_ir.LHS.Global(var_info.id))
                 else
                     typedecl.tag_error(var_info._tag)
                 end
@@ -589,8 +613,6 @@ function ToIR:convert_stat(cmds, stat)
                 local ltag = lhs._tag
                 if     ltag == "to_ir.LHS.Local" then
                     table.insert(cmds, ir.Cmd.Move(loc, lhs.id, val))
-                elseif ltag == "to_ir.LHS.Global" then
-                    table.insert(cmds, ir.Cmd.SetGlobal(loc, lhs.id, val))
                 elseif ltag == "to_ir.LHS.Array" then
                     table.insert(cmds, ir.Cmd.SetArr(loc, lhs.typ, lhs.arr, lhs.i, val))
                 elseif ltag == "to_ir.LHS.Table" then
@@ -607,21 +629,13 @@ function ToIR:convert_stat(cmds, stat)
     elseif tag == "ast.Stat.Decl" then
         for _, decl in ipairs(stat.decls) do
             local typ = decl._type
-            if not self.glb_id_of_decl[decl] then
-                self.loc_id_of_decl[decl] = ir.add_local(self.func, decl.name, typ)
-            end
+            self.loc_id_of_decl[decl] = ir.add_local(self.func, decl.name, typ)
         end
 
         for i, exp in ipairs(stat.exps) do
             local decl = stat.decls[i]
             if decl then
-                local g_id = self.glb_id_of_decl[decl]
-                if g_id then
-                    local val = self:exp_to_value(cmds, exp)
-                    table.insert(cmds, ir.Cmd.SetGlobal(decl.loc, g_id, val))
-                else
-                    self:exp_to_assignment(cmds, self.loc_id_of_decl[decl], exp)
-                end
+                self:exp_to_assignment(cmds, self.loc_id_of_decl[decl], exp)
             else
                 -- Extra argument to RHS; compute it for side effects and discard result
                 local _ = self:exp_to_value(cmds, exp)
@@ -643,38 +657,40 @@ function ToIR:convert_stat(cmds, stat)
 
     elseif tag == "ast.Stat.Functions" then
 
-        -- To handle LetRecs (`local f1, f2;`) , we register all the locals first.
+        -- To handle LetRecs (`local f1, f2;`), we register all the locals first.
         for _, func in ipairs(stat.funcs) do
-            if not self.toplevel_funcs[func] then
-                self.loc_id_of_decl[func] = ir.add_local(self.func, func.name, func._type)
-            end
+            local loc_id = ir.add_local(self.func, func.name, func._type)
+            self.loc_id_of_decl[func] = loc_id
 
             local exp = func.value
             if not self.fun_id_of_exp[exp] then
                 self:register_lambda(exp, func.name)
+            end
+
+            local f_id = self.fun_id_of_exp[exp]
+            if func.module then
+                assert(#self.func_stack == 1)
+                self.loc_id_of_exported_func[f_id] = loc_id
             end
         end
 
         for _ , func in ipairs(stat.funcs) do
             local exp = func.value
             self:convert_func(exp)
-            if not self.toplevel_funcs[func] then
-                local dst  = self.loc_id_of_decl[func]
-                local f_id = self.fun_id_of_exp[exp]
-                table.insert(cmds, ir.Cmd.NewClosure(exp.loc, dst, f_id))
-            end
+
+            local dst  = self.loc_id_of_decl[func]
+            local f_id = self.fun_id_of_exp[exp]
+            table.insert(cmds, ir.Cmd.NewClosure(exp.loc, dst, f_id))
         end
 
         -- To support mutual recursion, upvalues are initialized *after* the closures
         -- have been created.
         for _, func in ipairs(stat.funcs) do
-            if not self.toplevel_funcs[func] then
-                local f_id  = self.fun_id_of_exp[func.value]
-                local dst   = self.loc_id_of_decl[func]
-                local f_val = self.module.functions[f_id]
-                for _, upval_info in ipairs(f_val.captured_vars) do
-                    table.insert(cmds, ir.Cmd.SetUpvalue(func.loc, dst, upval_info.value, f_id))
-                end
+            local f_id  = self.fun_id_of_exp[func.value]
+            local dst   = self.loc_id_of_decl[func]
+            local f_val = self.module.functions[f_id]
+            for _, upval_info in ipairs(f_val.captured_vars) do
+                table.insert(cmds, ir.Cmd.SetUpvalue(func.loc, dst, upval_info.value, f_id))
             end
         end
 

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -82,7 +82,7 @@ function ToIR:init()
     self.call_exps      = {} -- { ast.Exp.CallFunc }
     self.dsts_of_call   = {} -- { ast.Exp => { var_id } }
 
-    -- Map's an exported function's ID to it's local variable ID
+    -- Maps an exported function's ID to it's local variable ID
     -- in the `$init` function.
     self.loc_id_of_exported_func = {} -- { integer => integer }
 end


### PR DESCRIPTION
Prior to this, the global userdata table `G` was being used for:
- module variables
- toplevel local variables (globals)
- constants (strings and metatables)

Now, module variables and toplevel local variables are captured as upvalues by the toplevel functions.
The `G` table has been renamed to `K`, and is only used for storing constants.

- The `ir.Cmd.SetGlobal` and `ir.Cmd.GetGlobal` instructions have been deleted. set-get operations on toplevel module/local variables are carried out by representing them as boxed upvalues.
- `ir.Value.Function` has been deleted. Toplevel functions are referenced using `ir.Value.LocalVar` and `ir.Value.Upvalue`. CallStatic still nearly works just the way it did.
- The constant propagation pass has been temporarily disabled, as it depended on the read/write counts to globals using the now deleted `GetGlobal` and `SetGlobal` ir instructions.
- The exports table is now created in `$init` instead of `luaopen_module`. As a result of this, `$init` is now `() -> Table` instead of  `() -> ()`.