### PR TITLE
Don't forget to update f_id_of_upvalue

### DIFF
--- a/pallene/ir.lua
+++ b/pallene/ir.lua
@@ -52,8 +52,8 @@ function ir.Function(loc, name, typ)
         typ = typ,            -- Type
         vars = {},            -- list of ir.VarDecl
         captured_vars = {},   -- list of ir.VarDecl
-        f_id_of_upvalue = {}, -- { integer => integer }
-        f_id_of_local = {},   -- { integer => integer }
+        f_id_of_upvalue = {}, -- { u_id => integer }
+        f_id_of_local = {},   -- { v_id => integer }
         body = false,         -- ir.Cmd
     }
 end

--- a/pallenec
+++ b/pallenec
@@ -115,7 +115,7 @@ local function pretty_print_ir(filename)
     local input, err = driver.load_input(filename)
     if not input then util.abort(err) end
 
-    local module, errs = driver.compile_internal(filename, input, "ir")
+    local module, errs = driver.compile_internal(filename, input, "optimize", opt_level)
     if not module then util.abort(table.concat(errs, "\n")) end
 
     io.stdout:write(print_ir(module))

--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -2277,6 +2277,27 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
         end)
     end)
 
+    -- https://github.com/pallene-lang/pallene/issues/508
+    describe("Issue 508:", function()
+        compile([[
+            local N = 42
+
+            function m.f()
+            end
+
+            function m.g(): integer
+                local x = N
+                m.f()
+                return x
+            end
+        ]])
+        it("Constant propagation correctly renumbers the upvalues", function()
+            run_test([[
+                assert(42 == test.g())
+            ]])
+        end)
+    end)
+
     describe("Uninitialized variables", function()
         compile([[
             function m.sign(x: integer): integer


### PR DESCRIPTION
Fixes #508. In the long term, we should look for ways to get rid of the f_id_of_upvalue altogether. If we had an analysis pass that computed it, we wouldn't need to maintain and update it across other compilation passes.

@ewmailing, could you please check if this fixes the bug on your end? Sorry it took so long, and thanks again for reporting it!