### PR TITLE
Fixed bug that caused uninitialized variables to go undetected on use

### DIFF
--- a/benchmarks/queen/lua.lua
+++ b/benchmarks/queen/lua.lua
@@ -1,7 +1,7 @@
-local m, isplaceok, printsolution, addqueen;m = {}
+local m = {}
 
 -- check whether position (n,c) is free from attacks
-function isplaceok (a, n, c)
+local function isplaceok (a, n, c)
   for i = 1, n - 1 do   -- for each queen already placed
     local d = a[i]
     if (d == c) or                -- same column?
@@ -15,7 +15,7 @@ end
 
 
 -- print a board
-function printsolution (N, a)
+local function printsolution (N, a)
   for i = 1, N do
     local ai = a[i]
     for j = 1, N do
@@ -35,7 +35,7 @@ end
 
 
 -- add to board 'a' all queens from 'n' to 'N'
-function addqueen (N, a, n)
+local function addqueen (N, a, n)
   if n > N then    -- all queens have been placed?
     printsolution(N, a)
   else  -- try to place n-th queen

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -965,13 +965,11 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
     elseif tag == "ast.Exp.UpvalueRecord" then
         local typ = exp._type
         assert(typ._tag == "types.T.Record")
+        -- UpvalueRecords are only used initialize local variables that are mutably captured, and lack
+        -- an initializer upon declaration.
+        assert(typ.is_upvalue_box)
 
-        -- `UpvalueRecord`s are used to initialize local variables which are later used as mutable upvalues,
-        -- but do not have any initializer expression upon declaration. We mark this instruction to make sure
-        -- the later passes don't confuse this for a user-written initializer expression.
-        local cmd = ir.Cmd.NewRecord(loc, typ, dst)
-        cmd._is_upvalue_box_init = true
-        table.insert(cmds, cmd)
+        table.insert(cmds, ir.Cmd.NewRecord(loc, typ, dst))
         table.insert(cmds, ir.Cmd.CheckGC())
 
     elseif tag == "ast.Exp.Lambda" then

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -121,11 +121,21 @@ local function test(cmd, uninit, loop)
     elseif typedecl.match_tag(cmd._tag, "ir.Cmd") then
         for _, val in ipairs(ir.get_srcs(cmd)) do
             if val._tag == "ir.Value.LocalVar" then
+                -- `SetField` instructions can count as initializers when the target is an
+                -- upvalue box. This is because upvalue boxes are allocated, but not initialized
+                -- upon declaration.
+                if cmd._tag == "ir.Cmd.SetField" and cmd.rec_typ.is_upvalue_box then
+                    uninit[val.id] = nil
+                end
                 check_use(val.id)
             end
         end
-        for _, v_id in ipairs(ir.get_dsts(cmd)) do
-            uninit[v_id] = nil
+
+        -- Artificial initializers introduced by the compilers do not count.
+        if not cmd._is_upvalue_box_init then
+            for _, v_id in ipairs(ir.get_dsts(cmd)) do
+                uninit[v_id] = nil
+            end
         end
 
         if tag == "ir.Cmd.Return" then

--- a/pallene/uninitialized.lua
+++ b/pallene/uninitialized.lua
@@ -132,7 +132,7 @@ local function test(cmd, uninit, loop)
         end
 
         -- Artificial initializers introduced by the compilers do not count.
-        if not cmd._is_upvalue_box_init then
+        if not (cmd._tag == "ir.Cmd.NewRecord" and cmd.rec_typ.is_upvalue_box) then
             for _, v_id in ipairs(ir.get_dsts(cmd)) do
                 uninit[v_id] = nil
             end

--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -78,6 +78,20 @@ describe("Uninitialized variable analysis: ", function()
         ]], "variable 'x' is used before being initialized")
     end)
 
+    it("catches use of uninitialized upvalue", function ()
+        assert_error([[
+            local m = {}
+            function m.foo()
+                local x: integer
+                if false then x = 1 end
+                local function g()
+                    x = x + 1
+                end
+            end
+            return m
+        ]], "variable 'x' is used before being initialized")
+    end)
+
     it("assumes that loops might not execute", function()
         assert_error([[
             local m: module = {}


### PR DESCRIPTION
Hopefully fixes #480.
It's still doing very minimal dataflow analysis.
We use one extra IR annotation to communicate to `uninitialized.lua` that certain `NewRecord` instructions shouldn't count as initializers.

So cases like these should work:

```
local x: integer;
if false then  x = 1 end
local function g(): integer
	return x + 10 -- use before init, but compiles anyway
end
```