### PR TITLE
Rename pallene_log to pallene_math_log

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1465,7 +1465,7 @@ gen_cmd["BuiltinMathLog"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dsts[1])
     local v = self:c_value(cmd.srcs[1])
     local b = self:c_value(cmd.srcs[2])
-    return util.render([[ $dst = pallene_log($v, $b); ]],
+    return util.render([[ $dst = pallene_math_log($v, $b); ]],
         { dst = dst, v = v, b = b })
 end
 

--- a/vm/src/pallene_core.h
+++ b/vm/src/pallene_core.h
@@ -215,8 +215,11 @@ lua_Integer pallene_shiftR(lua_Integer x, lua_Integer y)
     }
 }
 
+/* Based on math_log from lmathlib.c
+ * The C compiler should be able to get rid of the if statement if this function is inlined
+ * and the base parameter is a compile-time constant */
 static inline
-lua_Number pallene_log(lua_Integer x, lua_Integer base)
+lua_Number pallene_math_log(lua_Integer x, lua_Integer base)
 {
     if (base == l_mathop(10.0)) {
         return l_mathop(log10)(x);


### PR DESCRIPTION
I felt that pallene_log sounded like it was a logging function, instead of a math function. Let's
make the name a bit more explicit...

Also, add a comment saying that the code is based on the one from lmathlib.c, so we know where to check the next time when we port Pallene to a future Lua version.