### PR TITLE
Introducing new IR commands RenormArr and Nop

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,48 @@
+#!/bin/bash
+eval "$(luarocks path)"
+export PATH="$(pwd)/src/bin/:$PATH"
+export LUA_PATH="$(pwd)/src/?.lua;$LUA_PATH"
+export CFLAGS='-O2 -std=c99 -Wall -Werror -Wundef -Wpedantic -Wno-unused'
+
+function count_stack_saves() {
+    file="$1"
+    grep -Eo 'set[^\n]*\( *L *, *s2v\( *base' "$file" | wc -l
+}
+
+function is_in() {
+    element="$1"
+    shift
+    list="$*"
+    found=false
+    for e in $list; do
+        [ "$e" = "$element" ] && found=true && break
+    done
+    $found
+}
+
+if [ "$1" = "test" ]; then
+    shift
+    ./run-tests "$@"
+elif [ "$1" = "testgc" ]; then
+    shift
+    EXTRACFLAGS="-DHARDMEMTESTS" ./run-tests "$@"
+else
+
+    file="$1"
+    shift
+
+    lint_cmd="./run-lint -q"
+    run_cmd="lua lua_$file.lua"
+    flags=''
+    is_in c      $* && flags="$flags --emit-c" && run_cmd=true
+    is_in ir     $* && flags="$flags --print-ir"
+    is_in O0     $* && flags="$flags -O0"
+    is_in trace  $* && flags="$flags --use-traceback"
+    is_in gc     $* && CFLAGS='-O4 -DHARDMEMTESTS'
+    is_in nolint $* && lint_cmd=true
+    is_in norun  $* && run_cmd=true
+
+    $lint_cmd &&
+        pallenec $flags "$file".pln &&
+        $run_cmd
+fi

--- a/src/pallene/print_ir.lua
+++ b/src/pallene/print_ir.lua
@@ -122,9 +122,7 @@ local function Cmd(cmd)
     local tag = cmd._tag
 
     local lhs
-    if     tag == "ir.Cmd.Nop" then
-        return "nop"
-    elseif tag == "ir.Cmd.Return" then
+    if tag == "ir.Cmd.Return" then
         return "return " .. comma_concat(Vals(cmd.srcs))
     elseif tag == "ir.Cmd.SetArr"      then lhs = Bracket(cmd.src_arr, cmd.src_i)
     elseif tag == "ir.Cmd.SetTable"    then lhs = Bracket(cmd.src_tab, cmd.src_k)
@@ -154,6 +152,7 @@ local function Cmd(cmd)
     elseif tag == "ir.Cmd.JmpIf" then
         rhs = "jmpIf " .. Val(cmd.src_cond) .. ", " .. cmd.target_true .. ", " .. cmd.target_false
     elseif tag == "ir.Cmd.Jmp" then rhs = "jmp " .. cmd.target
+    elseif tag == "ir.Cmd.Nop" then rhs = "nop"
     elseif tagged_union.typename(cmd._tag) == "ir.Cmd" then
         local name = tagged_union.consname(cmd._tag)
         rhs = Call(name, Vals(ir.get_srcs(cmd)))


### PR DESCRIPTION
Introducing RenormArr so we can control through the intermediate representation when array renormalization happens. Both RenormArr and Nop will be important later when we start implementing renormalization--related optimizations.