### PR TITLE
Remove half-baked support for method calls

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -744,25 +744,6 @@ describe("Parser /", function()
         end)
     end)
 
-    describe("Method calls without parenthesis", function()
-
-        it("for string literals", function()
-            assert_expression_ast([[ o:m "asd" ]], {
-                _tag = "ast.Exp.CallMethod",
-                method = "m",
-                args = { { _tag = "ast.Exp.String", value = "asd" } }
-            })
-        end)
-
-        it("for table literals", function()
-            assert_expression_ast([[ o:m {} ]], {
-                _tag = "ast.Exp.CallMethod",
-                method = "m",
-                args = { { _tag = "ast.Exp.InitList" } }
-            })
-        end)
-    end)
-
     describe("Cast expressions", function()
 
         it("have lower precedence than suffixes", function()

--- a/src/pallene/assignment_conversion.lua
+++ b/src/pallene/assignment_conversion.lua
@@ -442,7 +442,7 @@ function Converter:visit_exp(exp)
     elseif tag == "ast.Exp.Lambda" then
         self:visit_lambda(exp)
 
-    elseif tag == "ast.Exp.CallFunc" or tag == "ast.Exp.CallMethod" then
+    elseif tag == "ast.Exp.CallFunc" then
         self:visit_exp(exp.exp)
         for _, arg in ipairs(exp.args) do
             self:visit_exp(arg)

--- a/src/pallene/ast.lua
+++ b/src/pallene/ast.lua
@@ -46,7 +46,7 @@ define_union("Stat", {
 })
 
 define_union("FuncStat", {
-    FuncStat = {"loc", "module", "name", "method", "ret_types", "value"},
+    FuncStat = {"loc", "module", "name", "ret_types", "value"},
 })
 
 -- Things that can appear in the LHS of an assignment. For example: x, x[i], x.name
@@ -65,7 +65,6 @@ define_union("Exp", {
     InitList      = {"loc", "fields"},
     Lambda        = {"loc", "arg_decls", "body"},
     CallFunc      = {"loc", "exp", "args"},
-    CallMethod    = {"loc", "exp", "method", "args"},
     Var           = {"loc", "var"},
     Unop          = {"loc", "op", "exp"},
     Binop         = {"loc", "lhs", "op", "rhs"},

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -636,7 +636,7 @@ function Parser:FuncStat(is_local)
 
     if method then
         self:syntax_error(self.prev.loc,
-            "Pallene does not yet implement method function definitions")
+            "Pallene does not yet implement method definitions")
         self:abort_parsing()
     end
 

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -601,26 +601,43 @@ function Parser:Block()
     return ast.Stat.Block(self.prev.loc, self:StatList())
 end
 
-function Parser:FuncStat()
+function Parser:FuncStat(is_local)
     local start = self:e("function")
+    local root  = self:e("NAME").value
 
-    local root = self:e("NAME").value
 
-    local fields = {}
-    while self:try(".") do
-        table.insert(fields, self:e("NAME").value)
-    end
-
-    if fields[2] then
-        self:syntax_error(self.prev.loc,
-            "more than one dot in the function name is not allowed")
-    end
-
-    local field = fields[1] or false
-
+    local field  = false
     local method = false
-    if self:try(":") then
-        method = self:e("NAME").value
+    if is_local then
+        if self:peek(".") then
+            self:syntax_error(self.next.loc, "local function name has a '.'")
+            self:abort_parsing()
+        end
+        if self:peek(":") then
+            self:syntax_error(self.next.loc, "local function name has a ':'")
+            self:abort_parsing()
+        end
+    else
+        local fields = {}
+        while self:try(".") do
+            table.insert(fields, self:e("NAME").value)
+        end
+
+        field = fields[1] or false
+        if fields[2] then
+            self:syntax_error(self.prev.loc,
+                "more than one dot in the function name is not allowed")
+        end
+
+        if self:try(":") then
+            method = self:e("NAME").value
+        end
+    end
+
+    if method then
+        self:syntax_error(self.prev.loc,
+            "Pallene does not yet implement method function definitions")
+        self:abort_parsing()
     end
 
     local module, name
@@ -653,7 +670,7 @@ function Parser:FuncStat()
     end
 
     return ast.FuncStat.FuncStat(
-        start.loc, module, name, method, return_types,
+        start.loc, module, name, return_types,
         ast.Exp.Lambda(start.loc, params, block))
 end
 
@@ -743,13 +760,7 @@ function Parser:Stat()
     elseif self:peek("local") then
         local start = self:advance()
         if self:peek("function") then
-            local fn = self:FuncStat()
-            if fn.module then
-                self:syntax_error(fn.loc, "local function name has a '.'")
-            end
-            if fn.method then
-                self:syntax_error(start.loc, "local function name has a ':'")
-            end
+            local fn = self:FuncStat(true)
             return ast.Stat.Functions(start.loc, {[fn.name]=true}, {fn})
         else
             local decls = self:DeclList(); if #decls == 0 then self:forced_syntax_error("NAME") end
@@ -771,7 +782,7 @@ function Parser:Stat()
         return ast.Stat.Return(start.loc, exps)
 
     elseif self:peek("function") then
-        local fn = self:FuncStat()
+        local fn = self:FuncStat(false)
         return ast.Stat.Functions(fn.loc, {}, {fn})
 
     elseif self:peek(is_primary_exp_first) then
@@ -787,7 +798,7 @@ function Parser:Stat()
             return ast.Stat.Assign(op.loc, lhs, rhs)
 
         else
-            if exp._tag == "ast.Exp.CallFunc" or exp._tag == "ast.Exp.CallMethod" then
+            if exp._tag == "ast.Exp.CallFunc" then
                 return ast.Stat.Call(exp.loc, exp)
             else
                 self:syntax_error(exp.loc,
@@ -852,7 +863,9 @@ function Parser:SuffixedExp()
             local _    = self:advance()
             local id   = self:e("NAME")
             local args = self:FuncArgs()
-            exp = ast.Exp.CallMethod(exp.loc, exp, id.value, args)
+            self:syntax_error(self.prev.loc,
+                "Pallene does not yet support method calls")
+            self:abort_parsing()
 
         elseif self:peek("(") or self:peek("STRING") or self:peek("{") then
             local args = self:FuncArgs()

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -860,9 +860,9 @@ function Parser:SuffixedExp()
             exp = ast.Exp.Var(start.loc, ast.Var.Bracket(start.loc, exp, index))
 
         elseif self:peek(":") then
-            local _    = self:advance()
-            local id   = self:e("NAME")
-            local args = self:FuncArgs()
+            local _ = self:advance()
+            local _ = self:e("NAME")  -- id
+            local _ = self:FuncArgs() -- args
             self:syntax_error(self.prev.loc,
                 "Pallene does not yet support method calls")
             self:abort_parsing()

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -248,7 +248,6 @@ function ToIR:convert_toplevel(prog_ast)
 
                 elseif stag == "ast.Stat.Functions" then
                     for _, func in ipairs(stat.funcs) do
-                        assert(not stat.method)
                         local f_id = self:register_lambda(func.value, func.name)
                         if func.module then
                             n_exports = n_exports + 1
@@ -920,7 +919,7 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
     local use_exp_to_value = false
 
     if not dst then
-        assert(tag == "ast.Exp.CallFunc" or tag == "ast.Exp.CallMethod")
+        assert(tag == "ast.Exp.CallFunc")
     end
 
     if     tag == "ast.Exp.InitList" then
@@ -1101,9 +1100,6 @@ function ToIR:exp_to_assignment(cmds, dst, exp)
         else
             table.insert(cmds, ir.Cmd.CallDyn(loc, f_typ, dsts, f_val, xs))
         end
-
-    elseif tag == "ast.Exp.CallMethod" then
-        error("not implemented")
 
     elseif tag == "ast.Exp.Var" then
         local var = exp.var

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -299,7 +299,7 @@ end
 function Typechecker:expand_function_returns(rhs)
     local N = #rhs
     local last = rhs[N]
-    if  last and (last._tag == "ast.Exp.CallFunc" or last._tag == "ast.Exp.CallMethod") then
+    if  last and (last._tag == "ast.Exp.CallFunc") then
         last = self:check_exp_synthesize(last)
         rhs[N] = last
         for i = 2, #last._types do
@@ -572,10 +572,6 @@ function Typechecker:check_stat(stat, is_toplevel)
 
             local typ = types.T.Function(arg_types, ret_types)
 
-            if func.method then -- not yet implemented
-                type_error(func.loc, "method syntax has not been implemented in Pallene yet")
-            end
-
             if func.module then
                 -- Module function
                 local sym = self.symbol_table:find_symbol(func.module)
@@ -747,11 +743,7 @@ end
 -- If the function returns 0 arguments, it is only allowed in a statement context.
 -- Void functions in an expression context are a constant source of headaches.
 function Typechecker:check_fun_call(exp, is_stat)
-    assert(exp._tag == "ast.Exp.CallFunc" or exp._tag == "ast.Exp.CallMethod")
-
-    if exp._tag == "ast.Exp.CallMethod" then -- not yet implemented
-        type_error(exp.loc, "method syntax has not been implemented in Pallene yet")
-    end
+    assert(exp._tag == "ast.Exp.CallFunc")
 
     exp.exp = self:check_exp_synthesize(exp.exp)
 
@@ -969,9 +961,6 @@ function Typechecker:check_exp_synthesize(exp)
 
     elseif tag == "ast.Exp.CallFunc" then
         exp = self:check_fun_call(exp, false)
-
-    elseif tag == "ast.Exp.CallMethod" then
-        error("not implemented")
 
     elseif tag == "ast.Exp.Cast" then
         exp._type = self:from_ast_type(exp.target)


### PR DESCRIPTION
The current support for ":" syntax is well-intended but buggy (See #580 and #581). Let's get rid of it for now. When it comes the time to implement method calls for real, it should not be difficult to add this stuff back in.

Closes #581