### PR TITLE
Fix a bug with "break"

### DIFF
--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -551,7 +551,7 @@ function Parser:FuncStat(is_local)
         self:region_end()
     end
 
-    local block = self:Block()
+    local block = self:FuncBody()
     local _     = self:e("end", start)
 
     for _, decl in ipairs(params) do
@@ -823,10 +823,20 @@ function Parser:FuncExp()
         self:syntax_error(typ.loc, "Function expressions cannot be type annotated")
     end
 
-    local block = self:Block()
+    local block = self:FuncBody()
     local _     = self:e("end", start)
 
     return ast.Exp.Lambda(start.loc, params, block)
+end
+
+function Parser:FuncBody()
+    local outer_loop_depth = self.loop_depth
+    self.loop_depth = 0
+
+    local block = self:Block()
+
+    self.loop_depth = outer_loop_depth
+    return block
 end
 
 function Parser:SimpleExp()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -363,6 +363,25 @@ describe("Parser /", function()
                 end
             ]], "break statement outside of a loop")
         end)
+
+        it("are not allowed outsize a loop (using function stat)", function()
+            assert_statements_error([[
+                while true do
+                    local function inner()
+                        break
+                    end
+                end
+            ]], "break statement outside of a loop")
+        end)
+
+        it("are not allowed outsize a loop (using function exp)", function()
+            assert_statements_error([[
+                while true do
+                    local inner: () -> () = function() break end
+                end
+            ]], "break statement outside of a loop")
+        end)
+
     end)
 
     describe("Return statements", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -354,7 +354,7 @@ describe("Parser /", function()
 
     describe("Break statements", function()
 
-        it("are not allowed outsize a loop", function()
+        it("are not allowed outside a loop", function()
             assert_statements_error([[
                 do
                     if x then
@@ -364,7 +364,7 @@ describe("Parser /", function()
             ]], "break statement outside of a loop")
         end)
 
-        it("are not allowed outsize a loop (using function stat)", function()
+        it("are not allowed outside a loop (using function stat)", function()
             assert_statements_error([[
                 while true do
                     local function inner()
@@ -374,7 +374,7 @@ describe("Parser /", function()
             ]], "break statement outside of a loop")
         end)
 
-        it("are not allowed outsize a loop (using function exp)", function()
+        it("are not allowed outside a loop (using function exp)", function()
             assert_statements_error([[
                 while true do
                     local inner: () -> () = function() break end


### PR DESCRIPTION
Previously, if a lambda was inside a loop then the body of the lambda was allowed to have break statements.  (That would crash the compiler)

Fixes #470.