### PR TITLE
For C flags, only use CFLAGS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,22 +88,15 @@ It is possible to change the compiler optimization level, for the Pallene compil
 Here are some examples:
 
 ```sh
-# execute no optimization (Pallene and C compiler)
+# disable Pallene optimization passes
 pallenec test.pln -O0
 
-# execute Pallene compiler optimizations and C compiler level 3 optimizations
-pallenec test.pln -O3
-
-# execute no optimizations for Pallene compiler but executes C compiler level 2 optimizations
-env CFLAGS="-O2" pallenec test.pln -O0
-
-# execute all default optimizations (same as -O2)
+# disable C compiler optimization
+export CFLAGS='-O0'
 pallenec test.pln
 ```
 
-**Note**: For the C compiler only, the setting set using `CFLAGS` overrides the setting set by flag `-O`.
-
-For more compiler options, see `pallenec --help`
+For more compiler options, see `./pallenec --help`
 
 ## Developing Pallene
 

--- a/run-tests
+++ b/run-tests
@@ -17,9 +17,9 @@ echo "--- Test Suite ---"
 # need to press Ctrl-C once and busted usually gets to exit gracefully.
 FLAGS=(--verbose --no-keep-going)
 
-# To speed things up, we tell the C compiler to skip optimizations.
-# Don't worry, the continuous integration server still tests with optimizations.
-export CFLAGS=-O0
+# To speed things up, we tell the C compiler to skip optimizations. (It's OK, the CI still uses -O2)
+# Also, add some compiler flags to verify standard compliance.
+export CFLAGS='-O0 -std=c99 -Wall -Werror -Wundef -Wpedantic -Wno-unused'
 
 if [ "$#" -eq 0 ]; then
     if command -v parallel >/dev/null; then

--- a/src/pallene/c_compiler.lua
+++ b/src/pallene/c_compiler.lua
@@ -18,7 +18,7 @@ local c_compiler = {}
 
 local CC = "cc"
 local CPPFLAGS = ""
-local CFLAGS_BASE = "-std=c99 -g -fPIC"
+local CFLAGS_BASE = "-std=c99 -g -fPIC -O2"
 local CFLAGS_WARN = "-Wall -Wundef -Wpedantic -Wno-unused"
 local USER_CFlAGS = os.getenv("CFLAGS") or ""
 
@@ -47,13 +47,11 @@ local function run_cc(args)
     return true, {}
 end
 
--- The third argument is the mod_name, which is not used by this
-function c_compiler.compile_c_to_o(in_filename, out_filename, _, opt_level)
+function c_compiler.compile_c_to_o(in_filename, out_filename)
     return run_cc({
         CPPFLAGS,
         CFLAGS_BASE,
         CFLAGS_WARN,
-        opt_level and "-O"..opt_level or "",
         USER_CFlAGS,
         "-x c",
         "-o", util.shell_quote(out_filename),

--- a/src/pallene/c_compiler.lua
+++ b/src/pallene/c_compiler.lua
@@ -16,11 +16,8 @@ local util = require "pallene.util"
 
 local c_compiler = {}
 
-local CC = "cc"
-local CPPFLAGS = ""
-local CFLAGS_BASE = "-std=c99 -g -fPIC -O2"
-local CFLAGS_WARN = "-Wall -Wundef -Wpedantic -Wno-unused"
-local USER_CFlAGS = os.getenv("CFLAGS") or ""
+local CC       = os.getenv("CC")       or "cc"
+local CFLAGS   = os.getenv("CFLAGS")   or "-O2"
 
 local function get_uname()
     local ok, err, uname = util.outputs_of_execute("uname -s")
@@ -49,10 +46,8 @@ end
 
 function c_compiler.compile_c_to_o(in_filename, out_filename)
     return run_cc({
-        CPPFLAGS,
-        CFLAGS_BASE,
-        CFLAGS_WARN,
-        USER_CFlAGS,
+        "-fPIC",
+        CFLAGS,
         "-x c",
         "-o", util.shell_quote(out_filename),
         "-c", util.shell_quote(in_filename),


### PR DESCRIPTION
To address #516, I'm planning to use Luarocks as a compilation backend. If we set things up the right way, we should be able to use Luarocks to compile our `c` files into shared libraries, in a cross-platform manner.

This PR has some CFLAGS-related changes to pave the way for that. When using Luarocks to build C modules, the only way to pass CFLAGS is via the CFLAGS environment variable. So what this commit does is take the flags we were passing directly in the c_compiler.lua and passing them via CFLAGS environment variable instead. This implies in a change in behavior. By default we will no longer compile with -g and -Wall. IMO, that might actually be a good thing. The -g causes larger executables and the -Wall is not relevant to end-users. (I'm still leaving the -Wall in the ./run-tests though)