### PR TITLE
Test script portability

### DIFF
--- a/run-lint
+++ b/run-lint
@@ -25,24 +25,24 @@ for file in \
     examples/*/*.lua  \
     examples/*/*.pln
 do
-    if grep --line-number "[$space$tab]$" "$file"; then
+    if grep -n "[$space$tab]$" "$file"; then
         # Forbid trailing whitespace because some editors like to automatically delete it.
         # Such whitespace can cause spurious diffs later down the road, when someone is working on
         # an unrelated pull request and their editor "helpfully" deletes the trailing whitespace.
         error "File $file has a line that ends in whitespace"
     fi
 
-    if grep --line-number "^$space*$tab" "$file"; then
+    if grep -n "^$space*$tab" "$file"; then
         # Standardize on spaces because mixing tabs and spaces is endless pain.
         error "File $file has tab-based indentation"
     fi
 
-    if ! grep --line-number --quiet 'SPDX-License-Identifier' "$file"; then
+    if ! grep -q 'SPDX-License-Identifier' "$file"; then
         error "File $file is missing a copyright header"
     fi
 done
 
-if grep --line-number -E \
+if grep -n -E \
     "^[$space$tab]*self:(check_exp|check_var|check_initializer)" \
     src/pallene/typechecker.lua;
 then

--- a/run-tests
+++ b/run-tests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # HOW TO USE: This is a wrapper around busted. Pass "gc" as the first argument for testing the
 # garbage collector. Except for "gc", the command-line arguments are the same of busted
@@ -16,7 +16,7 @@ echo "--- Test Suite ---"
 # Ctrl-C multiple times and one of those Ctrl-C's will likely kill the busted process itself,
 # meaning that the "teardown" routines are not run. On the other hand, with --no-keep-going we only
 # need to press Ctrl-C once and busted usually gets to exit gracefully.
-FLAGS=(--verbose --no-keep-going)
+FLAGS="--verbose --no-keep-going"
 
 # To speed things up, we tell the C compiler to skip optimizations. (It's OK, the CI still uses -O2)
 # Also, add some compiler flags to verify standard compliance.
@@ -24,15 +24,15 @@ export CFLAGS="-O0 -std=c99 -Wall -Werror -Wundef -Wno-unused $EXTRACFLAGS"
 
 if [ "$#" -eq 0 ]; then
     if command -v parallel >/dev/null; then
-        parallel busted -o utfTerminal "${FLAGS[@]}" ::: spec/*_spec.lua
+        parallel busted -o utfTerminal ${FLAGS} ::: spec/*_spec.lua
     else
         echo "GNU Parallel is not installed. Running the test suite in single threaded mode..."
-        busted "${FLAGS[@]}"
+        busted ${FLAGS}
     fi
     # By default, also run the linter because the CI cares about that.
     ./run-lint --quiet
 else
     # If we are running tests for a single spec file, then we do not use GNU Parallel. This way the
     # progress updates after each test, instead of all at once at end.
-    busted "${FLAGS[@]}" "$@"
+    busted ${FLAGS} "$@"
 fi


### PR DESCRIPTION
Changes avoiding bash-specifics and GNU extensions for `grep`.

These now run on, for example, Alpine Linux (with BusyBox `grep`) and with `dash` shell.