### PR TITLE
Recompile benchmarks when running test suite

### DIFF
--- a/spec/benchmarks_spec.lua
+++ b/spec/benchmarks_spec.lua
@@ -19,6 +19,13 @@ else
     print("Warning: not testing the LuaJIT benchmarks, because LuaJIT is not installed.")
 end
 
+setup(function()
+    -- Ensure that the benchmark executables are recompiled from scratch.
+    -- This is a hacky workaround; the proper fix would be to clean up the benchlib
+    -- and replace the current compilation logic by something simpler / saner.
+    util.execute("find benchmarks/ -name '*.so' -delete")
+end)
+
 local function test_benchmark(bench, params, expected_output)
     describe(bench .. " /", function()
         for _, impl in ipairs(impls) do


### PR DESCRIPTION
Because the test suite did not recompile the benchmarks, sometimes the tests would pass on the local machine but not pass on the CI server. The immediate workaround is to force recompilation when running the test suite. In the future it would be nice if we replaced the benchlib by something less crazy.