### PR TITLE
Check that the installed Lua version is the correct one.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
         branches: [ master ]
 
 env:
-    LUA_VERSION: 5.4.4
+    LUA_VERSION: 5.4.4-2
     LUAROCKS_VERSION: 3.9.0
 
 jobs:

--- a/pallene/coder.lua
+++ b/pallene/coder.lua
@@ -1800,10 +1800,22 @@ function Coder:generate_luaopen_function()
         init_function = self:lua_entry_point_name(1),
     })
 
+    -- NOTE: Version compatibility
+    -- ---------------------------
+    -- We have both a compile-time and a run-time test. The compile-time test ensures that the
+    -- version of Lua is exactly the one that this version of Pallene supports. The run-time test
+    -- checks that the Lua version didn't change behind our backs, after the Pallene module was
+    -- compiled. For example, if you update the Lua library but don't recompile the Pallene module.
+
     return (util.render([[
         int ${name}(lua_State *L)
         {
-            luaL_checkversion(L);
+
+            #if LUA_VERSION_RELEASE_NUM != 50404
+            #error "Lua version must be exactly 5.4.4"
+            #endif
+
+            luaL_checkcoreversion(L);
 
             /**/
             /* Constants */

--- a/pallene/pallenelib.lua
+++ b/pallene/pallenelib.lua
@@ -35,6 +35,7 @@
 
 return [==[
 #define LUA_CORE
+#include <lua.h>
 #include <lauxlib.h>
 #include <luacore.h>
 


### PR DESCRIPTION
This adds a compile-time check to see that the installed version of Lua matches the one that is supported by the current version of Pallene. It also adds a run-time check that raises an error in case you update your Lua but do not recompile your Pallene module. Fixes #18.

ATTENTION: I had to add a luaL_checkcoreversion function to the lua-internals. This means that you must update your lua-internals.