### PR TITLE
git-sync: support squash or rebase workflows

### DIFF
--- a/misc/git-sync
+++ b/misc/git-sync
@@ -38,29 +38,31 @@ end
 set old_branch (git branch --show-current)
 git switch --detach --quiet
 
-git for-each-ref refs/heads --format="%(refname)|%(refname:short)|%(upstream)|%(upstream:remotename)" |
-while read -d'|' localref branch upstream remote
+git for-each-ref refs/heads --format="%(refname)|%(refname:short)|%(upstream)|%(upstream:short)|%(upstream:remotename)" |
+while read -d'|' localref branch upstreamref upstream remote
     # Is this branch tracking an upstream branch?
-    if [ -z "$upstream" ]
+    if [ -z "$upstreamref" ]
         continue
     end
 
-    printf "LOCALREF %s\n" $branch
     # Does said upstream branch still exist?
-    if rev-exists $upstream
-        if is-ancestor $localref $upstream
+    if rev-exists $upstreamref
+        if is-ancestor $localref $upstreamref
             # Fast forward the local branch
-            git fetch . $upstream:$localref
-        else if is-ancestor $upstream $localref
+            git fetch . $upstreamref:$localref
+        else if is-ancestor $upstreamref $localref
             # Upload the local changes
             git push $remote $localref
         else
-            echo "It looks like someone rebased $localref or $upstream."
+            echo "It looks like someone rebased $branch or $upstream."
         end
     else
-        # Maybe this PR has been merged?
         if is-ancestor $localref $remote/HEAD
+            # PR was merged, it is safe to automatically delete the branch.
             git branch -d $branch
+        else
+            # PR was squashed or rebased. The algorithm isn't sure if we should delete.
+            echo "You might want to delete $branch, because $upstream was deleted."
         end
     end
 end


### PR DESCRIPTION
This week I decided to start squashing PRs that have a single commit. This results in prettier history than a --no-ff merge commit for a single commit... The end result of this single-commit squash is similar to rebase, except that github adds the PR number to the title the squashed commit.

To support this new workflow, I'm updating the git-sync script. We can't automatically delete the local copy of the branch that was squashed, because it would require a risky `git branch --delete --force`. But we can print a message to promt the user to delete it manually.

Also, this removes a debugging print statement that I had left by accident in the previous commit. Oops!