### PR TITLE
Use l_likely, l_noret

### DIFF
--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -242,7 +242,7 @@ function Coder:get_stack_slot(typ, dst, slot, loc, description_fmt, ...)
         assert(not typ.is_upvalue_box)
         local extra_args = table.pack(...)
         check_tag = util.render([[
-            if (PALLENE_UNLIKELY(!$test)) {
+            if (l_unlikely(!$test)) {
                 pallene_runtime_tag_check_error(L,
                     $file, $line, $expected_tag, rawtt($slot),
                     ${description_fmt}${opt_comma}${extra_args});
@@ -556,7 +556,7 @@ function Coder:lua_entry_point_definition(f_id)
 
     local arity_check = util.render([[
         int nargs = lua_gettop(L);
-        if (PALLENE_UNLIKELY(nargs != $nargs)) {
+        if (l_unlikely(nargs != $nargs)) {
             pallene_runtime_arity_error(L, $fname, $nargs, nargs);
         }
     ]], {
@@ -1237,7 +1237,7 @@ gen_cmd["SetTable"] = function(self, cmd, _func)
             TValue keyv; ${init_keyv}
             static int cache = -1;
             TValue *slot = pallene_getstr($field_len, $tab, $key, &cache);
-            if (PALLENE_UNLIKELY(isabstkey(slot))) {
+            if (l_unlikely(isabstkey(slot))) {
                 TValue valv; ${init_valv}
                 luaH_newkey(L, $tab, &keyv, &valv);
             } else {

--- a/vm/src/pallene_core.c
+++ b/vm/src/pallene_core.c
@@ -21,6 +21,8 @@
 #include <stdarg.h>
 #include <locale.h>
 
+#define PALLENE_UNREACHABLE __builtin_unreachable()
+
 const char *pallene_tag_name(int raw_tag)
 {
     if (raw_tag == LUA_VNUMINT) {
@@ -129,7 +131,7 @@ TString *pallene_string_concatN(lua_State *L, size_t n, TString **ss)
     size_t out_len = 0;
     for (size_t i = 0; i < n; i++) {
         size_t l = tsslen(ss[i]);
-        if (PALLENE_UNLIKELY(l >= (MAX_SIZE/sizeof(char)) - out_len)) {
+        if (l_unlikely(l >= (MAX_SIZE/sizeof(char)) - out_len)) {
             luaL_error(L, "string length overflow");
         }
         out_len += l;

--- a/vm/src/pallene_core.h
+++ b/vm/src/pallene_core.h
@@ -29,38 +29,26 @@
 
 #include <math.h>
 
-#define PALLENE_NORETURN __attribute__((noreturn))
-#define PALLENE_UNREACHABLE __builtin_unreachable()
-
-#define PALLENE_LIKELY(x)   __builtin_expect(!!(x), 1)
-#define PALLENE_UNLIKELY(x) __builtin_expect(!!(x), 0)
-
 const char *pallene_tag_name(int raw_tag);
 
-void pallene_runtime_tag_check_error(
+l_noret pallene_runtime_tag_check_error(
     lua_State *L, const char* file, int line, int expected_tag, int received_tag,
-    const char *description_fmt, ...)
-    PALLENE_NORETURN;
+    const char *description_fmt, ...);
 
-void pallene_runtime_arity_error(
-    lua_State *L, const char *name, int expected, int received)
-    PALLENE_NORETURN;
+l_noret pallene_runtime_arity_error(
+    lua_State *L, const char *name, int expected, int received);
 
-void pallene_runtime_divide_by_zero_error(
-    lua_State *L, const char* file, int line)
-    PALLENE_NORETURN;
+l_noret pallene_runtime_divide_by_zero_error(
+    lua_State *L, const char* file, int line);
 
-void pallene_runtime_mod_by_zero_error(
-    lua_State *L, const char* file, int line)
-    PALLENE_NORETURN;
+l_noret pallene_runtime_mod_by_zero_error(
+    lua_State *L, const char* file, int line);
 
-void pallene_runtime_number_to_integer_error(
-    lua_State *L, const char* file, int line)
-    PALLENE_NORETURN;
+l_noret pallene_runtime_number_to_integer_error(
+    lua_State *L, const char* file, int line);
 
-void pallene_runtime_array_metatable_error(
-    lua_State *L, const char* file, int line)
-    PALLENE_NORETURN;
+l_noret pallene_runtime_array_metatable_error(
+    lua_State *L, const char* file, int line);
 
 TString *pallene_string_concatN(
     lua_State *L, size_t n, TString **ss);
@@ -195,7 +183,7 @@ lua_Integer pallene_int_modi(
 static inline
 lua_Integer pallene_shiftL(lua_Integer x, lua_Integer y)
 {
-    if (PALLENE_LIKELY(l_castS2U(y) < PALLENE_NBITS)) {
+    if (l_likely(l_castS2U(y) < PALLENE_NBITS)) {
         return intop(<<, x, y);
     } else {
         if (l_castS2U(-y) < PALLENE_NBITS) {
@@ -208,7 +196,7 @@ lua_Integer pallene_shiftL(lua_Integer x, lua_Integer y)
 static inline
 lua_Integer pallene_shiftR(lua_Integer x, lua_Integer y)
 {
-    if (PALLENE_LIKELY(l_castS2U(y) < PALLENE_NBITS)) {
+    if (l_likely(l_castS2U(y) < PALLENE_NBITS)) {
         return intop(>>, x, y);
     } else {
         if (l_castS2U(-y) < PALLENE_NBITS) {
@@ -297,7 +285,7 @@ void pallene_renormalize_array(
     int line
 ){
     lua_Unsigned ui = (lua_Unsigned) i - 1;
-    if (PALLENE_UNLIKELY(ui >= arr->alimit)) {
+    if (l_unlikely(ui >= arr->alimit)) {
         pallene_grow_array(L, file, line, arr, ui);
     }
 }


### PR DESCRIPTION
We no longer need to define our own version of these macros. Fixes #525.