### PR TITLE
Remove the U comment in the generated code

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -386,9 +386,9 @@ function Coder:pallene_entry_point_declaration(f_id)
 
     local args = {} -- { {ctype, name , comment} }
     table.insert(args, {"lua_State *" , "L",    ""})
-    table.insert(args, {"StackValue *", "base", ""})
-    table.insert(args, {"Udata * restrict "     , "K",    ""})
-    table.insert(args, {"TValue * restrict ", "U", C.comment("upvalues")})
+    table.insert(args, {"StackValue *", "base", ""})     -- Lua stack pointer
+    table.insert(args, {"Udata * restrict " , "K",  ""}) -- constants table
+    table.insert(args, {"TValue * restrict ", "U" , ""}) -- upvalue array
 
     for i = 1, #arg_types do
         local v_id = ir.arg_var(func, i)


### PR DESCRIPTION
It is a bit cluttered to include this information in every single generated function. Let's use these comments only for the user-defined variables, to show the name of the variable in the original Pallene program.

Before:
```c
static char function_02(
    lua_State *L,
    StackValue *base,
    Udata * restrict K,
    TValue * restrict U,/* upvalues */
    lua_Integer x1  /* n */
);
```

After:
```c
static char function_02(
    lua_State *L,
    StackValue *base,
    Udata * restrict K,
    TValue * restrict U,
    lua_Integer x1  /* n */
);
```