### PR TITLE
Re-introduce constant propagation pass.

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1309,7 +1309,7 @@ gen_cmd["NewClosure"] = function (self, cmd, _func)
     -- The number of upvalues must fit inside a byte (the nupvalues in the ClosureHeader).
     -- However, we must check this limit ourselves, because luaF_newCclosure doesn't. If we have too
     -- many upvalues then that internal Lua function can overflow and do weird things.
-    local num_upvalues = #func.captured_vars + 1
+    local num_upvalues = func.num_upvalues + 1
     assert(num_upvalues <= 255)
 
     return util.render([[

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1309,7 +1309,7 @@ gen_cmd["NewClosure"] = function (self, cmd, _func)
     -- The number of upvalues must fit inside a byte (the nupvalues in the ClosureHeader).
     -- However, we must check this limit ourselves, because luaF_newCclosure doesn't. If we have too
     -- many upvalues then that internal Lua function can overflow and do weird things.
-    local num_upvalues = func.num_upvalues + 1
+    local num_upvalues = #func.captured_vars+ 1
     assert(num_upvalues <= 255)
 
     return util.render([[

--- a/pallene/constant_propagation.lua
+++ b/pallene/constant_propagation.lua
@@ -131,17 +131,21 @@ function constant_propagation.run(module)
         for cmd in ir.iter(func.body) do
             if cmd._tag == "ir.Cmd.SetUpvalues" then
                 local next_f   = assert(data_of_func[cmd.f_id])
+                local ir_func  = module.functions[cmd.f_id]
                 local new_u_id = next_f.new_upvalue_id
 
                 local new_srcs = {}
+                local new_captured_vars = {}
                 for u_id, value in ipairs(cmd.srcs) do
                     if not next_f.is_upvalue_constant[u_id] then
                         table.insert(new_srcs, value)
                         new_u_id[u_id] = #new_srcs
+                        table.insert(new_captured_vars, ir_func.captured_vars[u_id])
                     end
                 end
 
                 cmd.srcs = new_srcs
+                ir_func.captured_vars = new_captured_vars
             end
         end
     end

--- a/pallene/constant_propagation.lua
+++ b/pallene/constant_propagation.lua
@@ -135,17 +135,15 @@ function constant_propagation.run(module)
                 local new_u_id = next_f.new_upvalue_id
 
                 local new_srcs = {}
-                local new_captured_vars = {}
                 for u_id, value in ipairs(cmd.srcs) do
                     if not next_f.is_upvalue_constant[u_id] then
                         table.insert(new_srcs, value)
                         new_u_id[u_id] = #new_srcs
-                        table.insert(new_captured_vars, ir_func.captured_vars[u_id])
                     end
                 end
 
                 cmd.srcs = new_srcs
-                ir_func.captured_vars = new_captured_vars
+                ir_func.num_upvalues = #cmd.srcs
             end
         end
     end

--- a/pallene/driver.lua
+++ b/pallene/driver.lua
@@ -6,7 +6,7 @@
 local c_compiler = require "pallene.c_compiler"
 local checker = require "pallene.checker"
 local assignment_conversion = require "pallene.assignment_conversion"
--- local constant_propagation = require "pallene.constant_propagation"
+local constant_propagation = require "pallene.constant_propagation"
 local coder = require "pallene.coder"
 local Lexer = require "pallene.Lexer"
 local parser = require "pallene.parser"
@@ -52,7 +52,7 @@ driver.list_of_compiler_passes = {"lexer", "ast", "checker", "assignment_convers
 --
 -- @opt_level is used here to enable or disable Pallene optimizations. Follows GCC convention of
 -- level "0" being no optimization. Currently, every other level will enable Pallene optimizations.
-function driver.compile_internal(filename, input, stop_after, _opt_level)
+function driver.compile_internal(filename, input, stop_after, opt_level)
     stop_after = stop_after or "optimize"
 
     local errs
@@ -88,15 +88,11 @@ function driver.compile_internal(filename, input, stop_after, _opt_level)
     if not module then return abort() end
     if stop_after == "uninitialized" then return module end
 
-    -- After some changes to the representation of global and module variables,
-    -- the constant propagation pass is no longer functional. This pass remains
-    -- unused until a fix is in place.
-    --
-    -- if opt_level > 0 then
-    --     module, errs = constant_propagation.run(module)
-    --     if not module then return abort() end
-    --     if stop_after == "constant_propagation" then return module end
-    -- end
+    if opt_level > 0 then
+        module, errs = constant_propagation.run(module)
+        if not module then return abort() end
+        if stop_after == "constant_propagation" then return module end
+    end
 
     if stop_after == "optimize" then return module end
     error("impossible")

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -44,17 +44,12 @@ function ir.VarDecl(name, typ)
 end
 
 function ir.Function(loc, name, typ)
-    -- We need to store the number of upvalues separately (instead of just using #captured_vars) because
-    -- even though the captured_vars table is append-only, the actual number of upvalues may change
-    -- after the constant propagation pass. We cannot mutate the `captured_vars` table to reflect this change
-    -- because we still need type information of the propagated upvalues (which become constant values).
     return {
         loc = loc,            -- Location
         name = name,          -- string
         typ = typ,            -- Type
         vars = {},            -- list of ir.VarDecl
         captured_vars = {},   -- list of ir.VarDecl
-        num_upvalues  = 0,    -- integer (number of upvalues)
         f_id_of_upvalue = {}, -- { integer => integer }
         f_id_of_local = {},   -- { integer => integer }
         body = false,         -- ir.Cmd
@@ -100,7 +95,6 @@ end
 function ir.add_upvalue(func, name, typ)
     local decl = ir.VarDecl(name, typ)
     table.insert(func.captured_vars, decl)
-    func.num_upvalues = #func.captured_vars
     return #func.captured_vars
 end
 

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -158,7 +158,7 @@ local ir_cmd_constructors = {
     SetField   = {"loc", "rec_typ",        "src_rec", "field_name", "src_v"},
 
     -- Functions
-    NewClosure = {"loc", "dst"  , "f_id"},
+    NewClosure  = {"loc", "dst"  , "f_id"},
     SetUpvalues = {"loc", "src_f", "srcs", "f_id"},
 
     -- (dst is false if the return value is void, or unused)

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -30,7 +30,6 @@ function ir.Module()
     return {
         record_types       = {},  -- list of Type
         functions          = {},  -- list of ir.Function
-        globals            = {},  -- list of ir.VarDecl
         exported_functions = {},  -- list of function ids
         exported_globals   = {},  -- list of variable ids
         loc_id_of_exports  = nil, -- integer
@@ -207,6 +206,12 @@ for tag, fields in pairs(ir_cmd_constructors) do
         end
     end
     value_fields["ir.Cmd."..tag] = ff
+end
+
+
+-- Returns the value field names that contain inputs and outputs (ir.Value).
+function ir.get_value_field_names(cmd)
+    return assert(value_fields[cmd._tag])
 end
 
 -- Returns the inputs to the given command, a list of ir.Value.

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -44,12 +44,17 @@ function ir.VarDecl(name, typ)
 end
 
 function ir.Function(loc, name, typ)
+    -- We need to store the number of upvalues separately (instead of just using #captured_vars) because
+    -- even though the captured_vars table is append-only, the actual number of upvalues may change
+    -- after the constant propagation pass. We cannot mutate the `captured_vars` table to reflect this change
+    -- because we still need type information of the propagated upvalues (which become constant values).
     return {
         loc = loc,            -- Location
         name = name,          -- string
         typ = typ,            -- Type
         vars = {},            -- list of ir.VarDecl
         captured_vars = {},   -- list of ir.VarDecl
+        num_upvalues  = 0,    -- integer (number of upvalues)
         f_id_of_upvalue = {}, -- { integer => integer }
         f_id_of_local = {},   -- { integer => integer }
         body = false,         -- ir.Cmd
@@ -95,6 +100,7 @@ end
 function ir.add_upvalue(func, name, typ)
     local decl = ir.VarDecl(name, typ)
     table.insert(func.captured_vars, decl)
+    func.num_upvalues = #func.captured_vars
     return #func.captured_vars
 end
 


### PR DESCRIPTION
This PR re-introduces the constant propagation pass and fixes #444 (hopefully).

What's different:
- Upvalues and local variables are now propagated (There are no globals).
- Non-toplevel variables that are constants can be propagated as well.

For example:
```lua
local function f()
	local x = 1
	local function g(): integer
		return x + 10
	end
end
```
The code for the function `g` compiles down to:

```c    
lua_Integer x1;
    
x1 = intop(+, 1, 10);
return x1;
```

Overview:
- For every `ir.Function` in the module, we do a little bit of book keeping. Namely,
    - Read/Write count of every local var ID
    - Constant initializer (if any) of a local variable.
    - If a certain upvalue is actually a constant in disguise or not.
    - Constant value of an upvalue (which is just the constant initializer of the local variable it captures).

The overall structure is more or less the same.

First, we inspect all the `ir.Cmd.Move` instructions that have their `src` set to a constant value. This tells us which local variables have constant initializers.
Then, we inspect the read/write counts for all local variables and upvalues.

A local variable is a constant if:
 - It has a constant initializer.
 - It has a write count of 1 (assigned to only once).

An upvalue that captures a local var from it's surrounding function is a constant if:
  - If the local var is a constant

An upvalue that captures another upvalue from it's surrounding function is a constant if:
- The other upvalue that it's capturing is a constant too.

Once we have all this information, we go over the bodies of all functions, and propagate the constants.
This is done by **mutating** any `ir.Cmd` that has a `dst`/`dsts` which contain local vars/ upvalues that can be propagated.


**NOTE**: At the moment, unused variables (with write count of 0) are not elimited, and the upvalues which get constant propagated are still captured (but not used) by the `SetUpvalues` instruction. This requires a small fix. I refrained from doing this because I wasn't sure if the current way of mutating existing instructions is preferable. Moreover, I wasn't sure if we still want to keep the overall structure of the constant propagation or make it a class (like the other compiler passes).