### PR TITLE
Rename SetUpvalues to InitUpvalues

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1331,7 +1331,7 @@ gen_cmd["NewClosure"] = function (self, cmd, _func)
     })
 end
 
-gen_cmd["SetUpvalues"] = function(self, cmd, _func)
+gen_cmd["InitUpvalues"] = function(self, cmd, _func)
     local func = self.module.functions[cmd.f_id]
 
     assert(cmd.src_f._tag == "ir.Value.LocalVar")

--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -160,10 +160,10 @@ local ir_cmd_constructors = {
     SetField   = {"loc", "rec_typ",        "src_rec", "field_name", "src_v"},
 
     -- Functions
-    -- note: the reason NewClosure and SetUpvalues are separate operations is so
+    -- note: the reason NewClosure and InitUpvalues are separate operations is so
     -- we can create self-referential closures, for recursion or mutual recursion.
-    NewClosure  = {"loc", "dst"  , "f_id"},
-    SetUpvalues = {"loc", "src_f", "srcs", "f_id"},
+    NewClosure   = {"loc", "dst", "f_id"},
+    InitUpvalues = {"loc", "src_f", "srcs", "f_id"},
 
     -- (dst is false if the return value is void, or unused)
     CallStatic  = {"loc", "f_typ", "dsts", "src_f", "srcs"},

--- a/pallene/print_ir.lua
+++ b/pallene/print_ir.lua
@@ -200,7 +200,7 @@ local function Cmd(cmd)
     if     tag == "ir.Cmd.SetArr"      then lhs = Bracket(cmd.src_arr, cmd.src_i)
     elseif tag == "ir.Cmd.SetTable"    then lhs = Bracket(cmd.src_tab, cmd.src_k)
     elseif tag == "ir.Cmd.SetField"    then lhs = Field(cmd.src_rec, cmd.field_name)
-    elseif tag == "ir.Cmd.SetUpvalues" then lhs = Val(cmd.src_f) .. ".upvalues"
+    elseif tag == "ir.Cmd.InitUpvalues" then lhs = Val(cmd.src_f) .. ".upvalues"
     else
         lhs = comma_concat(Vars(ir.get_dsts(cmd)))
     end
@@ -218,7 +218,7 @@ local function Cmd(cmd)
     elseif tag == "ir.Cmd.GetField"   then rhs = Field(cmd.src_rec, cmd.field_name)
     elseif tag == "ir.Cmd.SetField"   then rhs = Val(cmd.src_v)
     elseif tag == "ir.Cmd.NewClosure" then rhs = Call("NewClosure", { Fun(cmd.f_id) })
-    elseif tag == "ir.Cmd.SetUpvalues"then rhs = comma_concat(Vals(cmd.srcs))
+    elseif tag == "ir.Cmd.InitUpvalues" then rhs = comma_concat(Vals(cmd.srcs))
     elseif tag == "ir.Cmd.CallStatic" then rhs = Call(Val(cmd.src_f), Vals(cmd.srcs))
     elseif tag == "ir.Cmd.CallDyn"    then rhs = Call(Val(cmd.src_f), Vals(cmd.srcs))
     else

--- a/pallene/to_ir.lua
+++ b/pallene/to_ir.lua
@@ -715,7 +715,7 @@ function ToIR:convert_stat(cmds, stat)
                 for _, val in ipairs(captured_vars) do
                     table.insert(srcs, val)
                 end
-                table.insert(cmds, ir.Cmd.SetUpvalues(func.loc, src_f, srcs, f_id))
+                table.insert(cmds, ir.Cmd.InitUpvalues(func.loc, src_f, srcs, f_id))
             end
         end
 
@@ -997,7 +997,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             for _, upval in ipairs(captured_vars) do
                 table.insert(srcs, upval)
             end
-            table.insert(cmds, ir.Cmd.SetUpvalues(exp.loc, src_f, srcs, f_id))
+            table.insert(cmds, ir.Cmd.InitUpvalues(exp.loc, src_f, srcs, f_id))
         end
 
     elseif tag == "ast.Exp.ExtraRet" then


### PR DESCRIPTION
This makes it clearer that this operation is only used to initialize the closure, and that upvalues should not be modified afterwards. Closes #515.