### PR TITLE
Toplevel statements can now end in semi-colons.

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -513,7 +513,7 @@ end
 Here is the complete syntax of Pallene in extended BNF.
 As usual, {A} means 0 or more As, and \[A\] means an optional A.
 
-    program ::= {toplevelrecord | topleveltypealias | toplevelvar | toplevelfunc}
+    program ::= {toplevelrecord | topleveltypealias | toplevelvar | toplevelfunc | ';'}
 
     toplevelrecord ::= record Name {recordfield} end
     recordfield ::= NAME ':' type [';']

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -161,8 +161,14 @@ function Parser:Program()
 
     -- module contents
     local tls = {}
-    while not self:peek("EOF") and not self:peek("return") do
-        table.insert(tls, self:Toplevel())
+    while true do
+        if self:try(";") then
+            -- skip empty statement
+        elseif not self:peek("EOF") and not self:peek("return") then
+            table.insert(tls, self:Toplevel())
+        else
+            break
+        end
     end
 
     -- return <modname>
@@ -185,6 +191,10 @@ function Parser:Program()
                 self:syntax_error(exp.loc,
                     "must return exactly the module variable '%s'", modname)
             end
+        end
+
+        while self:try(";") do
+            -- trailing semi colons
         end
 
         if not self:peek("EOF") then

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -697,7 +697,7 @@ function Parser:Stat(is_toplevel)
             return ast.Stat.Return(start.loc, {})
         else
             local exp_list = self:ExpList1()
-            self:skip_semis()
+            self:try(";")
             return ast.Stat.Return(start.loc, exp_list)
         end
 

--- a/pallene/parser.lua
+++ b/pallene/parser.lua
@@ -121,6 +121,11 @@ function Parser:region_end(skip_spaces)
     end
 end
 
+function Parser:skip_semis()
+    while self:try(";") do
+    end
+end
+
 --
 -- Toplevel
 --
@@ -159,16 +164,13 @@ function Parser:Program()
             "must begin with a module declaration; local <modname> = {}")
     end
 
+    -- skip any trailing semi-colons after the module statement.
+    self:skip_semis()
+
     -- module contents
     local tls = {}
-    while true do
-        if self:try(";") then
-            -- skip empty statement
-        elseif not self:peek("EOF") and not self:peek("return") then
-            table.insert(tls, self:Toplevel())
-        else
-            break
-        end
+    while not self:peek("EOF") and not self:peek("return") do
+        table.insert(tls, self:Toplevel())
     end
 
     -- return <modname>
@@ -193,10 +195,6 @@ function Parser:Program()
             end
         end
 
-        while self:try(";") do
-            -- trailing semi colons
-        end
-
         if not self:peek("EOF") then
             self:syntax_error(self.next.loc,
                 "the module return statement must be the last thing in the file")
@@ -219,6 +217,8 @@ function Parser:Toplevel()
         local _     = self:e("=")
         local typ   = self:Type()
         self:region_end()
+
+        self:skip_semis()
         return ast.Toplevel.Typealias(start.loc, id.value, typ)
 
     elseif self:peek("record") then
@@ -229,33 +229,19 @@ function Parser:Toplevel()
         while self:peek("NAME") do
             local decl = self:Decl()
             if not decl.type then self:forced_syntax_error(":") end
-            local _ = self:try(";")
+            self:skip_semis()
             table.insert(fields, decl)
         end
         self:e("end", start)
         self:region_end()
+
+        self:skip_semis()
         return ast.Toplevel.Record(start.loc, id.value, fields)
 
     else
-        local stats = {}
-        while
-            not self:peek("EOF") and
-            not self:peek("return") and
-            not self:peek("typealias") and
-            not self:peek("record")
-        do
-            local stat = self:Stat(true)
-            if stat._tag ~= "ast.Stat.Decl" and
-               stat._tag ~= "ast.Stat.Assign" and
-               stat._tag ~= "ast.Stat.Functions"
-            then
-                self:syntax_error(stat.loc,
-                    "toplevel statements can only be Returns, Declarations or Assignments")
-            end
-            table.insert(stats, stat)
-        end
+        local stats = self:StatList(true)
         assert(stats[1])
-        return ast.Toplevel.Stats(stats[1].loc, self:find_letrecs(stats))
+        return ast.Toplevel.Stats(stats[1].loc, stats)
     end
 end
 
@@ -267,7 +253,7 @@ function Parser:Type()
     if self:peek("(") then
         local loc = self.next.loc
         local aa  = self:TypeList()
-        local _   = self:e("->");
+        local _   = self:e("->")
         local bb  = self:RetTypes()
         return ast.Type.Function(loc, aa, bb)
     else
@@ -298,7 +284,7 @@ end
 
 function Parser:TypeList()
     local ts = {}
-    local open = self:e("(");
+    local open = self:e("(")
     if not self:peek(")") then
         table.insert(ts, self:Type())
         while self:try(",") do
@@ -490,14 +476,34 @@ function Parser:block_follow()
            self:peek("until")
 end
 
-function Parser:StatList()
+function Parser:toplevel_statlist_follow()
+    return self:peek("EOF") or
+           self:peek("return") or
+           self:peek("typealias") or
+           self:peek("record")
+end
+
+function Parser:StatList(is_toplevel)
     local stats = {}
-    while not self:block_follow() do
+    local follow_func = is_toplevel and
+        self.toplevel_statlist_follow or self.block_follow
+
+    while not follow_func(self) do
         if self:try(";") then
             -- skip empty statement
         else
-            local stat = self:Stat()
+            local stat = self:Stat(is_toplevel)
             local _    = self:try(";")
+
+            if is_toplevel and
+               stat._tag ~= "ast.Stat.Decl" and
+               stat._tag ~= "ast.Stat.Assign" and
+               stat._tag ~= "ast.Stat.Functions"
+            then
+                self:syntax_error(stat.loc,
+                    "toplevel statements can only be Returns, Declarations or Assignments")
+            end
+
             table.insert(stats, stat)
             if stat._tag == "ast.Stat.Return" then
                 break
@@ -687,10 +693,12 @@ function Parser:Stat(is_toplevel)
 
     elseif self:peek("return") then
         local start = self:e()
-        if self:peek(";") or self:block_follow() then
+        if self:try(";") or self:block_follow() then
             return ast.Stat.Return(start.loc, {})
         else
-            return ast.Stat.Return(start.loc, self:ExpList1())
+            local exp_list = self:ExpList1()
+            self:skip_semis()
+            return ast.Stat.Return(start.loc, exp_list)
         end
 
     elseif self:peek("function") then

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -409,6 +409,13 @@ describe("Parser /", function()
             })
         end)
 
+        it("cannot be followed by a multiple semicolons", function()
+            assert_program_error([[
+                local m: module = {}
+                return m;;
+            ]], "the module return statement must be the last thing in the file")
+        end)
+
         it("must be the last statement in the block", function()
             assert_statements_error([[
                 return 10

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -227,6 +227,17 @@ describe("Parser /", function()
                 return i
             ]], "must return exactly the module variable 'm'")
         end)
+
+        it("can have semi-colons at the toplevel", function ()
+            assert_parses_successfuly([[
+                local m: module = {};
+                record Number
+                    num: integer;
+                end;
+                return m;
+            ]])
+        end)
+
     end)
 
     --
@@ -396,12 +407,6 @@ describe("Parser /", function()
             assert_statements_ast("return 10;", {
                 { _tag = "ast.Stat.Return", exps = { { _tag = "ast.Exp.Integer", value = 10 } } }
             })
-        end)
-
-        it("cannot be followed by a multiple semicolons", function()
-            assert_statements_error([[
-                return;;
-            ]], "expected 'end' before ';', to close the 'function' at line 2")
         end)
 
         it("must be the last statement in the block", function()


### PR DESCRIPTION
Small patch to fix #446.
I think it's okay to allow repeated semi-colons (`;;;;`), since Lua does so too?

The  grammar for `statement` suggests that as well.

I'm not too sure where to add the tests for this though. 
The tests for the frontend generally exist to assert certain errors and I'm not sure if having something like this be tested in it's own `it` block in `execution_tests` is a good idea.