### PR TITLE
Luacheck 0.26.1 no longer needs the _ENV workaround

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,8 +21,6 @@
 ignore = {
     "212/self", -- Unused argument "self"
 
-    "214/_ENV", -- Used variable "env"
-
     "411/ok",    -- Redefining local "ok"
     "411/errs?", -- Redefining local "err" or "errs"
 


### PR DESCRIPTION
Remove the _ENV workaround from #518. This was a related to a Luacheck bug that only existed in Luacheck 0.26.0 and was fixed in 0.26.1, after we reported it.