### PR TITLE
Record tag error message includes record name instead of only "userdata"

### DIFF
--- a/spec/execution_tests.lua
+++ b/spec/execution_tests.lua
@@ -1390,11 +1390,9 @@ function execution_tests.run(compile_file, backend, _ENV, only_compile)
         end)
 
         it("check record tags", function()
-            -- TODO: change this message to mention the relevant record types
-            -- instead of only saying "userdata"
             run_test([[
                 local prim = test.make_prim(123)
-                assert_pallene_error("expected userdata but found userdata", test.get_x, prim)
+                assert_pallene_error("expected Foo but found Prim", test.get_x, prim)
             ]])
         end)
 

--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -254,7 +254,7 @@ function Coder:get_stack_slot(typ, dst, slot, loc, description_fmt, ...)
         check_tag = util.render([[
             if (l_unlikely(!$test)) {
                 pallene_runtime_tag_check_error(L,
-                    $file, $line, $expected_type, pallene_type_name(L, $slot),
+                    $file, $line, $expected_type, $slot,
                     ${description_fmt}${opt_comma}${extra_args});
             }
         ]], {

--- a/src/pallene/pallenelib.lua
+++ b/src/pallene/pallenelib.lua
@@ -48,6 +48,7 @@ return [==[
 
 /* Type tags */
 static const char *pallene_tag_name(int raw_tag);
+static const char *pallene_type_name(lua_State *L, const TValue *raw_type);
 static int pallene_is_truthy(const TValue *v);
 static int pallene_is_record(const TValue *v, const TValue *meta_table);
 static int pallene_bvalue(TValue *obj);
@@ -57,7 +58,8 @@ static void pallene_setbvalue(TValue *obj, int b);
 static void pallene_barrierback_unboxed(lua_State *L, GCObject *p, GCObject *v);
 
 /* Runtime errors */
-static l_noret pallene_runtime_tag_check_error(lua_State *L, const char* file, int line, int expected_tag, int received_tag,const char *description_fmt, ...);
+static l_noret pallene_runtime_tag_check_error(lua_State *L, const char* file, int line,
+                                const char *expected_type, const char *received_type, const char *description_fmt, ...);
 static l_noret pallene_runtime_arity_error(lua_State *L, const char *name, int expected, int received);
 static l_noret pallene_runtime_divide_by_zero_error(lua_State *L, const char* file, int line);
 static l_noret pallene_runtime_mod_by_zero_error(lua_State *L, const char* file, int line);
@@ -107,6 +109,17 @@ static const char *pallene_tag_name(int raw_tag)
     }
 }
 
+static const char *pallene_type_name(lua_State *L, const TValue *raw_type)
+{
+    if (rawtt(raw_type) == LUA_VNUMINT) {
+        return "integer";
+    } else if (rawtt(raw_type) == LUA_VNUMFLT) {
+        return "float";
+    } else {
+        return luaT_objtypename(L, raw_type);
+    }
+}
+
 static int pallene_is_truthy(const TValue *v)
 {
     return !l_isfalse(v);
@@ -147,14 +160,11 @@ static void pallene_runtime_tag_check_error(
     lua_State *L,
     const char* file,
     int line,
-    int expected_tag,
-    int received_tag,
+    const char *expected_type,
+    const char *received_type,
     const char *description_fmt,
     ...
 ){
-    const char *expected_type = pallene_tag_name(expected_tag);
-    const char *received_type = pallene_tag_name(received_tag);
-
     /* This code is inspired by luaL_error */
     luaL_where(L, 1);
     if (line > 0) {

--- a/src/pallene/pallenelib.lua
+++ b/src/pallene/pallenelib.lua
@@ -47,7 +47,6 @@ return [==[
 #define PALLENE_UNREACHABLE __builtin_unreachable()
 
 /* Type tags */
-static const char *pallene_tag_name(int raw_tag);
 static const char *pallene_type_name(lua_State *L, const TValue *v);
 static int pallene_is_truthy(const TValue *v);
 static int pallene_is_record(const TValue *v, const TValue *meta_table);
@@ -97,17 +96,6 @@ static TString *pallene_type_builtin(lua_State *L, TValue v);
 static TString *pallene_tostring(lua_State *L, const char* file, int line, TValue v);
 static void pallene_io_write(lua_State *L, TString *str);
 
-
-static const char *pallene_tag_name(int raw_tag)
-{
-    if (raw_tag == LUA_VNUMINT) {
-        return "integer";
-    } else if (raw_tag == LUA_VNUMFLT) {
-        return "float";
-    } else {
-        return ttypename(novariant(raw_tag));
-    }
-}
 
 static const char *pallene_type_name(lua_State *L, const TValue *v)
 {
@@ -182,7 +170,7 @@ static void pallene_runtime_tag_check_error(
         va_end(argp);
     }
     lua_pushfstring(L, ", expected %s but found %s",
-        expected_type, received_type_name);
+        expected_type_name, received_type_name);
     lua_concat(L, 5);
     lua_error(L);
     PALLENE_UNREACHABLE;


### PR DESCRIPTION
Fixes: #151

Code:

```lua
-- main.lua

Mod = require "Shapes"

C1 = Mod.Circle_New(3.0)
R1 = Mod.Rectangle_New(3.0, 4.0)

print(Mod.Circle_Area(R1))
print(Mod.Circle_Area(1)) 
```

```lua
-- Shapes.pln

local Shapes: module = {}

record Circle
    radius: float
end

record Rectangle
    length: float
    width: float
end

function Shapes.Circle_New(r: float): Circle
    local c: Circle = {radius = r}
    return c
end

function Shapes.Circle_Area(c: Circle): float
    return c.radius * c.radius * 3.1415
end

function Shapes.Rectangle_New(l: float, w: float): Rectangle
    local c: Rectangle = {length = l, width = w}
    return c
end

function Shapes.Rectangle_Area(c: Rectangle): float
    return c.length * c.width
end

return Shapes
```

Old behaviour
```bash
❯ lua main.lua                                  
lua: main.lua:8: file Shapes.pln: line 17: wrong type for argument 'c', expected userdata but found userdata
stack traceback:
        [C]: in function 'Shapes.Circle_Area'
        main.lua:8: in main chunk
        [C]: in ?

❯ lua main.lua
lua: main.lua:9: file Shapes.pln: line 17: wrong type for argument 'c', expected userdata but found integer
stack traceback:
        [C]: in function 'Shapes.Circle_Area'
        main.lua:9: in main chunk
        [C]: in ?
```

New behaviour
```bash
❯ lua main.lua
lua: main.lua:8: file Shapes.pln: line 17: wrong type for argument 'c', expected Circle but found Rectangle
stack traceback:
        [C]: in function 'Shapes.Circle_Area'
        main.lua:8: in main chunk
        [C]: in ?

❯ lua main.lua
lua: main.lua:9: file Shapes.pln: line 17: wrong type for argument 'c', expected Circle but found integer
stack traceback:
        [C]: in function 'Shapes.Circle_Area'
        main.lua:9: in main chunk
        [C]: in ?
```