### PR TITLE
Tagged union quality of life + cleanup

### DIFF
--- a/spec/tagged_union_spec.lua
+++ b/spec/tagged_union_spec.lua
@@ -3,13 +3,13 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 
 describe("Typedecl", function()
 
     setup(function()
         local foo = {}
-        typedecl.declare(foo, "foo", "Bar", {
+        tagged_union.declare(foo, "foo", "Bar", {
             ABC = {"a", "b", "c"},
             DEF = {"d", "e", "f"},
         })
@@ -18,24 +18,24 @@ describe("Typedecl", function()
     it("forbids repeated tags", function()
         assert.has_error(function()
             local mod = {}
-            typedecl.declare(mod, "TESTTYPE", "Foo", { Bar = {"x"} })
-            typedecl.declare(mod, "TESTTYPE", "Foo", { Bar = {"x"} })
+            tagged_union.declare(mod, "TESTTYPE", "Foo", { Bar = {"x"} })
+            tagged_union.declare(mod, "TESTTYPE", "Foo", { Bar = {"x"} })
         end, [[tag name "TESTTYPE.Foo.Bar" is already being used]])
     end)
 
     it("typeof works for declared type", function ()
-        assert.equals("foo.Bar", typedecl.typename("foo.Bar.ABC"))
+        assert.equals("foo.Bar", tagged_union.typename("foo.Bar.ABC"))
     end)
 
     it("typeof rejects undeclared types", function ()
-        assert.equals(nil,  typedecl.typename("foo.Bar.LMN"))
+        assert.equals(nil,  tagged_union.typename("foo.Bar.LMN"))
     end)
 
     it("consname works for declared type", function ()
-        assert.equals("ABC", typedecl.consname("foo.Bar.ABC"))
+        assert.equals("ABC", tagged_union.consname("foo.Bar.ABC"))
     end)
 
     it("consname rejects undeclared type", function ()
-        assert.equals(nil, typedecl.consname("foo.Bar.LMN"))
+        assert.equals(nil, tagged_union.consname("foo.Bar.LMN"))
     end)
 end)

--- a/spec/tagged_union_spec.lua
+++ b/spec/tagged_union_spec.lua
@@ -3,13 +3,14 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
+local mod = {}
 local tagged_union = require "pallene.tagged_union"
+local define_union = tagged_union.in_namespace(mod, "TagUnionTest")
 
 describe("Typedecl", function()
 
     setup(function()
-        local foo = {}
-        tagged_union.declare(foo, "foo", "Bar", {
+        define_union("Bar", {
             ABC = {"a", "b", "c"},
             DEF = {"d", "e", "f"},
         })
@@ -17,25 +18,24 @@ describe("Typedecl", function()
 
     it("forbids repeated tags", function()
         assert.has_error(function()
-            local mod = {}
-            tagged_union.declare(mod, "TESTTYPE", "Foo", { Bar = {"x"} })
-            tagged_union.declare(mod, "TESTTYPE", "Foo", { Bar = {"x"} })
-        end, [[tag name "TESTTYPE.Foo.Bar" is already being used]])
+            define_union("Foo", { Bar = {"x"} })
+            define_union("Foo", { Bar = {"x"} })
+        end, [[tag name "TagUnionTest.Foo.Bar" is already being used]])
     end)
 
     it("typeof works for declared type", function ()
-        assert.equals("foo.Bar", tagged_union.typename("foo.Bar.ABC"))
+        assert.equals("TagUnionTest.Bar", tagged_union.typename("TagUnionTest.Bar.ABC"))
     end)
 
     it("typeof rejects undeclared types", function ()
-        assert.equals(nil,  tagged_union.typename("foo.Bar.LMN"))
+        assert.equals(nil,  tagged_union.typename("TagUnionTest.Bar.LMN"))
     end)
 
     it("consname works for declared type", function ()
-        assert.equals("ABC", tagged_union.consname("foo.Bar.ABC"))
+        assert.equals("ABC", tagged_union.consname("TagUnionTest.Bar.ABC"))
     end)
 
     it("consname rejects undeclared type", function ()
-        assert.equals(nil, tagged_union.consname("foo.Bar.LMN"))
+        assert.equals(nil, tagged_union.consname("TagUnionTest.Bar.LMN"))
     end)
 end)

--- a/src/pallene/assignment_conversion.lua
+++ b/src/pallene/assignment_conversion.lua
@@ -390,7 +390,7 @@ function Converter:visit_stat(stat)
     elseif  tag == "ast.Stat.Break" then
         -- empty
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -462,7 +462,7 @@ function Converter:visit_exp(exp)
         self:visit_exp(exp.rhs)
 
     elseif tagged_union.typename(tag) ~= "ast.Exp" then
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 

--- a/src/pallene/assignment_conversion.lua
+++ b/src/pallene/assignment_conversion.lua
@@ -39,7 +39,7 @@
 -- ```
 
 local util     = require "pallene.util"
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 local types    = require "pallene.types"
 local ast      = require "pallene.ast"
 local typechecker = require "pallene.typechecker"
@@ -129,7 +129,7 @@ function Converter:visit_prog(prog_ast)
             end
         else
             -- skip record declarations and type aliases
-            assert(typedecl.typename(tl_node._tag) == "ast.Toplevel")
+            assert(tagged_union.typename(tl_node._tag) == "ast.Toplevel")
         end
     end
 end
@@ -390,7 +390,7 @@ function Converter:visit_stat(stat)
     elseif  tag == "ast.Stat.Break" then
         -- empty
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 end
 
@@ -461,8 +461,8 @@ function Converter:visit_exp(exp)
         self:visit_exp(exp.lhs)
         self:visit_exp(exp.rhs)
 
-    elseif typedecl.typename(tag) ~= "ast.Exp" then
-        typedecl.tag_error(tag)
+    elseif tagged_union.typename(tag) ~= "ast.Exp" then
+        tagged_union.tag_error(tag)
     end
 end
 

--- a/src/pallene/ast.lua
+++ b/src/pallene/ast.lua
@@ -3,12 +3,12 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 
 local ast = {}
 
 local function declare_type(type_name, cons)
-    typedecl.declare(ast, "ast", type_name, cons)
+    tagged_union.declare(ast, "ast", type_name, cons)
 end
 
 declare_type("Program", {

--- a/src/pallene/ast.lua
+++ b/src/pallene/ast.lua
@@ -3,19 +3,16 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-local tagged_union = require "pallene.tagged_union"
-
 local ast = {}
 
-local function declare_type(type_name, cons)
-    tagged_union.declare(ast, "ast", type_name, cons)
-end
+local tagged_union = require "pallene.tagged_union"
+local define_union = tagged_union.in_namespace(ast, "ast")
 
-declare_type("Program", {
+define_union("Program", {
     Program = {"loc", "ret_loc", "module_name", "tls", "type_regions", "comment_regions"}
 })
 
-declare_type("Type", {
+define_union("Type", {
     Nil      = {"loc"},
     Name     = {"loc", "name"},
     Array    = {"loc", "subtype"},
@@ -23,17 +20,17 @@ declare_type("Type", {
     Function = {"loc", "arg_types", "ret_types"},
 })
 
-declare_type("Toplevel", {
+define_union("Toplevel", {
     Stats     = {"loc", "stats"},
     Typealias = {"loc", "name", "type",},
     Record    = {"loc", "name", "field_decls"},
 })
 
-declare_type("Decl", {
+define_union("Decl", {
     Decl = {"loc", "name", "type"},
 })
 
-declare_type("Stat", {
+define_union("Stat", {
     Block     = {"loc", "stats"},
     While     = {"loc", "condition", "block"},
     Repeat    = {"loc", "block", "condition"},
@@ -48,18 +45,18 @@ declare_type("Stat", {
     Functions = {"loc", "declared_names", "funcs"}, -- For mutual recursion (see parser.lua)
 })
 
-declare_type("FuncStat", {
+define_union("FuncStat", {
     FuncStat = {"loc", "module", "name", "method", "ret_types", "value"},
 })
 
 -- Things that can appear in the LHS of an assignment. For example: x, x[i], x.name
-declare_type("Var", {
+define_union("Var", {
     Name    = {"loc", "name"},
     Bracket = {"loc", "t", "k"},
     Dot     = {"loc", "exp", "name"}
 })
 
-declare_type("Exp", {
+define_union("Exp", {
     Nil           = {"loc"},
     Bool          = {"loc", "value"},
     Integer       = {"loc", "value"},
@@ -79,7 +76,7 @@ declare_type("Exp", {
     UpvalueRecord = {"loc"},                  -- Inserted by assignment_conversion.lua
 })
 
-declare_type("Field", {
+define_union("Field", {
     List = {"loc", "exp"},
     Rec  = {"loc", "name", "exp"},
 })

--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -13,7 +13,7 @@ local gc = require "pallene.gc"
 local ir = require "pallene.ir"
 local pallenelib = require "pallene.pallenelib"
 local types = require "pallene.types"
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 local util = require "pallene.util"
 
 local coder = {}
@@ -45,7 +45,7 @@ local function ctype(typ)
     elseif tag == "types.T.Table"    then return "Table *"
     elseif tag == "types.T.Record"   then return "Udata *"
     elseif tag == "types.T.Any"      then return "TValue"
-    else   typedecl.tag_error(tag)
+    else   tagged_union.tag_error(tag)
     end
 end
 
@@ -96,7 +96,7 @@ local function lua_value(typ, src_slot)
     elseif tag == "types.T.Table"    then tmpl = "hvalue($src)"
     elseif tag == "types.T.Record"   then tmpl = "uvalue($src)"
     elseif tag == "types.T.Any"      then tmpl = "*($src)"
-    else typedecl.tag_error(tag)
+    else tagged_union.tag_error(tag)
     end
 
     local res = util.render(tmpl, {src = src_slot})
@@ -126,7 +126,7 @@ local function set_stack_slot(typ, dst_slot, value)
     elseif tag == "types.T.Table"    then tmpl = "sethvalue(L, $dst, $src);"
     elseif tag == "types.T.Record"   then tmpl = "setuvalue(L, $dst, $src);"
     elseif tag == "types.T.Any"      then tmpl = "setobj(L, $dst, &$src);"
-    else typedecl.tag_error(tag)
+    else tagged_union.tag_error(tag)
     end
 
     return (util.render(tmpl, { dst = dst_slot, src = value }))
@@ -179,8 +179,8 @@ local function pallene_type_tag(typ)
     elseif tag == "types.T.Array"    then return "LUA_TTABLE"
     elseif tag == "types.T.Table"    then return "LUA_TTABLE"
     elseif tag == "types.T.Record"   then return "LUA_TUSERDATA"
-    elseif tag == "types.T.Any"      then typedecl.tag_error(tag, "'Any' is not a Lua type tag.")
-    else typedecl.tag_error(tag)
+    elseif tag == "types.T.Any"      then tagged_union.tag_error(tag, "'Any' is not a Lua type tag.")
+    else tagged_union.tag_error(tag)
     end
 end
 
@@ -349,10 +349,10 @@ function Coder:c_value(value)
         return self:c_var(value.id)
     elseif tag == "ir.Value.Upvalue" then
         return self:c_upval(value.id)
-    elseif typedecl.tagname(tag) == "ir.Value" then
-        typedecl.tag_error(tag, "unable to get C expression for this value type.")
+    elseif tagged_union.tagname(tag) == "ir.Value" then
+        tagged_union.tag_error(tag, "unable to get C expression for this value type.")
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 end
 
@@ -633,7 +633,7 @@ end
 -- This section of the program is responsible for keeping track of the "global" values in the module
 -- that need to be seen from every function. We store them in the uservalues of an userdata object.
 
-typedecl.declare(coder, "coder", "Constant", {
+tagged_union.declare(coder, "coder", "Constant", {
     Metatable = {"typ"},
     String = {"str"},
 })
@@ -1387,7 +1387,7 @@ gen_cmd["CallStatic"] = function(self, cmd, func)
         f_id = assert(func.f_id_of_local[f_val.id])
         cclosure = string.format("clCvalue(&%s)", self:c_value(f_val))
     else
-        typedecl.tag_error(f_val._tag)
+        tagged_union.tag_error(f_val._tag)
     end
 
     table.insert(parts, self:update_stack_top(func, cmd))
@@ -1651,7 +1651,7 @@ gen_cmd["For"] = function(self, cmd, func)
     elseif typ._tag == "types.T.Float" then
         macro = "PALLENE_FLT_FOR_LOOP"
     else
-        typedecl.tag_error(typ._tag)
+        tagged_union.tag_error(typ._tag)
     end
 
     return (util.render([[
@@ -1676,8 +1676,8 @@ gen_cmd["CheckGC"] = function(self, cmd, func)
 end
 
 function Coder:generate_cmd(func, cmd)
-    assert(typedecl.typename(cmd._tag) == "ir.Cmd")
-    local name = typedecl.consname(cmd._tag)
+    assert(tagged_union.typename(cmd._tag) == "ir.Cmd")
+    local name = tagged_union.consname(cmd._tag)
     local f = assert(gen_cmd[name], "impossible")
     local out = f(self, cmd, func)
 
@@ -1782,7 +1782,7 @@ function Coder:generate_luaopen_function()
                     str = C.string(upv.str)
                 }))
         else
-            typedecl.tag_error(tag)
+            tagged_union.tag_error(tag)
         end
 
         if not is_upvalue_box then

--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -8,15 +8,17 @@
 -- This compiler pass converts a Pallene IR module into to executable C code.
 -- This file is fairly long. For navigation, look for the sectioning comments.
 
+local coder = {}
+
 local C = require "pallene.C"
 local gc = require "pallene.gc"
 local ir = require "pallene.ir"
 local pallenelib = require "pallene.pallenelib"
 local types = require "pallene.types"
-local tagged_union = require "pallene.tagged_union"
 local util = require "pallene.util"
 
-local coder = {}
+local tagged_union = require "pallene.tagged_union"
+local define_union = tagged_union.in_namespace(coder, "coder")
 
 local Coder
 local RecordCoder
@@ -633,7 +635,7 @@ end
 -- This section of the program is responsible for keeping track of the "global" values in the module
 -- that need to be seen from every function. We store them in the uservalues of an userdata object.
 
-tagged_union.declare(coder, "coder", "Constant", {
+define_union("Constant", {
     Metatable = {"typ"},
     String = {"str"},
 })

--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -182,7 +182,7 @@ local function pallene_type_tag(typ)
     elseif tag == "types.T.Array"    then return "LUA_TTABLE"
     elseif tag == "types.T.Table"    then return "LUA_TTABLE"
     elseif tag == "types.T.Record"   then return "LUA_TUSERDATA"
-    elseif tag == "types.T.Any"      then tagged_union.error(tag, "'Any' is not a Lua type tag.")
+    elseif tag == "types.T.Any"      then assert(false) -- 'Any' is not a type tag
     else tagged_union.error(tag)
     end
 end
@@ -352,8 +352,6 @@ function Coder:c_value(value)
         return self:c_var(value.id)
     elseif tag == "ir.Value.Upvalue" then
         return self:c_upval(value.id)
-    elseif tagged_union.tagname(tag) == "ir.Value" then
-        tagged_union.error(tag, "unable to get C expression for this value type.")
     else
         tagged_union.error(tag)
     end

--- a/src/pallene/constant_propagation.lua
+++ b/src/pallene/constant_propagation.lua
@@ -22,7 +22,7 @@
 --     end
 
 local ir = require "pallene.ir"
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 
 local constant_propagation = {}
 
@@ -36,7 +36,7 @@ local function is_constant_value(v)
     elseif tag == "ir.Value.LocalVar" then return false
     elseif tag == "ir.Value.Upvalue"  then return false
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 end
 
@@ -105,7 +105,7 @@ function constant_propagation.run(module)
                         next_f.constant_val_of_upvalue[u_id] = const_init
 
                     else
-                        typedecl.tag_error(value._tag)
+                        tagged_union.tag_error(value._tag)
                     end
                 end
 
@@ -135,7 +135,7 @@ function constant_propagation.run(module)
                     elseif value._tag == "ir.Value.Upvalue" then
                         next_f.constant_val_of_upvalue[u_id] = f_data.constant_val_of_upvalue[value.id]
                     else
-                        typedecl.tag_error(value._tag)
+                        tagged_union.tag_error(value._tag)
                     end
                 end
 

--- a/src/pallene/constant_propagation.lua
+++ b/src/pallene/constant_propagation.lua
@@ -36,7 +36,7 @@ local function is_constant_value(v)
     elseif tag == "ir.Value.LocalVar" then return false
     elseif tag == "ir.Value.Upvalue"  then return false
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -105,7 +105,7 @@ function constant_propagation.run(module)
                         next_f.constant_val_of_upvalue[u_id] = const_init
 
                     else
-                        tagged_union.tag_error(value._tag)
+                        tagged_union.error(value._tag)
                     end
                 end
 
@@ -135,7 +135,7 @@ function constant_propagation.run(module)
                     elseif value._tag == "ir.Value.Upvalue" then
                         next_f.constant_val_of_upvalue[u_id] = f_data.constant_val_of_upvalue[value.id]
                     else
-                        tagged_union.tag_error(value._tag)
+                        tagged_union.error(value._tag)
                     end
                 end
 

--- a/src/pallene/ir.lua
+++ b/src/pallene/ir.lua
@@ -20,13 +20,10 @@
 -- structured control flow is easier to reason about then an unstructured control flow graph built
 -- around basic blocks and gotos.
 
-local tagged_union = require "pallene.tagged_union"
-
 local ir = {}
 
-local function declare_type(type_name, cons)
-    tagged_union.declare(ir, "ir", type_name, cons)
-end
+local tagged_union = require "pallene.tagged_union"
+local define_union = tagged_union.in_namespace(ir, "ir")
 
 function ir.Module()
     return {
@@ -110,7 +107,7 @@ end
 -- Pallene IR
 --
 
-declare_type("Value", {
+define_union("Value", {
     Nil        = {},
     Bool       = {"value"},
     Integer    = {"value"},
@@ -120,7 +117,7 @@ declare_type("Value", {
     Upvalue    = {"id"},
 })
 
--- declare_type("Cmd"
+-- define_union("Cmd"
 local ir_cmd_constructors = {
     -- [IMPORTANT] Please use this naming convention:
     --  - "src" fields contain an "ir.Value".
@@ -202,7 +199,7 @@ local ir_cmd_constructors = {
     -- Garbage Collection (appears after memory allocations)
     CheckGC = {},
 }
-declare_type("Cmd", ir_cmd_constructors)
+define_union("Cmd", ir_cmd_constructors)
 
 -- We need to know, for each kind of command, which fields contain inputs (ir.Value) and which
 -- fields refer to outputs (local variable ID). We use a common naming convention for this.

--- a/src/pallene/ir.lua
+++ b/src/pallene/ir.lua
@@ -20,12 +20,12 @@
 -- structured control flow is easier to reason about then an unstructured control flow graph built
 -- around basic blocks and gotos.
 
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 
 local ir = {}
 
 local function declare_type(type_name, cons)
-    typedecl.declare(ir, "ir", type_name, cons)
+    tagged_union.declare(ir, "ir", type_name, cons)
 end
 
 function ir.Module()

--- a/src/pallene/print_ir.lua
+++ b/src/pallene/print_ir.lua
@@ -48,7 +48,7 @@ local function Val(val)
     elseif tag == "ir.Value.LocalVar" then return Var(val.id)
     elseif tag == "ir.Value.Upvalue"  then return Upval(val.id)
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 

--- a/src/pallene/print_ir.lua
+++ b/src/pallene/print_ir.lua
@@ -10,7 +10,7 @@
 local C = require "pallene.C"
 local ir = require "pallene.ir"
 local util = require "pallene.util"
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 
 
 
@@ -48,7 +48,7 @@ local function Val(val)
     elseif tag == "ir.Value.LocalVar" then return Var(val.id)
     elseif tag == "ir.Value.Upvalue"  then return Upval(val.id)
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 end
 
@@ -223,8 +223,8 @@ local function Cmd(cmd)
         rhs = "CallStatic ".. Call(Val(cmd.src_f), Vals(cmd.srcs))
     elseif tag == "ir.Cmd.CallDyn" then
         rhs = "CallDyn ".. Call(Val(cmd.src_f), Vals(cmd.srcs))
-    elseif typedecl.typename(cmd._tag) == "ir.Cmd" then
-        local name = typedecl.consname(cmd._tag)
+    elseif tagged_union.typename(cmd._tag) == "ir.Cmd" then
+        local name = tagged_union.consname(cmd._tag)
         rhs = Call(name, Vals(ir.get_srcs(cmd)))
     end
 

--- a/src/pallene/tagged_union.lua
+++ b/src/pallene/tagged_union.lua
@@ -31,7 +31,7 @@
 --         name = name,
 --     }
 
-local typedecl = {}
+local tagged_union = {}
 
 -- Ensure type tags are unique
 -- And keep track of who is the "parent" type
@@ -66,7 +66,7 @@ end
 -- @param mod_name     Name of the type's module (only used by tostring)
 -- @param type_name    Name of the type
 -- @param constructors Table describing the constructors of the ADT.
-function typedecl.declare(module, mod_name, type_name, constructors)
+function tagged_union.declare(module, mod_name, type_name, constructors)
     module[type_name] = {}
     for cons_name, fields in pairs(constructors) do
         local tag = make_tag(mod_name, type_name, cons_name)
@@ -87,11 +87,11 @@ function typedecl.declare(module, mod_name, type_name, constructors)
     end
 end
 
-function typedecl.typename(tag)
+function tagged_union.typename(tag)
     return typename_of[tag]
 end
 
-function typedecl.consname(tag)
+function tagged_union.consname(tag)
     return consname_of[tag]
 end
 
@@ -99,9 +99,9 @@ end
 --
 -- @param tag     The type tag (or token string) at which the error is to be thown (string)
 -- @param message The optional error message. (?string)
-function typedecl.tag_error(tag, message)
+function tagged_union.tag_error(tag, message)
     message = message or "input has the wrong type or an elseif case is missing"
     error(string.format("unhandled case '%s': %s", tag, message))
 end
 
-return typedecl
+return tagged_union

--- a/src/pallene/tagged_union.lua
+++ b/src/pallene/tagged_union.lua
@@ -5,38 +5,35 @@
 
 -- TAGGED UNIONS
 -- =============
--- Pallene's compiler uses many tagged unions / variant records. We represent
--- them as tables with a string `_tag`. This module exports helper functions for
--- custructing such tagged unions.
+-- Pallene's compiler uses many tagged unions / variant records.
+-- This module helps create and use such tagged unions.
 --
--- For example, the following block of code in the `ast` module creates
--- three constructor functions called `ast.Var.Name`, `ast.Var.Bracket`, and
--- `ast.Var.Dot`.
+-- Example usage: the code below defines a new tagged union in the "ast" namespace.
 --
---     declare_type("Var", {
+--     local tagged_union = require 'pallene.tagged_union'
+--     local define_union = tagged_union.in_namespace(ast, "ast")
+--
+--     define_union("Var", {
 --         Name    = {"loc", "name"},
 --         Bracket = {"loc", "t", "k"},
 --         Dot     = {"loc", "exp", "name"}
 --     })
 --
--- And we can call them like this
+-- It generates suitable constructor functions:
 --
 --     node = ast.Var.Name(loc, name)
 --
--- and it produces a table like this:
+-- The constructor produces a variant record containing a _tag field:
 --
---     {
---         _tag = "ast.Var.Name",
---         loc = loc,
---         name = name,
---     }
+--     { _tag = "ast.Var.Name", loc = loc, name = name }
+--
 
 local tagged_union = {}
 
--- Ensure type tags are unique
--- And keep track of who is the "parent" type
+-- These associative arrays ensure that type tags are unique.
+-- They also compute the "parent" type faster than substring manipulation.
 local typename_of = {} -- For example, "ast.Exp.Name" => "ast.Exp"
-local consname_of = {} -- For example, "ast.Exp.Name" => "
+local consname_of = {} -- For example, "ast.Exp.Name" => "Name"
 
 local function is_valid_name_component(s)
     -- In particular this does not allow ".", which is our separator
@@ -51,23 +48,19 @@ local function make_tag(mod_name, type_name, cons_name)
     local tag = typ      .. "." .. cons_name
     if typename_of[tag] then
         error(string.format("tag name %q is already being used", tag))
-    else
-        typename_of[tag] = typ
-        consname_of[tag] = cons_name
-        return tag
     end
+    typename_of[tag] = typ
+    consname_of[tag] = cons_name
+    return tag
 end
 
--- Create a namespaced algebraic datatype.
--- These objects can be pattern matched by their _tag.
--- See `ast.lua` and `types.lua` for usage examples.
---
+-- Create a tagged union constructor
 -- @param module       Module table where the type is being defined
--- @param mod_name     Name of the type's module (only used by tostring)
+-- @param mod_name     Name of the module
 -- @param type_name    Name of the type
--- @param constructors Table describing the constructors of the ADT.
-function tagged_union.declare(module, mod_name, type_name, constructors)
-    module[type_name] = {}
+-- @param constructors Name of the constructor => fields of the record
+local function define_union(mod_table, mod_name, type_name, constructors)
+    mod_table[type_name] = {}
     for cons_name, fields in pairs(constructors) do
         local tag = make_tag(mod_name, type_name, cons_name)
         local function cons(...)
@@ -83,7 +76,15 @@ function tagged_union.declare(module, mod_name, type_name, constructors)
             end
             return node
         end
-        module[type_name][cons_name] = cons
+        mod_table[type_name][cons_name] = cons
+    end
+end
+
+function tagged_union.in_namespace(mod_table, mod_name)
+    assert(type(mod_table) == "table")
+    assert(type(mod_name) == "string")
+    return function(type_name, constructors)
+        return define_union(mod_table, mod_name, type_name, constructors)
     end
 end
 
@@ -95,10 +96,7 @@ function tagged_union.consname(tag)
     return consname_of[tag]
 end
 
--- Throw an error at the given tag.
---
--- @param tag     The type tag (or token string) at which the error is to be thown (string)
--- @param message The optional error message. (?string)
+-- Use this in the last "else" of a tagged union switch-case.
 function tagged_union.tag_error(tag, message)
     message = message or "input has the wrong type or an elseif case is missing"
     error(string.format("unhandled case '%s': %s", tag, message))

--- a/src/pallene/tagged_union.lua
+++ b/src/pallene/tagged_union.lua
@@ -97,7 +97,7 @@ function tagged_union.consname(tag)
 end
 
 -- Use this in the last "else" of a tagged union switch-case.
-function tagged_union.tag_error(tag, message)
+function tagged_union.error(tag, message)
     message = message or "input has the wrong type or an elseif case is missing"
     error(string.format("unhandled case '%s': %s", tag, message))
 end

--- a/src/pallene/tagged_union.lua
+++ b/src/pallene/tagged_union.lua
@@ -97,9 +97,8 @@ function tagged_union.consname(tag)
 end
 
 -- Use this in the last "else" of a tagged union switch-case.
-function tagged_union.error(tag, message)
-    message = message or "input has the wrong type or an elseif case is missing"
-    error(string.format("unhandled case '%s': %s", tag, message))
+function tagged_union.error(tag)
+    error(string.format("pattern-match failure: %s", tag))
 end
 
 return tagged_union

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -7,19 +7,17 @@
 -- =========
 -- This compiler pass converts the Pallene syntax tree to the low level IR.
 
+local to_ir = {}
+
 local ir = require "pallene.ir"
 local types = require "pallene.types"
 local util = require "pallene.util"
-local tagged_union = require "pallene.tagged_union"
 local trycatch = require "pallene.trycatch"
 
-local to_ir = {}
+local tagged_union = require "pallene.tagged_union"
+local define_union = tagged_union.in_namespace(to_ir, "to_ir")
 
-local function declare_type(type_name, cons)
-    tagged_union.declare(to_ir, "to_ir", type_name, cons)
-end
-
-declare_type("LHS", {
+define_union("LHS", {
     Local  = {"id"},
     Global = {"id"},
     Array  = {"typ", "arr", "i"},
@@ -27,7 +25,7 @@ declare_type("LHS", {
     Record = {"typ", "rec", "field"},
 })
 
-declare_type("Var", {
+define_union("Var", {
     LocalVar   = {"id"},
     Upvalue    = {"id"},
     GlobalVar  = {"id"},

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -572,7 +572,8 @@ function ToIR:convert_stat(cmds, stat)
                     local typ = var.exp._type
                     table.insert(lhss, to_ir.LHS.Record(typ, t, var.name))
                 elseif tagged_union.tag_is_type(ttag) then
-                    tagged_union.error(ttag, "type not indexable.")
+                    -- Not indexable
+                    assert(false)
                 else
                     tagged_union.error(ttag)
                 end
@@ -1254,7 +1255,8 @@ function ToIR:value_is_truthy(cmds, exp, val)
         table.insert(cmds, ir.Cmd.IsTruthy(exp.loc, b, val))
         return ir.Value.LocalVar(b)
     elseif tagged_union.tag_is_type(typ) then
-        tagged_union.error(typ._tag, "unable to test this type for truthiness.")
+        -- Cannot be tested for truthyness
+        assert(false)
     else
         tagged_union.error(typ._tag)
     end

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -172,7 +172,7 @@ function ToIR:resolve_variable(decl)
             u_id = ir.add_upvalue(func, decl.name, decl._type)
             table.insert(captured_vars, ir.Value.Upvalue(var.id))
         else
-            tagged_union.tag_error(var._tag)
+            tagged_union.error(var._tag)
         end
 
         if u_id > MaxUpvalueCount then
@@ -263,7 +263,7 @@ function ToIR:convert_toplevel(prog_ast)
             local typ = tl_node._type
             self.rec_id_of_typ[typ] = ir.add_record_type(self.module, typ)
         else
-            tagged_union.tag_error(tag)
+            tagged_union.error(tag)
         end
     end
 
@@ -553,7 +553,7 @@ function ToIR:convert_stat(cmds, stat)
                 if var_info._tag == "to_ir.Var.LocalVar" then
                     table.insert(lhss, to_ir.LHS.Local(var_info.id))
                 else
-                    tagged_union.tag_error(var_info._tag)
+                    tagged_union.error(var_info._tag)
                 end
 
             elseif var._tag == "ast.Var.Bracket" then
@@ -572,13 +572,13 @@ function ToIR:convert_stat(cmds, stat)
                     local typ = var.exp._type
                     table.insert(lhss, to_ir.LHS.Record(typ, t, var.name))
                 elseif tagged_union.tag_is_type(ttag) then
-                    tagged_union.tag_error(ttag, "type not indexable.")
+                    tagged_union.error(ttag, "type not indexable.")
                 else
-                    tagged_union.tag_error(ttag)
+                    tagged_union.error(ttag)
                 end
 
             else
-                tagged_union.tag_error(var._tag)
+                tagged_union.error(var._tag)
             end
         end
 
@@ -637,7 +637,7 @@ function ToIR:convert_stat(cmds, stat)
                 elseif ltag == "to_ir.LHS.Record" then
                     table.insert(cmds, ir.Cmd.SetField(loc, lhs.typ, lhs.rec, lhs.field, val))
                 else
-                    tagged_union.tag_error(ltag)
+                    tagged_union.error(ltag)
                 end
             end
         end
@@ -718,7 +718,7 @@ function ToIR:convert_stat(cmds, stat)
         end
 
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -875,7 +875,7 @@ function ToIR:exp_to_value(cmds, exp, is_recursive)
                     error("not implemented")
                 end
             else
-                tagged_union.tag_error(def._tag)
+                tagged_union.error(def._tag)
             end
 
             local var_info = self:resolve_variable(decl)
@@ -886,7 +886,7 @@ function ToIR:exp_to_value(cmds, exp, is_recursive)
             elseif var_info._tag == "to_ir.Var.GlobalVar" then
                 -- Fallthrough to default
             else
-                tagged_union.tag_error(var_info._tag)
+                tagged_union.error(var_info._tag)
             end
 
         else
@@ -969,7 +969,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
             -- Fallthrough to default
 
         else
-            tagged_union.tag_error(typ._tag)
+            tagged_union.error(typ._tag)
         end
 
     elseif tag == "ast.Exp.UpvalueRecord" then
@@ -1089,7 +1089,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 assert(#xs == 1)
                 table.insert(cmds, ir.Cmd.BuiltinTostring(loc, dsts, xs))
             else
-                tagged_union.tag_error(bname)
+                tagged_union.error(bname)
             end
 
         elseif def and def._tag == "typechecker.Def.Function" then
@@ -1116,7 +1116,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
                 elseif var_info._tag == "to_ir.Var.GlobalVar" then
                     table.insert(cmds, ir.Cmd.GetGlobal(loc, dst, var_info.id))
                 else
-                    tagged_union.tag_error(var_info._tag)
+                    tagged_union.error(var_info._tag)
                 end
             else
                 use_exp_to_value = true
@@ -1140,13 +1140,13 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
               elseif typ._tag == "types.T.Record" then
                   cmd = ir.Cmd.GetField(loc, typ, dst, rec, field)
               else
-                  tagged_union.tag_error(typ._tag)
+                  tagged_union.error(typ._tag)
               end
 
               table.insert(cmds, cmd)
 
         else
-            tagged_union.tag_error(var._tag)
+            tagged_union.error(var._tag)
         end
 
     elseif tag == "ast.Exp.Unop" then
@@ -1254,9 +1254,9 @@ function ToIR:value_is_truthy(cmds, exp, val)
         table.insert(cmds, ir.Cmd.IsTruthy(exp.loc, b, val))
         return ir.Value.LocalVar(b)
     elseif tagged_union.tag_is_type(typ) then
-        tagged_union.tag_error(typ._tag, "unable to test this type for truthiness.")
+        tagged_union.error(typ._tag, "unable to test this type for truthiness.")
     else
-        tagged_union.tag_error(typ._tag)
+        tagged_union.error(typ._tag)
     end
 end
 

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -35,15 +35,17 @@
 -- check_exp and check_var functions. For example, instead of just `check_exp(foo.exp)` you should
 -- always write `foo.exp = check_exp(foo.exp)`.
 
+local typechecker = {}
+
 local ast = require "pallene.ast"
 local builtins = require "pallene.builtins"
 local symtab = require "pallene.symtab"
 local trycatch = require "pallene.trycatch"
 local types = require "pallene.types"
-local tagged_union = require "pallene.tagged_union"
 local util = require "pallene.util"
 
-local typechecker = {}
+local tagged_union = require "pallene.tagged_union"
+local define_union = tagged_union.in_namespace(typechecker, "typechecker")
 
 local Typechecker = util.Class()
 
@@ -98,15 +100,11 @@ end
 -- Symbol table
 --
 
-local function declare_type(type_name, cons)
-    tagged_union.declare(typechecker, "typechecker", type_name, cons)
-end
-
 --
 -- Type information, meant for for the type checker
 -- For each name in scope, the type checker wants to know if it is a value and what is its type.
 --
-declare_type("Symbol", {
+define_union("Symbol", {
     Type   = { "typ"  },
     Value  = { "typ", "def" },
     Module = { "typ", "symbols" }, -- Note: a module name can also be a type (e.g. "string")
@@ -116,7 +114,7 @@ declare_type("Symbol", {
 -- Provenance information, meant for the code generator
 -- For each name in the AST, we add an annotation to tell the codegen where it comes from.
 --
-declare_type("Def", {
+define_union("Def", {
     Variable = { "decl" }, -- ast.Decl
     Function = { "func" }, -- ast.FuncStat
     Builtin  = { "id"   }, -- string

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -130,7 +130,7 @@ local function loc_of_def(def)
     elseif tag == "typechecker.Def.Builtin" then
         error("builtin does not have a location")
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -190,7 +190,7 @@ function Typechecker:from_ast_type(ast_typ)
         elseif stag == "typechecker.Symbol.Value" then
             type_error(ast_typ.loc, "'%s' is not a type", name)
         else
-            tagged_union.tag_error(stag)
+            tagged_union.error(stag)
         end
 
     elseif tag == "ast.Type.Array" then
@@ -219,7 +219,7 @@ function Typechecker:from_ast_type(ast_typ)
         return types.T.Function(p_types, ret_types)
 
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -283,7 +283,7 @@ function Typechecker:check_program(prog_ast)
             tl_node._type = typ
 
         else
-            tagged_union.tag_error(tag)
+            tagged_union.error(tag)
         end
     end
 
@@ -394,7 +394,7 @@ function Typechecker:check_stat(stat, is_toplevel)
             elseif loop_type._tag == "types.T.Float" then
                 stat.step = ast.Exp.Float(stat.limit.loc, 1.0)
             else
-                tagged_union.tag_error(loop_type._tag, "loop type is not a number.")
+                tagged_union.error(loop_type._tag, "loop type is not a number.")
             end
         end
 
@@ -604,7 +604,7 @@ function Typechecker:check_stat(stat, is_toplevel)
         end
 
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 
     return stat
@@ -682,7 +682,7 @@ function Typechecker:check_var(var)
         elseif stag == "typechecker.Symbol.Module" then
             type_error(var.loc, "module '%s' is not a value", var.name)
         else
-            tagged_union.tag_error(stag)
+            tagged_union.error(stag)
         end
 
     elseif tag == "ast.Var.Dot" then
@@ -717,7 +717,7 @@ function Typechecker:check_var(var)
         var._type = arr_type.elem
 
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
     return var
 end
@@ -733,9 +733,9 @@ function Typechecker:coerce_numeric_exp_to_float(exp)
     elseif tag == "types.T.Integer" then
         return self:check_exp_synthesize(ast.Exp.ToFloat(exp.loc, exp))
     elseif tagged_union.typename(tag) == "types.T" then
-        tagged_union.tag_error(tag, "this type cannot be coerced to float.")
+        tagged_union.error(tag, "this type cannot be coerced to float.")
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -846,7 +846,7 @@ function Typechecker:check_exp_synthesize(exp)
             check_type_is_condition(exp.exp, "'not' operator")
             exp._type = types.T.Boolean()
         else
-            tagged_union.tag_error(op)
+            tagged_union.error(op)
         end
 
     elseif tag == "ast.Exp.Binop" then
@@ -956,7 +956,7 @@ function Typechecker:check_exp_synthesize(exp)
             exp._type = types.T.Integer()
 
         else
-            tagged_union.tag_error(op)
+            tagged_union.error(op)
         end
 
     elseif tag == "ast.Exp.CallFunc" then
@@ -993,7 +993,7 @@ function Typechecker:check_exp_synthesize(exp)
         exp._type = types.T.Float()
 
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 
     return exp
@@ -1028,7 +1028,7 @@ function Typechecker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
                         field.exp, expected_type.elem,
                         "array initializer")
                 else
-                    tagged_union.tag_error(ftag)
+                    tagged_union.error(ftag)
                 end
             end
         elseif expected_type._tag == "types.T.Module" then
@@ -1060,7 +1060,7 @@ function Typechecker:check_exp_verify(exp, expected_type, errmsg_fmt, ...)
                         field.exp, field_type,
                         "table initializer")
                 else
-                    tagged_union.tag_error(ftag)
+                    tagged_union.error(ftag)
                 end
             end
 

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -380,6 +380,7 @@ function Typechecker:check_stat(stat, is_toplevel)
 
         local loop_type = stat.decl._type
 
+
         if  loop_type._tag ~= "types.T.Integer" and
             loop_type._tag ~= "types.T.Float"
         then
@@ -394,7 +395,7 @@ function Typechecker:check_stat(stat, is_toplevel)
             elseif loop_type._tag == "types.T.Float" then
                 stat.step = ast.Exp.Float(stat.limit.loc, 1.0)
             else
-                tagged_union.error(loop_type._tag, "loop type is not a number.")
+                assert(false)
             end
         end
 
@@ -733,7 +734,8 @@ function Typechecker:coerce_numeric_exp_to_float(exp)
     elseif tag == "types.T.Integer" then
         return self:check_exp_synthesize(ast.Exp.ToFloat(exp.loc, exp))
     elseif tagged_union.typename(tag) == "types.T" then
-        tagged_union.error(tag, "this type cannot be coerced to float.")
+        -- Cannot be coerced to float
+        assert(false)
     else
         tagged_union.error(tag)
     end

--- a/src/pallene/types.lua
+++ b/src/pallene/types.lua
@@ -106,7 +106,9 @@ function types.indices(t)
         return t.field_types
 
     elseif tagged_union.typename(tag) == "types.T" then
-        tagged_union.error(tag, "cannot index this type.")
+        -- Not indexable
+        assert(false)
+
     else
         tagged_union.error(tag)
     end

--- a/src/pallene/types.lua
+++ b/src/pallene/types.lua
@@ -3,15 +3,12 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-local tagged_union = require "pallene.tagged_union"
-
 local types = {}
 
-local function declare_type(type_name, cons)
-    tagged_union.declare(types, "types", type_name, cons)
-end
+local tagged_union = require "pallene.tagged_union"
+local define_union = tagged_union.in_namespace(types, "types")
 
-declare_type("T", {
+define_union("T", {
     Any      = {},
     Nil      = {},
     Boolean  = {},

--- a/src/pallene/types.lua
+++ b/src/pallene/types.lua
@@ -3,12 +3,12 @@
 -- Please refer to the LICENSE and AUTHORS files for details
 -- SPDX-License-Identifier: MIT
 
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 
 local types = {}
 
 local function declare_type(type_name, cons)
-    typedecl.declare(types, "types", type_name, cons)
+    tagged_union.declare(types, "types", type_name, cons)
 end
 
 declare_type("T", {
@@ -49,7 +49,7 @@ function types.is_gc(t)
         return true
 
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 end
 
@@ -72,7 +72,7 @@ function types.is_condition(t)
         return false
 
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 
 end
@@ -96,7 +96,7 @@ function types.is_indexable(t)
         return false
 
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 end
 
@@ -108,10 +108,10 @@ function types.indices(t)
     elseif tag == "types.T.Record" then
         return t.field_types
 
-    elseif typedecl.typename(tag) == "types.T" then
-        typedecl.tag_error(tag, "cannot index this type.")
+    elseif tagged_union.typename(tag) == "types.T" then
+        tagged_union.tag_error(tag, "cannot index this type.")
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 end
 
@@ -119,8 +119,8 @@ function types.equals(t1, t2)
     local tag1 = t1._tag
     local tag2 = t2._tag
 
-    assert(typedecl.typename(tag1) == "types.T")
-    assert(typedecl.typename(tag2) == "types.T")
+    assert(tagged_union.typename(tag1) == "types.T")
+    assert(tagged_union.typename(tag2) == "types.T")
 
     if tag1 ~= tag2 then
         return false
@@ -189,7 +189,7 @@ function types.equals(t1, t2)
         return t1 == t2
 
     else
-        return typedecl.tag_error(tag1,
+        return tagged_union.tag_error(tag1,
             string.format("attempt to check equivalence of types %s and %s.", tag1, tag2))
     end
 end
@@ -244,7 +244,7 @@ function types.tostring(t)
     elseif tag == "types.T.Record" then
         return t.name
     else
-        typedecl.tag_error(tag)
+        tagged_union.tag_error(tag)
     end
 end
 

--- a/src/pallene/types.lua
+++ b/src/pallene/types.lua
@@ -46,7 +46,7 @@ function types.is_gc(t)
         return true
 
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -69,7 +69,7 @@ function types.is_condition(t)
         return false
 
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 
 end
@@ -93,7 +93,7 @@ function types.is_indexable(t)
         return false
 
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -106,9 +106,9 @@ function types.indices(t)
         return t.field_types
 
     elseif tagged_union.typename(tag) == "types.T" then
-        tagged_union.tag_error(tag, "cannot index this type.")
+        tagged_union.error(tag, "cannot index this type.")
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 
@@ -186,7 +186,7 @@ function types.equals(t1, t2)
         return t1 == t2
 
     else
-        return tagged_union.tag_error(tag1,
+        return tagged_union.error(tag1,
             string.format("attempt to check equivalence of types %s and %s.", tag1, tag2))
     end
 end
@@ -241,7 +241,7 @@ function types.tostring(t)
     elseif tag == "types.T.Record" then
         return t.name
     else
-        tagged_union.tag_error(tag)
+        tagged_union.error(tag)
     end
 end
 

--- a/src/pallene/uninitialized.lua
+++ b/src/pallene/uninitialized.lua
@@ -4,7 +4,7 @@
 -- SPDX-License-Identifier: MIT
 
 local ir = require "pallene.ir"
-local typedecl = require "pallene.typedecl"
+local tagged_union = require "pallene.tagged_union"
 
 local uninitialized = {}
 
@@ -118,7 +118,7 @@ local function test(cmd, uninit, loop)
             return true, loop.uninit
         end
 
-    elseif typedecl.typename(cmd._tag) == "ir.Cmd" then
+    elseif tagged_union.typename(cmd._tag) == "ir.Cmd" then
         for _, val in ipairs(ir.get_srcs(cmd)) do
             if val._tag == "ir.Value.LocalVar" then
                 -- `SetField` instructions can count as initializers when the target is an


### PR DESCRIPTION
Miscellaneous code cleanup in the `typedecl` module, which will now be called `tagged_union`. Please refer to the individual commit messages for details.