### PR TITLE
Manual: sum_list example: remove unnecessary “do”

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -167,7 +167,7 @@ Pallene's `for-in` loops carry some semantic importance that might be of relevan
 An example of such a loop might look like this:
 
 ```lua
-local function sum_list(xs: {integer}) do
+local function sum_list(xs: {integer})
     local sum: integer = 0
     for _, x: integer in ipairs(xs) do
         sum = sum + x


### PR DESCRIPTION
In manual, sum_list function has an extra do. If I’m not mistaken, this is an error in the documentation, because this example isn’t grammatically correct and doesn’t compile.

This tweak fixes that