### PR TITLE
Add the `types.T.Alias` type

### DIFF
--- a/spec/typechecker_spec.lua
+++ b/spec/typechecker_spec.lua
@@ -92,27 +92,27 @@ describe("Module", function()
         assert_error([[
             function m.f() end
             function m.f() end
-        ]], "multiple definitions for module field 'f'")
+        ]], "the module field 'f' is being shadowed")
     end)
 
     it("forbids repeated exported names (function / variable)", function()
         assert_error([[
             function m.f() end
             m.f = 1
-        ]], "multiple definitions for module field 'f'")
+        ]], "the module field 'f' is being shadowed")
     end)
 
     it("forbids repeated exported names (variable / variable)", function()
         assert_error([[
             m.x = 10
             m.x = 20
-        ]], "multiple definitions for module field 'x'")
+        ]], "the module field 'x' is being shadowed")
     end)
 
     it("forbids repeated exported names (in multiple assignment)", function()
         assert_error([[
             m.x, m.x = 10, 20
-        ]], "multiple definitions for module field 'x'")
+        ]], "the module field 'x' is being shadowed")
     end)
 
     it("ensures that exported variables are not in scope in their initializers", function()
@@ -142,6 +142,37 @@ describe("Typealias", function()
         ]], "'t' is not a type")
     end)
 
+    it("must not be shadowed by other typealias names", function()
+        assert_error([[
+            typealias point = {x: integer, y: integer}
+            typealias point = {x: float, y: float}
+        ]], "the type 'point' is being shadowed")
+    end)
+
+    it("must not be shadowed by record names", function()
+        assert_error([[
+            typealias point = {x: float, y: float}
+            record point
+                x: integer
+                y: integer
+            end
+        ]], "the type 'point' is being shadowed")
+    end)
+
+    it("must not be shadowed by module field names", function()
+        assert_error([[
+            typealias x = integer
+            m.x = 10
+        ]], "the type 'x' is being shadowed")
+    end)
+
+    it("must not be shadowed by function names", function()
+        assert_error([[
+            typealias f = integer
+            function m.f() end
+        ]], "the type 'f' is being shadowed")
+    end)
+
 end)
 
 describe("Record declaration", function()
@@ -153,6 +184,49 @@ describe("Record declaration", function()
                 x: float
             end
         ]], "duplicate field name 'x' in record type")
+    end)
+
+    it("must not be shadowed by other record names", function()
+        assert_error([[
+            record Point
+                x: integer
+                y: integer
+            end
+            record Point
+                x: float
+                y: float
+            end
+        ]], "the type 'Point' is being shadowed")
+    end)
+
+    it("must not be shadowed by typealias names", function()
+        assert_error([[
+            record Point
+                x: integer
+                y: integer
+            end
+            typealias Point = {x: float, y: float}
+        ]], "the type 'Point' is being shadowed")
+    end)
+
+    it("must not be shadowed by module field names", function()
+        assert_error([[
+            record P
+                x: integer
+                y: integer
+            end
+            m.P = 10
+        ]], "the type 'P' is being shadowed")
+    end)
+
+    it("must not be shadowed by function names", function()
+        assert_error([[
+            record P
+                x: integer
+                y: integer
+            end
+            function m.P() end
+        ]], "the type 'P' is being shadowed")
     end)
 
 end)
@@ -193,6 +267,71 @@ describe("Function declaration", function()
                 return 5319
             end
         ]], "function 'f' was not forward declared")
+    end)
+
+    it("must not be shadowed by typealias names", function()
+        assert_error([[
+            function m.f() end
+            typealias f = integer
+        ]], "the module field 'f' is being shadowed")
+    end)
+
+    it("must not be shadowed by record names", function()
+        assert_error([[
+            function m.f() end
+            record f
+                x: integer
+                y: integer
+            end
+        ]], "the module field 'f' is being shadowed")
+    end)
+
+    it("must not be shadowed by module field names", function()
+        assert_error([[
+            function m.f() end
+            m.f = 10
+        ]], "the module field 'f' is being shadowed")
+    end)
+
+    it("must not be shadowed by function names", function()
+        assert_error([[
+            function m.f() end
+            function m.f() end
+        ]], "the module field 'f' is being shadowed")
+    end)
+
+end)
+
+describe("Module fields", function()
+
+    it("must not be shadowed by typealias names", function()
+        assert_error([[
+            m.x = 10
+            typealias x = integer
+        ]], "the module field 'x' is being shadowed")
+    end)
+
+    it("must not be shadowed by record names", function()
+        assert_error([[
+            m.x = 10
+            record x
+                y: integer
+            end
+        ]], "the module field 'x' is being shadowed")
+    end)
+
+    it("must not be shadowed by function names", function()
+        assert_error([[
+            m.f = 10
+            function m.f() end
+        ]], "the module field 'f' is being shadowed")
+    end)
+
+    it("must not be shadowed by module field names", function()
+        assert_error([[
+            m.x = 10
+            m.x = 20
+        ]], "the module field 'x' is being shadowed")
     end)
 
 end)

--- a/spec/types_spec.lua
+++ b/spec/types_spec.lua
@@ -119,6 +119,21 @@ describe("Pallene types", function()
             local t2 = types.T.Record("P", {}, {}, false)
             assert.falsy(types.equals(t1, t2))
         end)
+
+        it("is true for similar type aliases", function()
+            local ta1 = types.T.Alias("A", types.T.Integer)
+            local ta2 = types.T.Alias("B", types.T.Integer)
+            assert.truthy(types.equals(ta1, ta2))
+        end)
+
+        it("should expand type aliases", function()
+            local ta = types.T.Alias("A", types.T.Integer)
+
+            assert.truthy(types.equals(
+                ta,
+                types.T.Integer
+            ))
+        end)
     end)
 
     describe("consistency", function()
@@ -161,5 +176,50 @@ describe("Pallene types", function()
                 types.T.Function({types.T.Integer},{types.T.Integer})
             ))
         end)
+
+        it("should be true for type aliases whose types are consistent", function()
+            local ta1 = types.T.Alias("A", types.T.Any)
+            local ta2 = types.T.Alias("B", types.T.Integer)
+            local ta3 = types.T.Alias("C", types.T.String)
+
+            assert.truthy(types.consistent(ta1, ta2))
+            assert.truthy(types.consistent(ta1, ta3))
+            assert.falsy(types.consistent(ta2, ta3))
+        end)
+
+        it("should expand type aliases", function()
+            local ta = types.T.Alias("A", types.T.Integer)
+
+            assert.truthy(types.consistent(
+                ta,
+                types.T.Integer
+            ))
+
+            assert.falsy(types.consistent(
+                ta,
+                types.T.String
+            ))
+        end)
     end)
+
+    describe("type aliases", function()
+
+        it("should recursively expand type aliases", function()
+            local ta1 = types.T.Alias("A", types.T.Integer)
+            local ta2 = types.T.Alias("B", ta1)
+            local ta3 = types.T.Alias("C", ta2)
+
+            assert.truthy(types.expand_typealias(ta3) == types.T.Integer)
+        end)
+
+        it("should be considered equal to the expanded type", function()
+            local ta1 = types.T.Alias("A", types.T.Integer)
+
+            assert.truthy(types.equals(
+                ta1,
+                types.T.Integer
+            ))
+        end)
+    end)
+
 end)

--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -1744,6 +1744,7 @@ end
 
 gen_cmd["ForStep"] = function(self, args)
     local typ = args.func.vars[args.cmd.dst_i].typ
+
     local macro
     if     typ._tag == "types.T.Integer" then
         macro = "PALLENE_INT_FOR_STEP"

--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -47,7 +47,6 @@ end
 -- @param typ : types.T
 -- @returns the correspoinding C type, as a string.
 local function ctype(typ)
-    local typ = types.expand_typealias(typ)
     local tag = typ._tag
     if     tag == "types.T.Nil"      then return "int"
     elseif tag == "types.T.Boolean"  then return "char"
@@ -100,7 +99,6 @@ end
 
 -- @param src_slot: The TValue* to read from
 local function lua_value(typ, src_slot)
-    local typ = types.expand_typealias(typ)
     local tmpl
     local tag = typ._tag
     if     tag == "types.T.Nil"      then tmpl = "0"
@@ -131,7 +129,6 @@ end
 -- Set a TValue* slot that is in the Lua or C stack.
 -- @param typ: type of source value
 local function set_stack_slot(typ, dst_slot, value)
-    local typ = types.expand_typealias(typ)
     local tmpl
     local tag = typ._tag
     if     tag == "types.T.Nil"      then tmpl = "setnilvalue($dst);"
@@ -151,7 +148,6 @@ local function set_stack_slot(typ, dst_slot, value)
 end
 
 local function opt_gc_barrier(typ, value, parent)
-    local typ = types.expand_typealias(typ)
     if types.is_gc(typ) then
         if typ._tag == "types.T.Any" or typ._tag == "types.T.Function" then
             local tmpl = "luaC_barrierback(L, obj2gco($p), &$v);"
@@ -186,7 +182,6 @@ end
 --
 
 local function pallene_type_tag(typ)
-    local typ = types.expand_typealias(typ)
     local tag = typ._tag
     if     tag == "types.T.Nil"      then return "nil"
     elseif tag == "types.T.Boolean"  then return "boolean"
@@ -203,7 +198,6 @@ local function pallene_type_tag(typ)
 end
 
 function Coder:test_tag(typ, slot)
-    local typ = types.expand_typealias(typ)
     local tmpl
     local tag = typ._tag
     if     tag == "types.T.Nil"      then tmpl = "ttisnil($slot)"
@@ -304,7 +298,6 @@ end
 function Coder:get_luatable_slot(typ, dst, slot, tab, loc, description_fmt, ...)
 
     local parts = {}
-    local typ = types.expand_typealias(typ)
 
     table.insert(parts,
         self:get_stack_slot(typ, dst, slot, loc, description_fmt, ...))
@@ -516,7 +509,6 @@ function Coder:pallene_entry_point_definition(f_id)
             -- field uninitialized and the C compiler doesn't like that because it means that a setobj
             -- may read from uninitialized memory.
             local typ, c_name, comment = self:prepare_local_var(func, v_id)
-            typ = types.expand_typealias(typ)
             local decl = C.declaration(ctype(typ), c_name)
             local initializer = (typ._tag == "types.T.Any") and " = {{0},0}" or ""
             table.insert(parts, decl..initializer..";"..comment)
@@ -1727,7 +1719,6 @@ end
 
 gen_cmd["ForPrep"] = function(self, args)
     local typ = args.func.vars[args.cmd.dst_i].typ
-    typ = types.expand_typealias(typ)
     local macro
     if     typ._tag == "types.T.Integer" then
         macro = "PALLENE_INT_FOR_PREP"
@@ -1753,7 +1744,6 @@ end
 
 gen_cmd["ForStep"] = function(self, args)
     local typ = args.func.vars[args.cmd.dst_i].typ
-    typ = types.expand_typealias(typ)
     local macro
     if     typ._tag == "types.T.Integer" then
         macro = "PALLENE_INT_FOR_STEP"

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -47,9 +47,9 @@ end
 
 function to_ir.convert(prog_ast)
     assert(prog_ast._tag == "ast.Program.Program")
-    local prog_ast = util.expand_type_aliases(prog_ast)
+    local alias_free_prog_ast = util.expand_type_aliases(prog_ast)
     local ok, ret = trycatch.pcall(function()
-        return ToIR.new():convert_toplevel(prog_ast.tls)
+        return ToIR.new():convert_toplevel(alias_free_prog_ast.tls)
     end)
 
     if not ok then

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -45,11 +45,9 @@ local function ir_error(loc, fmt, ...)
     trycatch.error("to_ir", msg)
 end
 
-local expand_type_aliases = util.expand_type_aliases
-
 function to_ir.convert(prog_ast)
     assert(prog_ast._tag == "ast.Program.Program")
-    expand_type_aliases(prog_ast, {})
+    local prog_ast = util.expand_type_aliases(prog_ast)
     local ok, ret = trycatch.pcall(function()
         return ToIR.new():convert_toplevel(prog_ast.tls)
     end)

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -45,8 +45,11 @@ local function ir_error(loc, fmt, ...)
     trycatch.error("to_ir", msg)
 end
 
+local expand_type_aliases = util.expand_type_aliases
+
 function to_ir.convert(prog_ast)
     assert(prog_ast._tag == "ast.Program.Program")
+    expand_type_aliases(prog_ast, {})
     local ok, ret = trycatch.pcall(function()
         return ToIR.new():convert_toplevel(prog_ast.tls)
     end)

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -729,17 +729,17 @@ function Typechecker:check_var(var)
 end
 
 local function is_numeric_type(typ)
-    local typ = types.expand_typealias(typ)
-    return typ._tag == "types.T.Integer" or typ._tag == "types.T.Float"
+    local actual_type = types.expand_typealias(typ)
+    return actual_type._tag == "types.T.Integer" or actual_type._tag == "types.T.Float"
 end
 
 function Typechecker:coerce_numeric_exp_to_float(exp)
-    local aliased_tag = types.expand_typealias(exp._type)._tag
-    if     aliased_tag == "types.T.Float" then
+    local actual_tag = types.expand_typealias(exp._type)._tag
+    if     actual_tag == "types.T.Float" then
         return exp
-    elseif aliased_tag == "types.T.Integer" then
+    elseif actual_tag == "types.T.Integer" then
         return self:check_exp_synthesize(ast.Exp.ToFloat(exp.loc, exp))
-    elseif tagged_union.typename(aliased_tag) == "types.T" then
+    elseif tagged_union.typename(actual_tag) == "types.T" then
         -- Cannot be coerced to float
         assert(false)
     else

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -156,7 +156,7 @@ function Typechecker:export_value_symbol(name, typ, def)
     assert(type(name) == "string")
     assert(tagged_union.typename(typ._tag) == "types.T")
     assert(self.module_symbol)
-    self:check_exported_symbol_shadowing(name, loc_of_def(def))
+    self:assert_exported_symbol_unused(name, loc_of_def(def))
     self.module_symbol.symbols[name] = typechecker.Symbol.Value(typ, def)
 end
 
@@ -164,11 +164,11 @@ function Typechecker:export_type_symbol(name, typ, loc)
     assert(type(name) == "string")
     assert(tagged_union.typename(typ._tag) == "types.T")
     assert(self.module_symbol)
-    self:check_exported_symbol_shadowing(name, loc)
+    self:assert_exported_symbol_unused(name, loc)
     self.module_symbol.symbols[name] = typechecker.Symbol.Type(typ)
 end
 
-function Typechecker:check_exported_symbol_shadowing(name, loc)
+function Typechecker:assert_exported_symbol_unused(name, loc)
     assert(type(name) == "string")
     local sym = self.module_symbol.symbols[name]
     if sym then

--- a/src/pallene/types.lua
+++ b/src/pallene/types.lua
@@ -28,9 +28,9 @@ define_union("T", {
     Alias    = {"name", "type"},
 })
 
-function types.is_gc(t)
-    local t = types.expand_typealias(t)
-    local tag = t._tag
+function types.is_gc(typ)
+    local actual_type = types.expand_typealias(typ)
+    local tag = actual_type._tag
     if     tag == "types.T.Nil" or
            tag == "types.T.Boolean" or
            tag == "types.T.Integer" or
@@ -52,9 +52,9 @@ function types.is_gc(t)
     end
 end
 
-function types.is_condition(t)
-    local t = types.expand_typealias(t)
-    local tag = t._tag
+function types.is_condition(typ)
+    local actual_type = types.expand_typealias(typ)
+    local tag = actual_type._tag
     if     tag == "types.T.Any" or
            tag == "types.T.Boolean"
     then
@@ -77,9 +77,9 @@ function types.is_condition(t)
 
 end
 
-function types.is_indexable(t)
-    local t = types.expand_typealias(t)
-    local tag = t._tag
+function types.is_indexable(typ)
+    local actual_type = types.expand_typealias(typ)
+    local tag = actual_type._tag
     if     tag == "types.T.Table" or
            tag == "types.T.Record"
     then
@@ -101,14 +101,14 @@ function types.is_indexable(t)
     end
 end
 
-function types.indices(t)
-    local t = types.expand_typealias(t)
-    local tag = t._tag
+function types.indices(typ)
+    local actual_type = types.expand_typealias(typ)
+    local tag = actual_type._tag
     if     tag == "types.T.Table" then
-        return t.fields
+        return actual_type.fields
 
     elseif tag == "types.T.Record" then
-        return t.field_types
+        return actual_type.field_types
 
     elseif tagged_union.typename(tag) == "types.T" then
         -- Not indexable
@@ -120,10 +120,10 @@ function types.indices(t)
 end
 
 function types.equals(t1, t2)
-    local t1 = types.expand_typealias(t1)
-    local t2 = types.expand_typealias(t2)
-    local tag1 = t1._tag
-    local tag2 = t2._tag
+    local rt1 = types.expand_typealias(t1)
+    local rt2 = types.expand_typealias(t2)
+    local tag1 = rt1._tag
+    local tag2 = rt2._tag
 
     assert(tagged_union.typename(tag1) == "types.T")
     assert(tagged_union.typename(tag2) == "types.T")
@@ -141,11 +141,11 @@ function types.equals(t1, t2)
         return true
 
     elseif tag1 == "types.T.Array" then
-        return types.equals(t1.elem, t2.elem)
+        return types.equals(rt1.elem, rt2.elem)
 
     elseif tag1 == "types.T.Table" then
-        local f1 = t1.fields
-        local f2 = t2.fields
+        local f1 = rt1.fields
+        local f2 = rt2.fields
 
         for name in pairs(f1) do
             if not f2[name] then
@@ -168,22 +168,22 @@ function types.equals(t1, t2)
         return true
 
     elseif tag1 == "types.T.Function" then
-        if #t1.arg_types ~= #t2.arg_types then
+        if #rt1.arg_types ~= #rt2.arg_types then
             return false
         end
 
-        for i = 1, #t1.arg_types do
-            if not types.equals(t1.arg_types[i], t2.arg_types[i]) then
+        for i = 1, #rt1.arg_types do
+            if not types.equals(rt1.arg_types[i], rt2.arg_types[i]) then
                 return false
             end
         end
 
-        if #t1.ret_types ~= #t2.ret_types then
+        if #rt1.ret_types ~= #rt2.ret_types then
             return false
         end
 
-        for i = 1, #t1.ret_types do
-            if not types.equals(t1.ret_types[i], t2.ret_types[i]) then
+        for i = 1, #rt1.ret_types do
+            if not types.equals(rt1.ret_types[i], rt2.ret_types[i]) then
                 return false
             end
         end
@@ -192,7 +192,7 @@ function types.equals(t1, t2)
 
     elseif tag1 == "types.T.Record" then
         -- Record types are nominal
-        return t1 == t2
+        return rt1 == rt2
 
     else
         return tagged_union.error(tag1,
@@ -204,12 +204,12 @@ end
 -- We forbid type casts that are 100% guaranteed to fail, e.g. int=>string.
 -- This is looser than the consistency requirement from gradual typing.
 function types.consistent(t1, t2)
-    local t1 = types.expand_typealias(t1)
-    local t2 = types.expand_typealias(t2)
+    local rt1 = types.expand_typealias(t1)
+    local rt2 = types.expand_typealias(t2)
     return (
-        t1._tag == "types.T.Any" or
-        t2._tag == "types.T.Any" or
-        t1._tag == t2._tag)
+        rt1._tag == "types.T.Any" or
+        rt2._tag == "types.T.Any" or
+        rt1._tag == rt2._tag)
 end
 
 local function join_type_list(list)
@@ -258,9 +258,9 @@ function types.tostring(t)
     end
 end
 
-local function is_optional(t)
-    local t = types.expand_typealias(t)
-    return t._tag == 'types.T.Any' or t._tag == "types.T.Nil"
+local function is_optional(typ)
+    local actual_type = types.expand_typealias(typ)
+    return actual_type._tag == 'types.T.Any' or actual_type._tag == "types.T.Nil"
 end
 
 -- The rightmost arguments to a function may be optional.
@@ -274,6 +274,9 @@ function types.number_of_mandatory_args(argtypes)
     return n
 end
 
+-- Recursively expand/resolve all type aliases until we reach a non-alias type.
+-- Input: a type belonging to the types.T namespace
+-- Output: a non-alias type
 function types.expand_typealias(type)
     if type._tag == "types.T.Alias" then
         return types.expand_typealias(type.type)

--- a/src/pallene/types.lua
+++ b/src/pallene/types.lua
@@ -282,4 +282,40 @@ function types.expand_typealias(type)
     end
 end
 
+-- This metatable adds the possibility for the actual-nominal type pair
+-- to be accessed through table fields instead of indexes
+local ACTUAL_NOMINAL_MT = {
+    __index = function(tbl, key)
+        if key == "actual" then
+            return tbl[1]
+        elseif key == "nominal" then
+            return tbl[2]
+        end
+        return nil
+    end
+}
+
+-- Returns a table with the following fields:
+-- * actual (index 1): the resolved type
+-- * nominal (index 2): the declared type
+--
+-- Since it has indexes, it can either be deconstructed
+--
+-- i.e.:
+-- ```
+-- local actual, nominal = table.unpack(types.resolve_type(some_type))
+-- ```
+-- or be accessed directly via the table fields
+--
+-- i.e.:
+-- ```
+-- local detailed_type = types.resolve_type(some_type)
+-- local actual = detailed_type.actual
+-- local nominal = detailed_type.nominal
+-- ```
+function types.resolve_type(type)
+    local actual_nominal_pair = {types.expand_typealias(type), type}
+    return setmetatable(actual_nominal_pair, ACTUAL_NOMINAL_MT)
+end
+
 return types

--- a/src/pallene/types.lua
+++ b/src/pallene/types.lua
@@ -285,40 +285,21 @@ function types.expand_typealias(type)
     end
 end
 
--- This metatable adds the possibility for the actual-nominal type pair
--- to be accessed through table fields instead of indexes
-local ACTUAL_NOMINAL_MT = {
-    __index = function(tbl, key)
-        if key == "actual" then
-            return tbl[1]
-        elseif key == "nominal" then
-            return tbl[2]
-        end
-        return nil
-    end
-}
-
 -- Returns a table with the following fields:
--- * actual (index 1): the resolved type
--- * nominal (index 2): the declared type
+-- * actual: the resolved type
+-- * nominal: the declared type
 --
--- Since it has indexes, it can either be deconstructed
---
--- i.e.:
--- ```
--- local actual, nominal = table.unpack(types.resolve_type(some_type))
--- ```
--- or be accessed directly via the table fields
---
--- i.e.:
+-- Example:
 -- ```
 -- local detailed_type = types.resolve_type(some_type)
 -- local actual = detailed_type.actual
 -- local nominal = detailed_type.nominal
 -- ```
 function types.resolve_type(type)
-    local actual_nominal_pair = {types.expand_typealias(type), type}
-    return setmetatable(actual_nominal_pair, ACTUAL_NOMINAL_MT)
+    return {
+        actual  = types.expand_typealias(type),
+        nominal = type
+    }
 end
 
 return types

--- a/src/pallene/util.lua
+++ b/src/pallene/util.lua
@@ -126,4 +126,23 @@ function util.Class()
     return cls
 end
 
+function util.expand_type_aliases(ast_node, visited)
+    local types = require "pallene.types"
+    visited = visited or {}
+    if type(ast_node) ~= "table" or visited[ast_node] then
+        return
+    end
+    visited[ast_node] = true
+    if ast_node._type then
+        local alias = ast_node._type
+        ast_node._type = types.expand_typealias(alias)
+        assert(ast_node._type, "Failed to expand type alias" .. types.tostring(alias))
+    end
+    for k, v in pairs(ast_node) do
+        if type(v) == "table" then
+            util.expand_type_aliases(v, visited)
+        end
+    end
+end
+
 return util

--- a/src/pallene/util.lua
+++ b/src/pallene/util.lua
@@ -148,7 +148,7 @@ function util.expand_type_aliases(ast_node, visited)
             this[k] = util.expand_type_aliases(v, visited)
         end
     end
-    
+
     return this
 end
 


### PR DESCRIPTION
## Description 

With the purpose of being able to retrieve aliased types in the AST, we've introduced the new `Alias` type to the `types.T` namespace.

Since we have the goal of being able to generate a type declaration file from a valid Pallene program, we are now forbidding exported symbols from shadowing each other. It is a measure for improving such files' consistency, so that their types don't mean different things depending on the reading order of the declarations.

## Changes summary

### Type shadowing prevention

* Added checks to prevent typealiases, records, functions, and module fields from shadowing each other’s names. The typechecker now raises descriptive errors when such shadowing occurs, and new tests have been added to verify these rules (`spec/typechecker_spec.lua`). [[1]](diffhunk://#diff-e371010d4be0af6088a5f850db598cb3515500048063e01d1b5ad8e57ff9c79fR145-R175) [[2]](diffhunk://#diff-e371010d4be0af6088a5f850db598cb3515500048063e01d1b5ad8e57ff9c79fR189-R231) [[3]](diffhunk://#diff-e371010d4be0af6088a5f850db598cb3515500048063e01d1b5ad8e57ff9c79fR272-R336)
* Refactored type symbol export logic in `Typechecker` to use a new `export_type_symbol` method and a unified `check_exported_symbol_shadowing` function for consistent error handling. [[1]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L159-R184) [[2]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L266-R288) [[3]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6R303)

### Type alias expansion and comparison

* Updated the typechecker to consistently resolve and expand type aliases when checking types (e.g., in conditions, for-loops, function calls, and variable indexing), ensuring correct type comparisons and error messages. [[1]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L79-R84) [[2]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L381-R425) [[3]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6R454-R460) [[4]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L447-R486) [[5]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L709-R739) [[6]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L725-R762) [[7]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L754-R789) [[8]](diffhunk://#diff-6a62295852ef07bf09924550cd268b60a1dfe7c221533febda49e3fbc10a39b6L801-R838)
* Added new tests to verify that type aliases are correctly expanded and compared for equality and consistency, including recursive expansion. (`spec/types_spec.lua`) [[1]](diffhunk://#diff-14659c78e6badf6893fd91371759d94605bef28c20e63e5613201067fa1da601R122-R136) [[2]](diffhunk://#diff-14659c78e6badf6893fd91371759d94605bef28c20e63e5613201067fa1da601R179-R224)

### IR conversion and code generation

* Modified IR conversion to expand type aliases before processing, ensuring the IR operates on fully-resolved types. (`src/pallene/to_ir.lua`)
* Minor cleanup in code generation for for-loops, removing unnecessary blank lines. (`src/pallene/coder.lua`)