### PR TITLE
Oops. Fix a bug where --print-ir was unusable

### DIFF
--- a/pallenec
+++ b/pallenec
@@ -60,7 +60,7 @@ local function compile_up_to(stop_after)
     return out
 end
 
-local function print_ir()
+local function do_print_ir()
     local module = compile_up_to("optimize")
     io.stdout:write(print_ir(module))
 end
@@ -68,6 +68,6 @@ end
 if     args.emit_c      then compile("pln", "c")
 elseif args.emit_lua    then compile("pln", "lua")
 elseif args.compile_c   then compile("c" ,  "so")
-elseif args.dump_ir     then print_ir()
+elseif args.print_ir    then do_print_ir()
 else --[[default]]           compile("pln", "so")
 end

--- a/spec/print_ir_spec.lua
+++ b/spec/print_ir_spec.lua
@@ -9,8 +9,9 @@ local execution_tests = require "spec.execution_tests"
 local function compile(filename, pallene_code)
     assert(util.set_file_contents(filename, pallene_code))
     local cmd = string.format("./pallenec --print-ir %s", util.shell_quote(filename))
-    local ok, _, _, errmsg = util.outputs_of_execute(cmd)
+    local ok, _, result, errmsg = util.outputs_of_execute(cmd)
     assert(ok, errmsg)
+    assert(string.match(result, 'function main'))
 end
 
 describe("#pretty_printer /", function ()


### PR DESCRIPTION
This fixes an embarassing bug from #536. Instead of printing the IR, it would compile the Pallene file, as if you had called pallenec with no command line flags. Unfortunately, the unit tests didn't catch this because we were only looking at the exit code and not whether it was generating correct IR output.

I still don't think that the test suite should look at the entire IR, because that changes often and would break the tests all the time.
However, looking for the "function main" that is always there at least ensures that the output isn't completely empty, which is what was happening here.