### PR TITLE
Slightly adjust frameenter/exit in generated C

### DIFF
--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -465,9 +465,7 @@ function Coder:pallene_entry_point_definition(f_id)
     local frameexit = ""
     if self.flags.use_traceback then
         table.insert(prologue, util.render([[
-            /**/
             PALLENE_C_FRAMEENTER(L, "$name");
-            /**/
         ]], {
             name = func.name
         }));
@@ -529,8 +527,8 @@ function Coder:pallene_entry_point_definition(f_id)
             ${prologue}
             /**/
             ${body}
-            ${ret_mult}
             ${frameexit}
+            ${ret_mult}
             ${ret_stat}
         }
     ]], {
@@ -623,9 +621,7 @@ function Coder:lua_entry_point_definition(f_id)
     local cargs = nargs
     if self.flags.use_traceback then
         frameenter = util.render([[
-            /**/
             PALLENE_LUA_FRAMEENTER(L, $fun_name);
-            /**/
         ]], {
             fun_name = self:lua_entry_point_name(f_id),
         })


### PR DESCRIPTION
1) Don't add blank lines around FRAMEENTER.

    static void function_03(
        lua_State *L,
        Udata * restrict K,
        TValue * restrict U
    ) {
        PALLENE_C_FRAMEENTER(L, "myfunc");
        StackValue *base = L->top.p;
        ptrdiff_t base_offset = savestack(L, base);

2) Move the FRAMEEXIT to before the multi-return assignments. The assingments+return are a single thing.

    PALLENE_FRAMEEXIT();
    *ret2 = x3;
    return x2;