### PR TITLE
--emit-lua: Don't "math.ln=math.log" at the start of every file

### DIFF
--- a/spec/translator_spec.lua
+++ b/spec/translator_spec.lua
@@ -35,10 +35,6 @@ end)
 local function assert_translation(pallene_code, expected)
     assert(compile("__translation_test__.pln", pallene_code))
     local contents = assert(util.get_file_contents("__translation_test__.lua"))
-    -- The introduction of math.ln in Pallene to workaround single param math.log requires emitted
-    -- Lua code to handle this as well. The current workaround injects "math.ln = math.log; " at
-    -- the beginning of the emited Lua. This function needs to account for this injection.
-    expected = "math.ln = math.log; " .. expected
     assert.are.same(expected, contents)
 end
 


### PR DESCRIPTION
It cluttered the start of *every* file, for something that was a corner case. I've replaced it with a simple gsub for math.ln-->math.log. It's not perfect, but should be good enough until we can get rid of math.ln.