### PR TITLE
Remove trailing whitespace and add a lint check against it.

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1452,7 +1452,7 @@ gen_cmd["BuiltinMathCeil"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dsts[1])
     local v = self:c_value(cmd.srcs[1])
     local line = cmd.loc.line
-    return util.render([[ $dst = pallene_math_ceil(L, PALLENE_SOURCE_FILE, $line, $v); ]], { 
+    return util.render([[ $dst = pallene_math_ceil(L, PALLENE_SOURCE_FILE, $line, $v); ]], {
         dst = dst, v = v, line = C.integer(line) })
 end
 
@@ -1460,7 +1460,7 @@ gen_cmd["BuiltinMathFloor"] = function(self, cmd, _func)
     local dst = self:c_var(cmd.dsts[1])
     local v = self:c_value(cmd.srcs[1])
     local line = cmd.loc.line
-    return util.render([[ $dst = pallene_math_floor(L, PALLENE_SOURCE_FILE, $line, $v); ]], { 
+    return util.render([[ $dst = pallene_math_floor(L, PALLENE_SOURCE_FILE, $line, $v); ]], {
         dst = dst, v = v, line = C.integer(line) })
 end
 
@@ -1502,7 +1502,7 @@ gen_cmd["BuiltinMathModf"] = function(self, cmd, _func)
     local dst2 = self:c_var(cmd.dsts[2])
     local v = self:c_value(cmd.srcs[1])
     local line = cmd.loc.line
-    return util.render([[ $dst1 = pallene_math_modf(L, PALLENE_SOURCE_FILE, $line, $v, &$dst2); ]], { 
+    return util.render([[ $dst1 = pallene_math_modf(L, PALLENE_SOURCE_FILE, $line, $v, &$dst2); ]], {
         dst1 = dst1, dst2 = dst2, v = v, line = C.integer(line) })
 end
 

--- a/pallene/translator.lua
+++ b/pallene/translator.lua
@@ -101,7 +101,7 @@ function translator.translate(input, prog_ast)
     -- Whatever characters that were not included in the partials should be added.
     instance:add_previous(#input)
 
-    -- This prepends any compatibility shims we need. 
+    -- This prepends any compatibility shims we need.
     instance:prepend_compatibility_code()
 
     return table.concat(instance.partials)

--- a/run-lint
+++ b/run-lint
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+space=' '
 tab='	'
 ok=yes
 
@@ -22,11 +23,19 @@ for file in \
     examples/*/*.lua examples/*/*.pln \
     vm/src/pallene_core.c vm/src/pallene_core.h
 do
-    if grep "^$tab" "$file"; then
+    if grep --line-number "[$space$tab]$" "$file"; then
+        # Forbid trailing whitespace because some editors like to automatically delete it.
+        # Such whitespace can cause spurious diffs later down the road, when someone is working on
+        # an unrelated pull request and their editor "helpfully" deletes the trailing whitespace.
+        error "File $file has a line that ends in whitespace"
+    fi
+
+    if grep --line-number "^$tab" "$file"; then
+        # Standardize on spaces because mixing tabs and spaces is endless pain.
         error "File $file has tab-based indentation"
     fi
 
-    if ! grep --quiet 'SPDX-License-Identifier' "$file"; then
+    if ! grep --line-number --quiet 'SPDX-License-Identifier' "$file"; then
         error "File $file is missing a copyright header"
     fi
 done

--- a/vm/src/pallene_core.h
+++ b/vm/src/pallene_core.h
@@ -220,9 +220,9 @@ lua_Integer pallene_shiftR(lua_Integer x, lua_Integer y)
 }
 
 /* Some Lua math functions return integer if the result fits in integer, or float if it doesn't.
- * In Pallene, we can't return different types, so we instead raise an error if it doesn't fit 
+ * In Pallene, we can't return different types, so we instead raise an error if it doesn't fit
  * See also: pushnumint in lmathlib */
-static inline 
+static inline
 lua_Integer pallene_checked_float_to_int(lua_State *L, const char* file, int line, lua_Number d)
 {
     lua_Integer n;


### PR DESCRIPTION
Trailing whitespace in source code can be annoying because some editors (e.g. Kakoune) like to delete it by default. That can result in spurious diffs while you're working on an unrelated thing. Let's avoid this by standardizing on no trailing whitespace.