### PR TITLE
Getting started with the stack-trace improvement

### DIFF
--- a/src/pallene/pallenelib.lua
+++ b/src/pallene/pallenelib.lua
@@ -627,5 +627,9 @@ static void pallene_io_write(lua_State *L, TString *str)
         } \
     }
 
+/* Custom stack-trace management. */
+#define PALLENE_FRAMEENTER(L, from_lua)    /* Dummy */
+#define PALLENE_SETLINE(L, line)           /* Dummy */
+#define PALLENE_FRAMEEXIT(L, value)        /* Dummy */
 
 ]==]


### PR DESCRIPTION
Getting started with the Full stack-trace support for Pallene. Added some dummy macros in ``pallenelib.lua``. I will make necessary changes in the ``coder.lua`` next, emitting Pallene functions using those macros.

The initial design specs. to solve the stack-trace problem in Pallene: [The Pallene Tracer](https://docs.google.com/document/d/1JNMswjvCXlri4nYjLI5f1w3HrkHa7xSKyXSYxNG1MWs/edit?usp=sharing).

Resolves #565