### PR TITLE
Fix test failues due to C99 warning on macos (Apple clang)

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -20,7 +20,7 @@ FLAGS=(--verbose --no-keep-going)
 
 # To speed things up, we tell the C compiler to skip optimizations. (It's OK, the CI still uses -O2)
 # Also, add some compiler flags to verify standard compliance.
-export CFLAGS="-O0 -std=c99 -Wall -Werror -Wundef -Wno-unused $EXTRACFLAGS"
+export CFLAGS="-O0 -std=c99 -Wall -Werror -Wundef -Wno-unused -Wno-typedef-redefinition $EXTRACFLAGS"
 
 if [ "$#" -eq 0 ]; then
     if command -v parallel >/dev/null; then


### PR DESCRIPTION
This is needed to prevent complilation failure on macos (Apple clang). Exemple of the failure message is shown below.

I guess another option is to avoid the CallInfo redefinitiion on `luacore.h` line 2386 to make in C99 compliant?

```
◼
0 successes / 1 failure / 0 errors / 0 pending : 0.202854 seconds

Failure → spec/traceback_spec.lua @ 31
Rectangle
spec/traceback_spec.lua:11: command failed: pallenec spec/traceback/rect/rect.pln --use-traceback

stack traceback:
        spec/traceback_spec.lua:11: in upvalue 'assert_test'
        spec/traceback_spec.lua:32: in function <spec/traceback_spec.lua:31>

In file included from /tmp/lua_fLecVi:12:
/Users/bjorn/repos/lua/pallene/.localua/include/luacore.h:2386:25: error: redefinition of typedef 'CallInfo' is a C11 feature [-Werror,-Wtypedef-redefinition]
 2386 | typedef struct CallInfo CallInfo;
      |                         ^
/Users/bjorn/repos/lua/pallene/.localua/include/luacore.h:3:25: note: previous definition is here
    3 | typedef struct CallInfo CallInfo;
      |                         ^
1 error generated.
internal error: compiler failed
compilation line: cc -fPIC -O0 -std=c99 -Wall -Werror -Wundef -Wno-unused  -x c -o /tmp/lua_ASuPlq -c /tmp/lua_fLecVi
```