### PR TITLE
Linter: enforce that we use return value of check_exp 

### DIFF
--- a/run-lint
+++ b/run-lint
@@ -41,6 +41,14 @@ do
     fi
 done
 
+if grep --line-number -E \
+    "^[$space$tab]*self:(check_exp|check_var|check_initializer)" \
+    src/pallene/typechecker.lua;
+then
+    # Using grep to catch this logic error isn't ideal, but it's better than nothing.
+    error "You should not ignore the return value here"
+fi
+
 if [ "$ok" != yes ]; then
     exit 1
 fi

--- a/run-lint
+++ b/run-lint
@@ -32,7 +32,7 @@ do
         error "File $file has a line that ends in whitespace"
     fi
 
-    if grep --line-number "^$tab" "$file"; then
+    if grep --line-number "^$space*$tab" "$file"; then
         # Standardize on spaces because mixing tabs and spaces is endless pain.
         error "File $file has tab-based indentation"
     fi

--- a/run-lint
+++ b/run-lint
@@ -2,11 +2,12 @@
 
 space=' '
 tab='	'
-ok=yes
 
 red='\033[1;31m'
 green='\033[1;32m'
 reset='\033[0m'
+
+ok=yes
 
 error() {
     printf "${red}ERROR${reset} %s\n" "$*"

--- a/run-lint
+++ b/run-lint
@@ -14,7 +14,7 @@ error() {
 }
 
 echo "--- Lua Lint ---"
-luacheck src/ spec/ examples/ "$@" || exit 1
+luacheck src/ spec/ examples/ "$@" || error "Luacheck found problems"
 echo
 
 echo "--- Other checks ---"

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -33,7 +33,7 @@
 --
 -- IMPORTANT: For these transformations to work you should always use the return value from the
 -- check_exp and check_var functions. For example, instead of just `check_exp(foo.exp)` you should
--- always write `foo.exp = check_exp(foo.exp)`.
+-- always write `foo.exp = check_exp(foo.exp)`. Our linter script enforces this.
 
 local typechecker = {}
 


### PR DESCRIPTION
If we don't use the return value of these functions, it results in a nasty and hard to find bug. The linter should be able to offer some protection, despite not being the perfect tool for the job.