### PR TITLE
Conform to latest Luacheck

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,10 +19,9 @@
 -- [3] https://github.com/mpeterv/luacheck#editor-support
 
 ignore = {
-    "211/_.*",  -- Unused local variable, when name starts with "_"
-
-    "212/_.*",  -- Unused argument, when name starts with "_"
     "212/self", -- Unused argument "self"
+
+    "214/_ENV", -- Used variable "env"
 
     "411/ok",    -- Redefining local "ok"
     "411/errs?", -- Redefining local "err" or "errs"

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -835,7 +835,7 @@ end
 
 -- Converts a typechecked ast.Exp to a ir.Value. If necessary, will create a fresh variable, and add
 -- intermediate computations to the @cmds list.
-function ToIR:exp_to_value(cmds, exp, _recursive)
+function ToIR:exp_to_value(cmds, exp, is_recursive)
     local tag = exp._tag
     if     tag == "ast.Exp.Nil" then
         return ir.Value.Nil()
@@ -895,7 +895,7 @@ function ToIR:exp_to_value(cmds, exp, _recursive)
         return self:exp_to_value(cmds, exp.exp)
     end
 
-    if _recursive then
+    if is_recursive then
         -- Avoid infinite loop due to type error
         error(string.format(
             "Neither exp_to_value or exp_to_assignment handled tag %q)",

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -1599,7 +1599,7 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
         it("works on positive numbers", function()
             run_test([[
                 assert(1.0 == test.exponential_value(0.0))
-                assert(2.718 == tonumber(string.format("%.3f", 
+                assert(2.718 == tonumber(string.format("%.3f",
                     test.exponential_value(1.0))))
             ]])
         end)


### PR DESCRIPTION
Our CI started failing because some recent version of Luacheck (don't know which one) changed how it deals with unused variables. This is what I noticed:

1. By default, Luacheck now considers that a '_' prefix marks variables which are unused. We no longer need to handle this special case in our luacheckrc.
2. There is a new warning category (214) that complains about using a variable that was marked as being unused. There were two places in our code that were affected by this. The first was a variable called "_recursive", which I renamed without the underscore. The second was _ENV, which I told luacheck to ignore in the configuration file.