### PR TITLE
Avoid gcc warning for math.mininteger literals

### DIFF
--- a/src/pallene/C.lua
+++ b/src/pallene/C.lua
@@ -37,7 +37,7 @@ function C.string(s)
 end
 
 function C.integer(n)
-    return string.format("%i", n)
+    return string.format("%d", n)
 end
 
 function C.boolean(b)

--- a/src/pallene/C.lua
+++ b/src/pallene/C.lua
@@ -37,7 +37,16 @@ function C.string(s)
 end
 
 function C.integer(n)
-    return string.format("%d", n)
+    -- We must special case the MIN_INTEGER, otherwise gcc -Wall will complain about the C constant
+    -- literal being so large that it becomes unsigned. The issue is that -9223372036854775808 is
+    -- parsed as the unary negation of a positive integer literal which is too big to for int64_t.
+    if n == math.maxinteger then
+        return "LUA_MAXINTEGER"
+    elseif n == math.mininteger then
+        return "LUA_MININTEGER"
+    else
+        return string.format("%d", n)
+    end
 end
 
 function C.boolean(b)


### PR DESCRIPTION
Running the test suite under -Wall -Werror would choke on programs with -9223372036854775808 as an integer literal. GCC warns that the "integer constant is so large that it is unsigned". I am not sure what version of GCC added this warning and/or enabled it in -Wall, but it happens for me on GCC 12.1.1.

The fix is to represent these things using the appropriate C macros, similarly to how we handle HUGE_VAL for floating point numbers.