### PR TITLE
Improved error message when an "end" is missing

### DIFF
--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -43,15 +43,6 @@ function Parser:init(lexer)
     self:advance(); self:advance()
 end
 
-function Parser:pay_attention_to_suspicious_indentation(open_tok, close_tok)
-    local d1 = assert(self.indent_of_token[open_tok])
-    local d2 = assert(self.indent_of_token[close_tok])
-    if d1 > d2 then
-        table.insert(self.mismatched_indentation, open_tok)
-        table.insert(self.mismatched_indentation, close_tok)
-    end
-end
-
 function Parser:advance()
     local tok, err
     repeat
@@ -98,7 +89,13 @@ function Parser:e(name, open_tok)
     local tok = self:try(name)
     if tok then
         if open_tok then
-            self:pay_attention_to_suspicious_indentation(open_tok, tok)
+            -- Pay attention to suspicious indentation
+            local d1 = assert(self.indent_of_token[open_tok])
+            local d2 = assert(self.indent_of_token[tok])
+            if d1 > d2 then
+                table.insert(self.mismatched_indentation, open_tok)
+                table.insert(self.mismatched_indentation, tok)
+            end
         end
         return tok
     else

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -902,4 +902,27 @@ describe("Parser /", function()
             })
         end)
     end)
+
+    describe("Missing 'end' errors", function()
+
+        it("point to the opening delimiter", function()
+            assert_program_error([[
+                local m = {}
+                local function foo()
+
+                return m
+            ]], "expected 'end' before end of the file, to close the 'function' at line 2")
+        end)
+
+        it("use indentation to find the actual location of the error", function()
+            assert_program_error([[
+                local m = {}
+                local function foo()
+                    if true then
+                end
+                return m
+            ]], "expected 'end' to close 'if' at line 3, before this less indented 'end'")
+        end)
+
+    end)
 end)


### PR DESCRIPTION
If an "end" token is missing, we now use an indentation-based heuristic to try to spot the actual culprit for the error. In addition to showing the location where the error was detected, we also show the location of the block opener that we think is to blame. For example,

```lua
local m = {}
local function foo()
    if true then
end
return m
```

Now shows this error:

    syntax error: foo.pln:6:1: expected 'end' before end of the file, to close the 'function' at line 2
    syntax error: foo.pln:3:5: ...possibly because this 'if' is missing an 'end' (mismatched indentation)
    compilation aborted due to previous error

We give a similar error message for mismatched parenthesis and curly braces, provided that the open and close brace are on different lines.

-----------------

🙋 I tried to make the error message fit in a single line, but I'm not sure if this wording is ideal... Any suggestions?