### PR TITLE
Remove gratuitous parentheses in examples

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -195,7 +195,7 @@ As an example, consider the same `sum_list` function from above written without 
 local function iter(arr: {any}, prev: integer): (any, any)
     local i = prev + 1
     local x = arr[i]
-    if x == (nil as any) then
+    if x == nil as any then
         return nil, nil
     end
 
@@ -260,8 +260,8 @@ Pallene also allows you to downcast from `any` to other types.
 This is checked at run-time, and may result in a run-time type error.
 
 ```lua
-local v = (17 as any)
-local s = (v as string)  -- run-time error: v is not a string
+local v = 17 as any
+local s = v as string  -- run-time error: v is not a string
 ```
 
 The `any` type allows for a limited form of dynamic typing.
@@ -280,7 +280,7 @@ The reason for this is that, for performance, Pallene must know at compile-time 
 
 ```lua
 local function f(x: any, y: any): integer
-    return (x as integer) + (y as integer)
+    return x as integer + y as integer
 end
 ```
 
@@ -405,7 +405,7 @@ For expressions the colon is already used for method calls, so Pallene uses the 
 
 ```lua
 function foo(x : any) : integer
-   local y: integer = (x as integer)
+   local y: integer = x as integer
    return y + y
 end
 ```


### PR DESCRIPTION
Of course, ignore this suggestion if you want to keep the parenthesis for stylistic reasons. But to me they add noise and beg the question “are they needed?” (I had to test to learn that they are not).

Perhaps the “operator precedence” of `as` should be documented in the manual?