### PR TITLE
git-sync: Use "git branch -d" to delete branches

### DIFF
--- a/misc/git-sync
+++ b/misc/git-sync
@@ -38,28 +38,29 @@ end
 set old_branch (git branch --show-current)
 git switch --detach --quiet
 
-git for-each-ref refs/heads --format="%(refname):%(upstream):%(upstream:remotename)" |
-while read -d':' localref upstream remote
+git for-each-ref refs/heads --format="%(refname)|%(refname:short)|%(upstream)|%(upstream:remotename)" |
+while read -d'|' localref branch upstream remote
     # Is this branch tracking an upstream branch?
-    if [ -z "$upstream" ]; continue; end
+    if [ -z "$upstream" ]
+        continue
+    end
 
+    printf "LOCALREF %s\n" $branch
     # Does said upstream branch still exist?
     if rev-exists $upstream
         if is-ancestor $localref $upstream
             # Fast forward the local branch
             git fetch . $upstream:$localref
-
         else if is-ancestor $upstream $localref
             # Upload the local changes
             git push $remote $localref
-
         else
             echo "It looks like someone rebased $localref or $upstream."
         end
     else
         # Maybe this PR has been merged?
         if is-ancestor $localref $remote/HEAD
-            git update-ref -d $localref
+            git branch -d $branch
         end
     end
 end


### PR DESCRIPTION
This patch fixes a bug with our git-sync script, which caused it to fail to properly dispose of the deleted branches. **If you were using this script, you must clone fresh copy of the repository from Github,** in order to get rid of the garbage branch data that has accumulated in your local copy.

The problem was that we used "git update-ref -d" to delete the local branches. That deleted the local branch but did not delete the tracking information between the local branch and the local branch (that one that you set using "git push -u"). The result is that over time the .gitconfig accumulates this tracking info that never gets deleted. I noticed it for the first time when I tried to create a new branch with a name that had previously been used in a since-deleted branch. I got the following error message:

    Your branch is based on 'origin/lua-core', but the upstream is gone.