### PR TITLE
Remove obsolete .syntastic config file

### DIFF
--- a/.syntastic_c_config
+++ b/.syntastic_c_config
@@ -1,2 +1,0 @@
--I./lua/src/
--I./runtime


### PR DESCRIPTION
It referred to the directories for the custom Lua and for the Pallene library. These no longer exist now that the custom Lua is on a separate repository.