### PR TITLE
More flexible consistency rule

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -757,28 +757,6 @@ describe("Binary operator", function()
 
 end)
 
-describe("Cast operator", function()
-
-    local function test(typ1, typ2, expected_error)
-        local description = string.format(
-            "'as' cannot convert incompatible types (%s, %s)", typ1, typ2)
-
-        local code = util.render([[
-            function m.fn(x: $typ1)
-                local _ = x as $typ2
-            end
-        ]], { typ1 = typ1, typ2 = typ2 })
-
-        it(description, function()
-            assert_error(code, expected_error)
-        end)
-    end
-
-    test("boolean", "float",     "in cast expression")
-    test("nil",     "string",    "in cast expression")
-    test("{float}", "{integer}", "in cast expression")
-end)
-
 describe("Function call", function()
 
     it("must be a function (non-any)", function()

--- a/spec/types_spec.lua
+++ b/spec/types_spec.lua
@@ -122,50 +122,44 @@ describe("Pallene types", function()
     end)
 
     describe("consistency", function()
-        it("it always true for value", function()
+        it("allows 'any' on either side", function()
             assert.truthy(types.consistent(types.T.Any(), types.T.Any()))
             assert.truthy(types.consistent(types.T.Any(), types.T.Integer()))
             assert.truthy(types.consistent(types.T.Integer(), types.T.Any()))
         end)
 
-        it("works for arrays", function()
-            local t1 = types.T.Array(types.T.Any())
-            local t2 = types.T.Array(types.T.Integer())
-            local t3 = types.T.Array(types.T.Array(types.T.Integer))
-            assert.truthy(types.consistent(t1, t2))
-            assert.truthy(types.consistent(t1, t3))
-            assert.falsy(types.consistent(t2, t3))
+        it("allows types with same tag", function()
+            assert.truthy(types.consistent(
+                types.T.Integer(),
+                types.T.Integer()
+            ))
+
+            assert.truthy(types.consistent(
+                types.T.Array(types.T.Integer()),
+                types.T.Array(types.T.Integer())
+            ))
+
+            assert.truthy(types.consistent(
+                types.T.Array(types.T.Integer()),
+                types.T.Array(types.T.String())
+            ))
+
+            assert.truthy(types.consistent(
+                types.T.Function({types.T.Integer()}, {types.T.Integer()}),
+                types.T.Function({types.T.String(), types.T.String()}, {})
+            ))
         end)
 
-        it("works for tables", function()
-            local t1 = types.T.Table({x = types.T.Any()})
-            local t2 = types.T.Table({x = types.T.Integer()})
-            local t3 = types.T.Table({x = types.T.Array(types.T.Integer)})
-            assert.truthy(types.consistent(t1, t2))
-            assert.truthy(types.consistent(t1, t3))
-            assert.falsy(types.consistent(t2, t3))
-        end)
+        it("forbids different tags", function()
+            assert.falsy(types.consistent(
+                types.T.Integer(),
+                types.T.String()
+            ))
 
-        it("works for arrays", function()
-            local t1 = types.T.Array(types.T.Any())
-            local t2 = types.T.Array(types.T.Integer())
-            local t3 = types.T.Array(types.T.Array(types.T.Integer))
-            assert.truthy(types.consistent(t1, t2))
-            assert.truthy(types.consistent(t1, t3))
-            assert.falsy(types.consistent(t2, t3))
-        end)
-
-
-        it("works for functions with same arity", function()
-            local v = types.T.Any()
-            local i = types.T.Integer()
-            local s = types.T.String()
-            local f1 = types.T.Function({v, v}, {v})
-            local f2 = types.T.Function({i, i}, {i})
-            local f3 = types.T.Function({s, s}, {s})
-            assert.truthy(types.consistent(f1, f2))
-            assert.truthy(types.consistent(f1, f3))
-            assert.falsy(types.consistent(f2, f3))
+            assert.falsy(types.consistent(
+                types.T.Array(types.T.Integer()),
+                types.T.Function({types.T.Integer()},{types.T.Integer()})
+            ))
         end)
     end)
 end)


### PR DESCRIPTION
This commit loosens the type consistency restriction for type casts. Previously we used the rule from Gradual Typing, which required that both types be equal up to 'any'. In the new rule we only check if the type tag matches. Casting to and from "any" is still allowed. Furthermore, the new rule also allows casts from one array type to another, even if the array contents are different. We also between any pair of function type no matter the type of argument or arity.

The motivation for the new rule is that Pallene type checks only check the type tag anyway. The type casts that used to be forbidden but are now allowed are type casts that theoretically might run without error at runtime. Now we only forbid type casts that are guaranteed to fail, such as int=>string or array=>function.