### PR TITLE
Fixed `ir.Cmd.SetUpvalue` instruction.

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1326,7 +1326,7 @@ gen_cmd["NewClosure"] = function (self, cmd, _func)
     })
 end
 
-gen_cmd["SetUpvalue"] = function(self, cmd, _func)
+gen_cmd["SetUpvalues"] = function(self, cmd, _func)
     local func = self.module.functions[cmd.f_id]
 
     assert(cmd.src_f._tag == "ir.Value.LocalVar")
@@ -1337,6 +1337,10 @@ gen_cmd["SetUpvalue"] = function(self, cmd, _func)
         local typ   = func.captured_vars[i].typ
         local c_val = self:c_value(val)
         local upvalue_dst = string.format("&(ccl->upvalue[%s])", C.integer(i))
+
+        -- Even though the CClosure is a heap object, it is safe to use `set_stack_slot` as
+        -- there are no operations in between the closure's creation and the upvalue initialization
+        -- that may trigger a GC Cycle.
         table.insert(capture_upvalues, set_stack_slot(typ, upvalue_dst, c_val))
     end
 

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -313,7 +313,7 @@ end
 -- @returns the C parameter name for the upvalue u_id
 function Coder:c_upval(u_id)
     assert(self.current_func)
-    local typ = self.current_func.captured_vars[u_id].decl.typ
+    local typ = self.current_func.captured_vars[u_id].typ
     -- Since upvalue boxes do not have metatables, type checking them at runtime is not possible.
     -- Moreover, since upvalues are only passed around internally by Pallene, it is ok to assume that
     -- their types will be correct. So we directly cast it using `lua_value` without a tag check.
@@ -1333,9 +1333,9 @@ gen_cmd["SetUpvalue"] = function(self, cmd, _func)
     local cclosure = string.format("clCvalue(&%s)", self:c_var(cmd.src_f.id))
 
     local capture_upvalues = {}
-    for i, upval_info in ipairs(func.captured_vars) do
-        local typ   = upval_info.decl.typ
-        local c_val = self:c_value(upval_info.value)
+    for i, val in ipairs(cmd.srcs) do
+        local typ   = func.captured_vars[i].typ
+        local c_val = self:c_value(val)
         local upvalue_dst = string.format("&(ccl->upvalue[%s])", C.integer(i))
         table.insert(capture_upvalues, set_stack_slot(typ, upvalue_dst, c_val))
     end

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1327,18 +1327,16 @@ gen_cmd["NewClosure"] = function (self, cmd, _func)
 end
 
 gen_cmd["SetUpvalue"] = function(self, cmd, _func)
-    local func = self.module.functions[cmd.f_id]
-    local capture_upvalues = {}
+    local src_f = cmd.src_f
+    assert(src_f._tag == "ir.Value.LocalVar")
 
-    local cclosure = string.format("clCvalue(&%s)", self:c_var(cmd.dst))
-    for i, upval_info in ipairs(func.captured_vars) do
-        local typ   = upval_info.decl.typ
-        local c_val = self:c_value(upval_info.value)
-        local upvalue_dst = string.format("&(%s->upvalue[%s])", cclosure, C.integer(i))
-        table.insert(capture_upvalues, set_stack_slot(typ, upvalue_dst, c_val))
-    end
+    local cclosure = string.format("clCvalue(&%s)", self:c_var(src_f.id))
+    local c_val = self:c_value(cmd.src)
 
-    return table.concat(capture_upvalues, "\n")
+    local u_index = C.integer(cmd.u_id)
+    local upvalue_dst = string.format("&(%s->upvalue[%s])", cclosure, u_index)
+
+    return set_stack_slot(cmd.dst_typ, upvalue_dst, c_val)
 end
 
 gen_cmd["CallStatic"] = function(self, cmd, func)

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -44,20 +44,13 @@ function ir.VarDecl(name, typ)
     }
 end
 
-function ir.UpvalInfo(decl, val)
-    return {
-        decl = decl, -- ir.VarDecl
-        value = val, -- ir.Value
-    }
-end
-
 function ir.Function(loc, name, typ)
     return {
         loc = loc,            -- Location
         name = name,          -- string
         typ = typ,            -- Type
         vars = {},            -- list of ir.VarDecl
-        captured_vars = {},   -- list of ir.UpvalInfo
+        captured_vars = {},   -- list of ir.VarDecl
         f_id_of_upvalue = {}, -- { integer => integer }
         f_id_of_local = {},   -- { integer => integer }
         body = false,         -- ir.Cmd
@@ -100,9 +93,9 @@ function ir.add_local(func, name, typ)
     return #func.vars
 end
 
-function ir.add_upvalue(func, name, typ, value)
+function ir.add_upvalue(func, name, typ)
     local decl = ir.VarDecl(name, typ)
-    table.insert(func.captured_vars, ir.UpvalInfo(decl, value))
+    table.insert(func.captured_vars, decl)
     return #func.captured_vars
 end
 
@@ -167,7 +160,7 @@ local ir_cmd_constructors = {
 
     -- Functions
     NewClosure = {"loc", "dst"  , "f_id"},
-    SetUpvalue = {"loc", "src_f", "f_id"},
+    SetUpvalue = {"loc", "src_f", "srcs", "f_id"},
 
     -- (dst is false if the return value is void, or unused)
     CallStatic  = {"loc", "f_typ", "dsts", "src_f", "srcs"},

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -167,7 +167,7 @@ local ir_cmd_constructors = {
 
     -- Functions
     NewClosure = {"loc", "dst", "f_id"},
-    SetUpvalue = {"loc", "dst", "src", "f_id"},
+    SetUpvalue = {"loc", "src_f", "u_id", "dst_typ", "src"},
 
     -- (dst is false if the return value is void, or unused)
     CallStatic  = {"loc", "f_typ", "dsts", "src_f", "srcs"},

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -166,8 +166,8 @@ local ir_cmd_constructors = {
     SetField   = {"loc", "rec_typ",        "src_rec", "field_name", "src_v"},
 
     -- Functions
-    NewClosure = {"loc", "dst", "f_id"},
-    SetUpvalue = {"loc", "src_f", "u_id", "dst_typ", "src"},
+    NewClosure = {"loc", "dst"  , "f_id"},
+    SetUpvalue = {"loc", "src_f", "f_id"},
 
     -- (dst is false if the return value is void, or unused)
     CallStatic  = {"loc", "f_typ", "dsts", "src_f", "srcs"},

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -160,7 +160,7 @@ local ir_cmd_constructors = {
 
     -- Functions
     NewClosure = {"loc", "dst"  , "f_id"},
-    SetUpvalue = {"loc", "src_f", "srcs", "f_id"},
+    SetUpvalues = {"loc", "src_f", "srcs", "f_id"},
 
     -- (dst is false if the return value is void, or unused)
     CallStatic  = {"loc", "f_typ", "dsts", "src_f", "srcs"},

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -711,7 +711,7 @@ function ToIR:convert_stat(cmds, stat)
                 for _, val in ipairs(captured_vars) do
                     table.insert(srcs, val)
                 end
-                table.insert(cmds, ir.Cmd.SetUpvalue(func.loc, src_f, srcs, f_id))
+                table.insert(cmds, ir.Cmd.SetUpvalues(func.loc, src_f, srcs, f_id))
             end
         end
 
@@ -981,7 +981,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             for _, upval in ipairs(captured_vars) do
                 table.insert(srcs, upval)
             end
-            table.insert(cmds, ir.Cmd.SetUpvalue(exp.loc, src_f, srcs, f_id))
+            table.insert(cmds, ir.Cmd.SetUpvalues(exp.loc, src_f, srcs, f_id))
         end
 
     elseif tag == "ast.Exp.ExtraRet" then


### PR DESCRIPTION
This fixes the code codegen for `ir.Cmd.SetUpvalue` where it would set *all* upvalues of a closure instead of the ones it is supposed to set. 

Sample codegen for a closure with 3 integer upvalues.
Before:

```c
setivalue(&(clCvalue(&x4)->upvalue[1]), x1);
setivalue(&(clCvalue(&x4)->upvalue[2]), x2);
setivalue(&(clCvalue(&x4)->upvalue[3]), x3);
setobj(L, s2v(base + 0), &x4);
setivalue(&(clCvalue(&x4)->upvalue[1]), x1);
setivalue(&(clCvalue(&x4)->upvalue[2]), x2);
setivalue(&(clCvalue(&x4)->upvalue[3]), x3);
setobj(L, s2v(base + 0), &x4);
setivalue(&(clCvalue(&x4)->upvalue[1]), x1);
setivalue(&(clCvalue(&x4)->upvalue[2]), x2);
setivalue(&(clCvalue(&x4)->upvalue[3]), x3);
setobj(L, s2v(base + 0), &x4);
x5 = function_03(L, base + 1, K, clCvalue(&x4)->upvalue);
base = restorestack(L, base_offset);
```

after:

```c
setivalue(&(clCvalue(&x4)->upvalue[1]), x1);
setivalue(&(clCvalue(&x4)->upvalue[2]), x2);
setivalue(&(clCvalue(&x4)->upvalue[3]), x3);
setobj(L, s2v(base + 0), &x4);
x5 = function_03(L, base + 1, K, clCvalue(&x4)->upvalue);
base = restorestack(L, base_offset);
```

In addition, the ir.Cmd.Upvalue itself has had some changes.
The closure argument is now called `src_f`, and the upvalue index it's supposed to initialize is called `u_id`. (It cannot be called `dst` because `gc.lua` assumes every `dst` is a local var)