### PR TITLE
Add require statement

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -951,6 +951,14 @@ describe("Parser /", function()
             }, tl)
         end)
 
+        it("forbids require as toplevel assignment", function()
+            assert_program_error([[
+                local m = {}
+                m.foo = require("bar")
+                return m
+            ]], "calls to require are only allowed in toplevel declarations")
+        end)
+
         it("forbids require after a function definition", function()
             assert_program_error([[
                 local m = {}

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -906,6 +906,120 @@ describe("Parser /", function()
 
     end)
 
+    --
+    -- Require
+    --
+
+    describe("Require statements", function()
+
+        it("produces an ast.Toplevel.Require node", function()
+            local prog_ast = assert_parses_successfuly([[
+                local m = {}
+                local foo = require("bar")
+                return m
+            ]])
+            local tl = prog_ast.tls[1]
+            assert_is_subset({
+                _tag = "ast.Toplevel.Require",
+                local_name_decl = { _tag = "ast.Decl.Decl", name = "foo" },
+                module_name_exp = { _tag = "ast.Exp.String", value = "bar" },
+            }, tl)
+        end)
+
+        it("allows multiple requires at the top", function()
+            local prog_ast = assert_parses_successfuly([[
+                local m = {}
+                local a = require("mod_a")
+                local b = require("mod_b")
+                return m
+            ]])
+            assert_is_subset({ _tag = "ast.Toplevel.Require" }, prog_ast.tls[1])
+            assert_is_subset({ _tag = "ast.Toplevel.Require" }, prog_ast.tls[2])
+        end)
+
+        it("forbids require after a function definition", function()
+            assert_program_error([[
+                local m = {}
+                function m.f() end
+                local foo = require("bar")
+                return m
+            ]], "require statements must appear before any other toplevel statement")
+        end)
+
+        it("forbids require after a record definition", function()
+            assert_program_error([[
+                local m = {}
+                record R
+                    x: integer
+                end
+                local foo = require("bar")
+                return m
+            ]], "require statements must appear before any other toplevel statement")
+        end)
+
+        it("forbids require after a typealias definition", function()
+            assert_program_error([[
+                local m = {}
+                typealias T = integer
+                local foo = require("bar")
+                return m
+            ]], "require statements must appear before any other toplevel statement")
+        end)
+
+        it("forbids type annotation in require", function()
+            assert_program_error([[
+                local m = {}
+                local foo: integer = require("bar")
+                return m
+            ]], "type annotation is not allowed at require statements")
+        end)
+
+        it("forbids multiple assignment in require", function()
+            assert_program_error([[
+                local m = {}
+                local a, b = require("x"), require("y")
+                return m
+            ]], "cannot use a multiple-assignment in require statements")
+        end)
+
+        it("forbids require with no arguments", function()
+            assert_program_error([[
+                local m = {}
+                local foo = require()
+                return m
+            ]], "require() must be called with exactly one argument")
+        end)
+
+        it("forbids require with multiple arguments", function()
+            assert_program_error([[
+                local m = {}
+                local foo = require("a", "b")
+                return m
+            ]], "require() must be called with exactly one argument")
+        end)
+
+    end)
+
+    --
+    -- Qualified type names
+    --
+
+    describe("Qualified type names", function()
+
+        it("parses mod.Type as QualifiedName", function()
+            assert_type_ast("mod.MyType", {
+                _tag = "ast.Type.QualifiedName",
+                module = "mod",
+                name = "MyType",
+            })
+        end)
+
+    end)
+
+    --
+    -- Type declaration file
+    --
+
     describe("Type declaration file / ", function()
 
         local tdf = [[

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -937,6 +937,20 @@ describe("Parser /", function()
             assert_is_subset({ _tag = "ast.Toplevel.Require" }, prog_ast.tls[2])
         end)
 
+        it("allows require argument without parenthesis", function()
+            local prog_ast = assert_parses_successfuly([[
+                local m = {}
+                local foo = require "bar"
+                return m
+            ]])
+            local tl = prog_ast.tls[1]
+            assert_is_subset({
+                _tag = "ast.Toplevel.Require",
+                local_name_decl = { _tag = "ast.Decl.Decl", name = "foo" },
+                module_name_exp = { _tag = "ast.Exp.String", value = "bar" },
+            }, tl)
+        end)
+
         it("forbids require after a function definition", function()
             assert_program_error([[
                 local m = {}

--- a/spec/typechecker_spec.lua
+++ b/spec/typechecker_spec.lua
@@ -142,27 +142,38 @@ end)
 --
 
 describe("Require", function()
-
-    it("forbids require calls as expressions", function()
-        assert_error([[
-            function m.f()
-                local x = require("foo")
-            end
-        ]], "calls to require are only allowed in toplevel declarations")
-    end)
-
-    it("forbids require calls as expressions", function()
+    it("forbids require calls in toplevel assignments", function()
         assert_error([[
             m.x = require("foo")
         ]], "calls to require are only allowed in toplevel declarations")
     end)
 
     it("forbids non-string argument", function()
-        -- Compile only to typechecker; the parser will produce a Toplevel.Require
-        -- with a non-string exp which the typechecker should reject.
         assert_error([[
-            local x = require(42)
+            local x = require(1)
         ]], "require argument must be a string literal")
+    end)
+
+    it("forbids require calls as expressions", function()
+        assert_error([[
+            function m.f()
+                local x = require("foo")
+            end
+        ]], "the use of 'require' is forbidden here")
+    end)
+
+    it("forbids using require as value", function()
+        assert_error([[
+            local x = require
+        ]], "the use of 'require' is forbidden here")
+    end)
+
+    it("forbids assigning to require", function()
+        assert_error([[
+            local function f()
+                require = 1
+            end
+        ]], "the use of 'require' is forbidden here")
     end)
 
     it("forbids shadowing require as local variable declaration", function()
@@ -178,7 +189,6 @@ describe("Require", function()
             end
         ]], "shadowing of 'require' is not allowed")
     end)
-
 
     it("forbids shadowing require as a function parameter", function()
         assert_error([[
@@ -196,13 +206,18 @@ describe("Require", function()
         ]], "shadowing of 'require' is not allowed")
     end)
 
-    -- TODO: this is breaking because we are not treating this case correctly
-    it("forbids assigning to require", function()
+    it("forbids shadowing require as a typealias name", function()
         assert_error([[
-            local function f()
-                require = 10
+            typealias require = integer
+        ]], "shadowing of 'require' is not allowed")
+    end)
+
+    it("forbids shadowing require as a record name", function()
+        assert_error([[
+            record require
+                x: integer
             end
-        ]], "assignment to 'require' is not allowed")
+        ]], "shadowing of 'require' is not allowed")
     end)
 
     local dep_filename = "__require_dep__.d.pln"

--- a/spec/typechecker_spec.lua
+++ b/spec/typechecker_spec.lua
@@ -34,6 +34,20 @@ local function assert_error(body, expected_err)
     assert.match(expected_err, errs, 1, true)
 end
 
+local function assert_errors(body, expected_err)
+    local module, errs = run_typechecker(util.render([[
+        local m: module = {}
+        $body
+        return m
+    ]], {
+        body = body
+    }))
+    assert.falsy(module)
+    for _, err in ipairs(expected_err) do
+        assert.match(err, errs, 1, true)
+    end
+end
+
 --
 -- Type
 --
@@ -119,6 +133,184 @@ describe("Module", function()
         assert_error([[
             m.x = m.x
         ]], "module field 'x' does not exist")
+    end)
+
+end)
+
+--
+-- Require
+--
+
+describe("Require", function()
+
+    it("forbids require calls inside function bodies", function()
+        assert_error([[
+            function m.f()
+                local x = require("foo")
+            end
+        ]], "calls to require are only allowed in toplevel declarations")
+    end)
+
+    it("forbids require calls as expressions", function()
+        assert_error([[
+            local function foo(m: any) end
+            function m.f()
+                foo(require("bar"))
+            end
+        ]], "calls to require are only allowed in toplevel declarations")
+    end)
+
+    it("forbids non-string argument", function()
+        -- Compile only to typechecker; the parser will produce a Toplevel.Require
+        -- with a non-string exp which the typechecker should reject.
+        assert_error([[
+            local x = require(42)
+        ]], "require argument must be a string literal")
+    end)
+
+    local dep_filename = "__require_dep__.d.pln"
+
+    local function write_type_file(fname, content)
+        local f = assert(io.open(fname, "w"))
+        f:write(content)
+        f:close()
+    end
+
+    describe("with valid .d.pln files", function()
+        setup(function()
+            local dep_content = [[
+                typealias MyInt = integer
+                record Point
+                    x: integer
+                    y: integer
+                end
+                add: (integer, integer) -> integer
+            ]]
+            write_type_file(dep_filename, dep_content)
+        end)
+
+        teardown(function()
+            os.remove(dep_filename)
+        end)
+
+        it("imports types from a .d.pln file", function()
+            local module, errs = run_typechecker(util.render([[
+                local m: module = {}
+                local dep = require("__require_dep__")
+                local x: dep.Point = { x = 1, y = 2 }
+                return m
+            ]], {}))
+            assert.truthy(module, errs)
+        end)
+
+        it("imports typealias from a .d.pln file", function()
+            local module, errs = run_typechecker(util.render([[
+                local m: module = {}
+                local dep = require("__require_dep__")
+                local x: dep.MyInt = 42
+                return m
+            ]], {}))
+            assert.truthy(module, errs)
+        end)
+
+        it("imports value declarations from a .d.pln file", function()
+            local module, errs = run_typechecker(util.render([[
+                local m: module = {}
+                local dep = require("__require_dep__")
+                local x: integer = dep.add(1, 2)
+                return m
+            ]], {}))
+            assert.truthy(module, errs)
+        end)
+
+        it("rejects access to non-existent module field", function()
+            assert_error([[
+                local dep = require("__require_dep__")
+                local x = dep.nonexistent
+            ]], "module field 'nonexistent' does not exist")
+        end)
+
+        it("rejects access to non-existent module type", function()
+            assert_error([[
+                local dep = require("__require_dep__")
+                local x: dep.NonExistingType = nil
+            ]], "type 'dep.NonExistingType' is not declared")
+        end)
+    end)
+
+    describe("with invalid .d.pln files", function()
+
+        setup(function()
+            local dep_content = "" -- empty string as each test will write its own content
+            write_type_file(dep_filename, dep_content)
+        end)
+
+        teardown(function()
+            os.remove(dep_filename)
+        end)
+
+        it("reports parsing errors in .d.pln files", function()
+            local dep_content = [[
+                typealias MyInt = integer
+                a = 10
+            ]]
+            write_type_file(dep_filename, dep_content)
+            local errors = {
+                "could not load module '__require_dep__'",
+                "type annotation expected in type declaration file",
+                "unexpected '=' while trying to parse a type declaration"
+            }
+            assert_errors([[
+                local dep = require("__require_dep__")
+            ]], errors)
+        end)
+
+        it("reports type errors from invalid .d.pln files", function()
+            local dep_content = [[
+                typealias MyInt = int3ger
+            ]]
+            write_type_file(dep_filename, dep_content)
+            local errors = {
+                "could not load module '__require_dep__'",
+                "type 'int3ger' is not declared"
+            }
+            assert_errors([[
+                local dep = require("__require_dep__")
+            ]], errors)
+        end)
+    end)
+
+    it("reports error when .d.pln file does not exist", function()
+        local errors = {
+            "could not load module '__nonexistent_module__'",
+            "No such file or directory"
+        }
+        assert_errors([[
+            local dep = require("__nonexistent_module__")
+        ]], errors)
+    end)
+end)
+
+describe("Qualified types", function()
+
+    it("rejects undeclared module in qualified type", function()
+        assert_error([[
+            local x: undeclared_mod.Foo = 1
+        ]], "module 'undeclared_mod' is not declared")
+    end)
+
+    it("rejects non-module name in qualified type", function()
+        assert_error([[
+            local y = 10
+            local x: y.Foo = 1
+        ]], "'y' is not a module")
+    end)
+
+    it("rejects undeclared type in module", function()
+        -- Use the string module which is always available
+        assert_error([[
+            local x: string.Nonexistent = "hi"
+        ]], "type 'string.Nonexistent' is not declared")
     end)
 
 end)

--- a/spec/typechecker_spec.lua
+++ b/spec/typechecker_spec.lua
@@ -143,7 +143,7 @@ end)
 
 describe("Require", function()
 
-    it("forbids require calls inside function bodies", function()
+    it("forbids require calls as expressions", function()
         assert_error([[
             function m.f()
                 local x = require("foo")
@@ -153,10 +153,7 @@ describe("Require", function()
 
     it("forbids require calls as expressions", function()
         assert_error([[
-            local function foo(m: any) end
-            function m.f()
-                foo(require("bar"))
-            end
+            m.x = require("foo")
         ]], "calls to require are only allowed in toplevel declarations")
     end)
 

--- a/spec/typechecker_spec.lua
+++ b/spec/typechecker_spec.lua
@@ -165,6 +165,46 @@ describe("Require", function()
         ]], "require argument must be a string literal")
     end)
 
+    it("forbids shadowing require as local variable declaration", function()
+        assert_error([[
+            local require: integer
+        ]], "shadowing of 'require' is not allowed")
+    end)
+
+    it("forbids shadowing require as a local function", function()
+        assert_error([[
+            local function require()
+                local require: integer = 1
+            end
+        ]], "shadowing of 'require' is not allowed")
+    end)
+
+
+    it("forbids shadowing require as a function parameter", function()
+        assert_error([[
+            function m.f(require: integer): integer
+                return require
+            end
+        ]], "shadowing of 'require' is not allowed")
+    end)
+
+    it("forbids shadowing require as a for-loop variable", function()
+        assert_error([[
+            function m.f()
+                for require = 1, 10 do end
+            end
+        ]], "shadowing of 'require' is not allowed")
+    end)
+
+    -- TODO: this is breaking because we are not treating this case correctly
+    it("forbids assigning to require", function()
+        assert_error([[
+            local function f()
+                require = 10
+            end
+        ]], "assignment to 'require' is not allowed")
+    end)
+
     local dep_filename = "__require_dep__.d.pln"
 
     local function write_type_file(fname, content)

--- a/src/pallene/assignment_conversion.lua
+++ b/src/pallene/assignment_conversion.lua
@@ -390,7 +390,8 @@ function Converter:visit_stat(stat)
     elseif  tag == "ast.Stat.Break" then
         -- empty
     elseif  tag == "ast.Stat.Require" then
-        -- empty
+        -- Require statements only accepts string literals,
+        -- so there is no expression to visit.
     else
         tagged_union.error(tag)
     end

--- a/src/pallene/assignment_conversion.lua
+++ b/src/pallene/assignment_conversion.lua
@@ -389,6 +389,8 @@ function Converter:visit_stat(stat)
 
     elseif  tag == "ast.Stat.Break" then
         -- empty
+    elseif  tag == "ast.Stat.Require" then
+        -- empty
     else
         tagged_union.error(tag)
     end

--- a/src/pallene/ast.lua
+++ b/src/pallene/ast.lua
@@ -20,11 +20,12 @@ define_union("TypeFile", {
 })
 
 define_union("Type", {
-    Nil      = {"loc"},
-    Name     = {"loc", "name"},
-    Array    = {"loc", "subtype"},
-    Table    = {"loc", "fields"},
-    Function = {"loc", "arg_types", "ret_types"},
+    Nil           = {"loc"},
+    Name          = {"loc", "name"},
+    Array         = {"loc", "subtype"},
+    Table         = {"loc", "fields"},
+    Function      = {"loc", "arg_types", "ret_types"},
+    QualifiedName = {"loc", "module", "name"},
 })
 
 define_union("Toplevel", {

--- a/src/pallene/ast.lua
+++ b/src/pallene/ast.lua
@@ -32,6 +32,7 @@ define_union("Toplevel", {
     Stats     = {"loc", "stats"},
     Typealias = {"loc", "name", "type",},
     Record    = {"loc", "name", "field_decls"},
+    Require   = {"loc", "local_name", "module_name"},
 })
 
 define_union("Decl", {

--- a/src/pallene/ast.lua
+++ b/src/pallene/ast.lua
@@ -32,7 +32,7 @@ define_union("Toplevel", {
     Stats     = {"loc", "stats"},
     Typealias = {"loc", "name", "type",},
     Record    = {"loc", "name", "field_decls"},
-    Require   = {"loc", "local_name", "arg_module_name"},
+    Require   = {"loc", "local_name_decl", "module_name_exp"},
 })
 
 define_union("Decl", {

--- a/src/pallene/ast.lua
+++ b/src/pallene/ast.lua
@@ -32,6 +32,7 @@ define_union("Toplevel", {
     Stats     = {"loc", "stats"},
     Typealias = {"loc", "name", "type",},
     Record    = {"loc", "name", "field_decls"},
+    Require   = {"loc", "local_name", "arg_module_name"},
 })
 
 define_union("Decl", {
@@ -51,7 +52,6 @@ define_union("Stat", {
     Return    = {"loc", "exps"},
     Break     = {"loc"},
     Functions = {"loc", "declared_names", "funcs"}, -- For mutual recursion (see parser.lua)
-    Require   = {"loc", "local_name", "module_name"},
 })
 
 define_union("FuncStat", {

--- a/src/pallene/ast.lua
+++ b/src/pallene/ast.lua
@@ -32,7 +32,6 @@ define_union("Toplevel", {
     Stats     = {"loc", "stats"},
     Typealias = {"loc", "name", "type",},
     Record    = {"loc", "name", "field_decls"},
-    Require   = {"loc", "local_name", "module_name"},
 })
 
 define_union("Decl", {
@@ -52,6 +51,7 @@ define_union("Stat", {
     Return    = {"loc", "exps"},
     Break     = {"loc"},
     Functions = {"loc", "declared_names", "funcs"}, -- For mutual recursion (see parser.lua)
+    Require   = {"loc", "local_name", "module_name"},
 })
 
 define_union("FuncStat", {

--- a/src/pallene/driver.lua
+++ b/src/pallene/driver.lua
@@ -235,10 +235,9 @@ function driver.compile_type_file(path)
         return false, { err }
     end
 
-    local ast
-    ast, err = driver.compile_internal_d_pln(path, input)
+    local ast, errs = driver.compile_internal_d_pln(path, input)
     if not ast then
-        return false, { err }
+        return false, errs
     end
 
     return ast, {}

--- a/src/pallene/driver.lua
+++ b/src/pallene/driver.lua
@@ -207,7 +207,6 @@ function driver.compile_internal_d_pln(filename, input, stop_after)
 
     local function abort()
         if type(errs) == "string" then errs = { errs } end
-        table.insert(errs, "compilation aborted due to previous error")
         return false, errs
     end
 

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -1332,7 +1332,7 @@ function parser.parse_type_file(lexer)
     local p = Parser.new(lexer)
 
     local ok, ret = trycatch.pcall(function()
-        return p:TypeDeclarationFile()
+        return p:TypeDeclarationFile(lexer.file_name)
     end)
 
     -- Re-throw internal errors

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -286,6 +286,9 @@ function Parser:Program()
         table.insert(tls, tl)
 
         if tl._tag == "ast.Toplevel.Stats" then
+            -- This variable will always be decremented at the end of the loop.
+            -- It remaining 1 means that we are at a sequence of require statements.
+            local require_stmt_allowed = 1
             for i, stat in ipairs(tl.stats) do
                 if stat._tag == "ast.Stat.Assign" then
                     for _, var in ipairs(stat.vars) do
@@ -296,9 +299,16 @@ function Parser:Program()
                     end
                 elseif stat._tag == "ast.Stat.Decl" then
                     if has_require_exp(stat) then
-                        tl.stats[i] = self:convert_decl_to_require(stat)
+                        if require_stmt_allowed > 0 then
+                            tl.stats[i] = self:convert_decl_to_require(stat)
+                            require_stmt_allowed = require_stmt_allowed + 1
+                        else
+                            self:recoverable_syntax_error(stat.loc,
+                                "require statements must appear after the module declaration and before any other toplevel statements")
+                        end
                     end
                 end
+                require_stmt_allowed = require_stmt_allowed - 1
             end
 
             local last = tl.stats[#tl.stats]

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -219,6 +219,7 @@ local function has_require_exp(stat)
 end
 
 function Parser:convert_decl_to_require(stat)
+    assert(stat._tag == "ast.Stat.Decl")
     local decl = stat.decls[1]
     local exp  = stat.exps[1]
     if #stat.decls > 1 or #stat.exps > 1 then
@@ -256,10 +257,13 @@ function Parser:separate_requires_from_tl_stats(tl_stats)
     end
 
     for _, stat in ipairs(tl_stats.stats) do
-        if has_require_exp(stat) then
+        if stat._tag == "ast.Stat.Decl" and has_require_exp(stat) then
             commit_stats()
             local require_stmt = self:convert_decl_to_require(stat)
             table.insert(tls, require_stmt)
+        elseif stat._tag == "ast.Stat.Assign" and has_require_exp(stat) then
+            self:recoverable_syntax_error(stat.loc,
+                "calls to require are only allowed in toplevel declarations")
         else
             table.insert(stats_group, stat)
         end

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -200,6 +200,45 @@ local is_toplevel_first = Union({
     is_stat_first,
 })
 
+local function is_require_call(exp)
+    return exp._tag         == "ast.Exp.CallFunc" and
+           exp.exp._tag     == "ast.Exp.Var"      and
+           exp.exp.var._tag == "ast.Var.Name"     and
+           exp.exp.var.name == "require"
+end
+
+local function has_require_exp(stat)
+    local exps = stat.exps
+    if not exps then return false end
+    for _, exp in ipairs(exps) do
+        if is_require_call(exp) then
+            return true
+        end
+    end
+    return false
+end
+
+function Parser:convert_decl_to_require(stat)
+    local decl = stat.decls[1]
+    local exp  = stat.exps[1]
+    if #stat.decls > 1 or #stat.exps > 1 then
+        self:recoverable_syntax_error(stat.loc,
+            "cannot use a multiple-assignment in require statements")
+    end
+    assert(decl._tag == "ast.Decl.Decl")
+    if decl.type then
+        self:recoverable_syntax_error(decl.loc,
+            "type annotation is not allowed at require statements")
+    end
+    assert(is_require_call(exp))
+    if #exp.args ~= 1 then
+        self:recoverable_syntax_error(exp.loc,
+            "require() must be called with exactly one argument")
+    end
+    local module_name = exp.args[1]
+    return ast.Toplevel.Require(stat.loc, decl.name, module_name)
+end
+
 --
 -- Toplevel
 --
@@ -247,13 +286,17 @@ function Parser:Program()
         table.insert(tls, tl)
 
         if tl._tag == "ast.Toplevel.Stats" then
-            for _, stat in ipairs(tl.stats) do
+            for i, stat in ipairs(tl.stats) do
                 if stat._tag == "ast.Stat.Assign" then
                     for _, var in ipairs(stat.vars) do
                         if var._tag ~= "ast.Var.Dot" then
                             self:recoverable_syntax_error(var.loc,
                                 "toplevel assignments are only possible with module fields")
                         end
+                    end
+                elseif stat._tag == "ast.Stat.Decl" then
+                    if has_require_exp(stat) then
+                        tl.stats[i] = self:convert_decl_to_require(stat)
                     end
                 end
             end

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -356,7 +356,7 @@ function Parser:Program()
         start_loc, end_loc, modname, tls, self.type_regions)
 end
 
-function Parser:TypeDeclarationFile(modname)
+function Parser:TypeDeclarationFile(module_name)
 
     local start_loc = self.next.loc
 
@@ -386,7 +386,7 @@ function Parser:TypeDeclarationFile(modname)
     end
 
     return ast.TypeFile.TypeFile(
-        start_loc, modname, decls
+        start_loc, module_name, decls
     )
 end
 

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -236,7 +236,7 @@ function Parser:convert_decl_to_require(stat)
             "require() must be called with exactly one argument")
     end
     local module_name = exp.args[1]
-    return ast.Toplevel.Require(stat.loc, decl.name, module_name)
+    return ast.Stat.Require(stat.loc, decl.name, module_name)
 end
 
 --

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -284,7 +284,7 @@ function Parser:tls_emerge_requires(tls)
                 if sep_tl._tag == "ast.Toplevel.Require" then
                     if not require_allowed then
                         self:recoverable_syntax_error(sep_tl.loc,
-                            "require statements must appear before any other toplevel statements")
+                            "require statements must appear before any other toplevel statement")
                     end
                 else
                     require_allowed = false

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -235,8 +235,7 @@ function Parser:convert_decl_to_require(stat)
         self:recoverable_syntax_error(exp.loc,
             "require() must be called with exactly one argument")
     end
-    local arg_module_name = exp.args[1]
-    return ast.Toplevel.Require(stat.loc, decl.name, arg_module_name)
+    return ast.Toplevel.Require(stat.loc, decl, exp.args[1])
 end
 
 --

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -235,13 +235,70 @@ function Parser:convert_decl_to_require(stat)
         self:recoverable_syntax_error(exp.loc,
             "require() must be called with exactly one argument")
     end
-    local module_name = exp.args[1]
-    return ast.Stat.Require(stat.loc, decl.name, module_name)
+    local arg_module_name = exp.args[1]
+    return ast.Toplevel.Require(stat.loc, decl.name, arg_module_name)
 end
 
 --
 -- Toplevel
 --
+
+function Parser:separate_requires_from_tl_stats(tl_stats)
+    assert(tl_stats._tag == "ast.Toplevel.Stats")
+    local tls = {}
+    local stats_group = {}
+
+    local function commit_stats()
+        if #stats_group > 0 then
+            local stats_tl = ast.Toplevel.Stats(stats_group[1].loc, stats_group)
+            table.insert(tls, stats_tl)
+            stats_group = {}
+        end
+    end
+
+    for _, stat in ipairs(tl_stats.stats) do
+        if has_require_exp(stat) then
+            commit_stats()
+            local require_stmt = self:convert_decl_to_require(stat)
+            table.insert(tls, require_stmt)
+        else
+            table.insert(stats_group, stat)
+        end
+    end
+
+    commit_stats()
+
+    return tls
+end
+
+-- This function rebuilds the list of toplevel statements, bringing the require statements from the Stats toplevels
+-- into their own toplevels and ensuring that they appear before any other toplevel statements.
+function Parser:tls_emerge_requires(tls)
+    local result = {}
+    local require_allowed = true
+
+    for _, tl in ipairs(tls) do
+        if tl._tag == "ast.Toplevel.Stats" then
+            local separated_tls = self:separate_requires_from_tl_stats(tl)
+
+            for _, sep_tl in ipairs(separated_tls) do
+                if sep_tl._tag == "ast.Toplevel.Require" then
+                    if not require_allowed then
+                        self:recoverable_syntax_error(sep_tl.loc,
+                            "require statements must appear before any other toplevel statements")
+                    end
+                else
+                    require_allowed = false
+                end
+                table.insert(result, sep_tl)
+            end
+        else
+            table.insert(result, tl)
+            require_allowed = false
+        end
+    end
+    return result
+end
 
 function Parser:Program()
 
@@ -286,10 +343,7 @@ function Parser:Program()
         table.insert(tls, tl)
 
         if tl._tag == "ast.Toplevel.Stats" then
-            -- This variable will always be decremented at the end of the loop.
-            -- It remaining 1 means that we are at a sequence of require statements.
-            local require_stmt_allowed = 1
-            for i, stat in ipairs(tl.stats) do
+            for _, stat in ipairs(tl.stats) do
                 if stat._tag == "ast.Stat.Assign" then
                     for _, var in ipairs(stat.vars) do
                         if var._tag ~= "ast.Var.Dot" then
@@ -297,18 +351,7 @@ function Parser:Program()
                                 "toplevel assignments are only possible with module fields")
                         end
                     end
-                elseif stat._tag == "ast.Stat.Decl" then
-                    if has_require_exp(stat) then
-                        if require_stmt_allowed > 0 then
-                            tl.stats[i] = self:convert_decl_to_require(stat)
-                            require_stmt_allowed = require_stmt_allowed + 1
-                        else
-                            self:recoverable_syntax_error(stat.loc,
-                                "require statements must appear after the module declaration and before any other toplevel statements")
-                        end
-                    end
                 end
-                require_stmt_allowed = require_stmt_allowed - 1
             end
 
             local last = tl.stats[#tl.stats]
@@ -318,6 +361,8 @@ function Parser:Program()
             end
         end
     end
+
+    tls = self:tls_emerge_requires(tls)
 
     -- return <modname>
     if return_stat then

--- a/src/pallene/parser.lua
+++ b/src/pallene/parser.lua
@@ -441,7 +441,12 @@ function Parser:SimpleType()
 
     elseif self:peek("NAME") then
         local tok = self:advance()
-        return ast.Type.Name(tok.loc, tok.value)
+        local name = ast.Type.Name(tok.loc, tok.value)
+        if self:try(".") then
+            local id = self:e("NAME")
+            name = ast.Type.QualifiedName(tok.loc, name.name, id.value)
+        end
+        return name
 
     elseif self:peek("{") then
         local open = self:advance()

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -1058,7 +1058,7 @@ function ToIR:exp_to_value(bb, exp, is_recursive)
                 end
             elseif def._tag == "typechecker.Def.Import" then
                 -- TODO: Handle module imported fields
-                return ir.Value.Nil -- added just so the compiler don't break while this case is not implemented
+                error("not implemented")
             else
                 tagged_union.error(def._tag)
             end

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -324,7 +324,6 @@ function ToIR:export_local(bb, func_or_var, loc_id)
 end
 
 function ToIR:convert_toplevel(prog_ast)
-
     -- Create the $init function (it must have ID = 1)
     local id = ir.add_function(self.module, false, "$init", types.T.Function({}, {types.T.Table({})}))
     local init_func = self.module.functions[id]
@@ -365,6 +364,9 @@ function ToIR:convert_toplevel(prog_ast)
         elseif tag == "ast.Toplevel.Record" then
             local typ = tl_node._type
             self.rec_id_of_typ[typ] = ir.add_record_type(self.module, typ)
+        elseif tag == "ast.Toplevel.Require" then
+            -- TODO implement require
+            ir_error(tl_node.loc, "require statements are not implemented yet")
         else
             tagged_union.error(tag)
         end
@@ -897,9 +899,6 @@ function ToIR:convert_stat(bb, stat)
                 bb:append_cmd(ir.Cmd.InitUpvalues(func.loc, src_f, srcs, f_id))
             end
         end
-
-    elseif tag == "ast.Stat.Require" then
-        -- TODO: implement module requires
 
     else
         tagged_union.error(tag)

--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -898,6 +898,9 @@ function ToIR:convert_stat(bb, stat)
             end
         end
 
+    elseif tag == "ast.Stat.Require" then
+        -- TODO: implement module requires
+
     else
         tagged_union.error(tag)
     end
@@ -1054,6 +1057,9 @@ function ToIR:exp_to_value(bb, exp, is_recursive)
                     -- See https://github.com/pallene-lang/pallene/issues/337
                     error("not implemented")
                 end
+            elseif def._tag == "typechecker.Def.Import" then
+                -- TODO: Handle module imported fields
+                return ir.Value.Nil -- added just so the compiler don't break while this case is not implemented
             else
                 tagged_union.error(def._tag)
             end

--- a/src/pallene/type_extractor.lua
+++ b/src/pallene/type_extractor.lua
@@ -143,6 +143,8 @@ local function typeof_tls(node, typedefs)
                 error("Unknown statement type: " .. tostring(stat._tag))
             end
         end
+    elseif node._tag == "ast.Toplevel.Require" then
+        -- do nothing
     else
         error("Unknown node type: " .. tostring(node._tag))
     end

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -231,6 +231,25 @@ function Typechecker:from_ast_type(ast_typ)
             tagged_union.error(stag)
         end
 
+    elseif tag == "ast.Type.QualifiedName" then
+        local mod, name = ast_typ.module, ast_typ.name
+        local mod_sym = self.symbol_table:find_symbol(mod)
+
+        if not mod_sym then
+            type_error(ast_typ.loc, "module '%s' is not declared", mod)
+        elseif mod_sym._tag ~= "typechecker.Symbol.Module" then
+            type_error(ast_typ.loc, "'%s' is not a module", mod)
+        end
+
+        local type_sym = mod_sym.symbols[name]
+        if not type_sym then
+            type_error(ast_typ.loc, "type '%s.%s' is not declared", mod, name)
+        elseif type_sym._tag ~= "typechecker.Symbol.Type" then
+            type_error(ast_typ.loc, "'%s.%s' is not a type", mod, name)
+        else
+            return type_sym.typ
+        end
+
     elseif tag == "ast.Type.Array" then
         local subtype = self:from_ast_type(ast_typ.subtype)
         return types.T.Array(subtype)

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -232,23 +232,7 @@ function Typechecker:from_ast_type(ast_typ)
         end
 
     elseif tag == "ast.Type.QualifiedName" then
-        local mod, name = ast_typ.module, ast_typ.name
-        local mod_sym = self.symbol_table:find_symbol(mod)
-
-        if not mod_sym then
-            type_error(ast_typ.loc, "module '%s' is not declared", mod)
-        elseif mod_sym._tag ~= "typechecker.Symbol.Module" then
-            type_error(ast_typ.loc, "'%s' is not a module", mod)
-        end
-
-        local type_sym = mod_sym.symbols[name]
-        if not type_sym then
-            type_error(ast_typ.loc, "type '%s.%s' is not declared", mod, name)
-        elseif type_sym._tag ~= "typechecker.Symbol.Type" then
-            type_error(ast_typ.loc, "'%s.%s' is not a type", mod, name)
-        else
-            return type_sym.typ
-        end
+        return self:try_access_qualified_type(ast_typ)
 
     elseif tag == "ast.Type.Array" then
         local subtype = self:from_ast_type(ast_typ.subtype)
@@ -358,7 +342,7 @@ function Typechecker:check_type_file(prog_ast)
 
     assert(prog_ast._tag == "ast.TypeFile.TypeFile")
 
-    local modname = prog_ast.modname
+    local module_name = prog_ast.module_name
 
     -- 1) Add primitive types to the symbol table
     self:add_type_symbol("any",     types.T.Any)
@@ -372,7 +356,7 @@ function Typechecker:check_type_file(prog_ast)
         local tag = decl._tag
 
         if tag == "ast.TypeFile.Typealias" then
-            local typ = types.T.Alias(modname .. "." .. decl.name, self:from_ast_type(decl.type))
+            local typ = types.T.Alias(module_name .. "." .. decl.name, self:from_ast_type(decl.type))
             self:add_type_symbol(decl.name, typ)
             decl._type = typ
 
@@ -388,7 +372,7 @@ function Typechecker:check_type_file(prog_ast)
                 field_types[field_name] = self:from_ast_type(field_decl.type)
             end
 
-            local typ = types.T.Record(modname .. '.' .. decl.name, field_names, field_types, false)
+            local typ = types.T.Record(module_name .. '.' .. decl.name, field_names, field_types, false)
             self:add_type_symbol(decl.name, typ)
 
             decl._type = typ
@@ -737,7 +721,6 @@ function Typechecker:check_stat(stat, is_toplevel)
             else
                 symbols[decl.name] = typechecker.Symbol.Value(decl._type, typechecker.Def.Import(module_name, decl.name))
             end
-            print(string.format("Adding %s to the symbol table", localname .. '.' .. decl.name))
         end
         self:add_module_symbol(localname, false, symbols)
     else
@@ -745,6 +728,36 @@ function Typechecker:check_stat(stat, is_toplevel)
     end
 
     return stat
+end
+
+--
+-- If the given type named is of the form x.y.z, check for its existence and return the corresponding types.T
+--
+function Typechecker:try_access_qualified_type(qualified_type)
+    assert(qualified_type._tag == "ast.Type.QualifiedName")
+
+    local mod, type = qualified_type.module, qualified_type.name
+
+    local mod_sym = self.symbol_table:find_symbol(mod)
+    if not mod_sym then
+        type_error(qualified_type.loc, "module '%s' is not declared", mod)
+    elseif mod_sym._tag ~= "typechecker.Symbol.Module" then
+        type_error(qualified_type.loc, "'%s' is not a module", mod)
+    end
+
+    local type_sym = mod_sym.symbols[type]
+    if not type_sym then
+        type_error(qualified_type.loc, "type '%s.%s' is not declared", mod, type)
+    elseif type_sym._tag ~= "typechecker.Symbol.Type" then
+        type_error(qualified_type.loc, "'%s.%s' is not a type", mod, type)
+    end
+
+    local typ = type_sym.typ
+
+    assert(typ._tag == "types.T.Alias" or typ._tag == "types.T.Record",
+        "only types.T.Alias and types.T.Record can be qualified types")
+
+    return typ
 end
 
 --

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -266,7 +266,7 @@ end
 
 function Typechecker:load_required_ast(tl_require)
     assert(tl_require._tag == "ast.Toplevel.Require")
-    local require_arg = tl_require.arg_module_name
+    local require_arg = tl_require.module_name_exp
 
     if require_arg._tag ~= "ast.Exp.String" then
         type_error(require_arg.loc, "require argument must be a string literal")
@@ -295,7 +295,7 @@ function Typechecker:import_symbols(tl_require)
     local req_ast = self:load_required_ast(tl_require)
 
     local symbols = {}
-    local local_name, module_name = tl_require.local_name, tl_require.arg_module_name.value
+    local local_name, module_name = tl_require.local_name_decl.name, tl_require.module_name_exp.value
     for _, decl in ipairs(req_ast.decls) do
         local tag = decl._tag
         if tag == "ast.TypeFile.Typealias" or

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -200,6 +200,8 @@ function Typechecker:assert_exported_symbol_unused(name, loc)
         elseif sym._tag == "typechecker.Symbol.Module" then
             type_error(loc, "the module variable '%s' is being shadowed", name)
         end
+    elseif name == "require" then
+        type_error(loc, "shadowing of 'require' is not allowed")
     end
 end
 
@@ -847,7 +849,7 @@ function Typechecker:check_var(var)
         local sym = self.symbol_table:find_symbol(var.name)
         if not sym then
             if var.name == "require" then
-                type_error(var.loc, "calls to require are only allowed in toplevel declarations", var.name)
+                type_error(var.loc, "the use of 'require' is forbidden here", var.name)
             else
                 type_error(var.loc, "variable '%s' is not declared", var.name)
             end

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -161,6 +161,9 @@ end
 function Typechecker:add_value_symbol(name, typ, def)
     assert(type(name) == "string")
     assert(tagged_union.typename(typ._tag) == "types.T")
+    if name == "require" then
+        type_error(loc_of_def(def), "shadowing of 'require' is not allowed")
+    end
     return self.symbol_table:add_symbol(name, typechecker.Symbol.Value(typ, def))
 end
 
@@ -294,6 +297,9 @@ function Typechecker:import_symbols(tl_require)
 
     local symbols = {}
     local local_name, module_name = tl_require.local_name_decl.name, tl_require.module_name_exp.value
+    if local_name == "require" then
+        type_error(tl_require.local_name_decl.loc, "shadowing of 'require' is not allowed")
+    end
     for _, decl in ipairs(req_ast.decls) do
         local tag = decl._tag
         if tag == "ast.TypeFile.Typealias" or

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -264,6 +264,50 @@ function Typechecker:from_ast_type(ast_typ)
     end
 end
 
+function Typechecker:load_required_ast(tl_require)
+    assert(tl_require._tag == "ast.Toplevel.Require")
+    local require_arg = tl_require.arg_module_name
+
+    if require_arg._tag ~= "ast.Exp.String" then
+        type_error(require_arg.loc, "require argument must be a string literal")
+    end
+
+    local module_name = require_arg.value
+
+    local driver = require "pallene.driver"
+    local type_ast, _ = driver.parse_type_file(string.format("%s.d.pln", module_name))
+
+    -- TODO: Reporting error
+    if not type_ast then
+        local msg = string.format("file error:" .. require_arg.loc:format_error( "could not find module '%s'", module_name))
+        table.insert(self.errors, msg)
+        trycatch.error("file-error")
+    end
+
+    assert(type_ast._tag == "ast.TypeFile.TypeFile")
+
+    return type_ast
+end
+
+function Typechecker:import_symbols(tl_require)
+    local req_ast = self:load_required_ast(tl_require)
+
+    local symbols = {}
+    local local_name, module_name = tl_require.local_name, tl_require.arg_module_name.value
+    for _, decl in ipairs(req_ast.decls) do
+        local tag = decl._tag
+        if tag == "ast.TypeFile.Typealias" or
+            tag == "ast.TypeFile.Record"    then
+            symbols[decl.name] = typechecker.Symbol.Type(decl._type)
+        elseif tag == "ast.TypeFile.Decl" then
+            symbols[decl.name] = typechecker.Symbol.Value(decl._type, typechecker.Def.Import(module_name, decl.name))
+        else
+            tagged_union.error(tag)
+        end
+    end
+    self:add_module_symbol(local_name, false, symbols)
+end
+
 function Typechecker:check_program(prog_ast)
 
     assert(prog_ast._tag == "ast.Program.Program")
@@ -325,6 +369,9 @@ function Typechecker:check_program(prog_ast)
             self:add_type_symbol(tl_node.name, typ)
 
             tl_node._type = typ
+
+        elseif tag == "ast.Toplevel.Require" then
+            self:import_symbols(tl_node)
 
         else
             tagged_union.error(tag)
@@ -696,33 +743,6 @@ function Typechecker:check_stat(stat, is_toplevel)
             func.value = self:check_exp_verify(func.value, func._type, "toplevel function")
         end
 
-    elseif tag == "ast.Stat.Require" then
-        -- TODO: improve this section
-        local localname = stat.local_name
-        local require_arg = stat.module_name
-        if require_arg._tag ~= "ast.Exp.String" then
-            type_error(require_arg.loc, "require argument must be a string literal")
-        end
-        local module_name = require_arg.value
-
-        local driver = require "pallene.driver"
-        local type_ast, errs = driver.parse_type_file(string.format("%s.d.pln", module_name))
-
-        if not type_ast then
-            -- TODO this is not a type error. Need to change this
-            type_error(stat.loc, "could not find module '%s'", module_name)
-        end
-
-        local symbols = {}
-        for _, decl in ipairs(type_ast.decls) do
-            if decl._tag == "ast.Toplevel.Typealias" or
-                decl._tag == "ast.Toplevel.Record"    then
-                symbols[decl.name] = typechecker.Symbol.Type(decl._type)
-            else
-                symbols[decl.name] = typechecker.Symbol.Value(decl._type, typechecker.Def.Import(module_name, decl.name))
-            end
-        end
-        self:add_module_symbol(localname, false, symbols)
     else
         tagged_union.error(tag)
     end

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -136,7 +136,7 @@ define_union("Def", {
     Variable = { "decl" }, -- ast.Decl
     Function = { "func" }, -- ast.FuncStat
     Builtin  = { "id"   }, -- string
---  Import   = { ??? },
+    Import   = { "module", "field" }, -- string, string
 })
 
 local function loc_of_def(def)
@@ -711,9 +711,34 @@ function Typechecker:check_stat(stat, is_toplevel)
             func.value = self:check_exp_verify(func.value, func._type, "toplevel function")
         end
 
-    elseif tag == "ast.Toplevel.Require" then
-        -- ok
-        -- TODO: import the module and add its symbols to the symbol table
+    elseif tag == "ast.Stat.Require" then
+        -- TODO: improve this section
+        local localname = stat.local_name
+        local require_arg = stat.module_name
+        if require_arg._tag ~= "ast.Exp.String" then
+            type_error(require_arg.loc, "require argument must be a string literal")
+        end
+        local module_name = require_arg.value
+
+        local driver = require "pallene.driver"
+        local type_ast, errs = driver.parse_type_file(string.format("%s.d.pln", module_name))
+
+        if not type_ast then
+            -- TODO this is not a type error. Need to change this
+            type_error(stat.loc, "could not find module '%s'", module_name)
+        end
+
+        local symbols = {}
+        for _, decl in ipairs(type_ast.decls) do
+            if decl._tag == "ast.Toplevel.Typealias" or
+                decl._tag == "ast.Toplevel.Record"    then
+                symbols[decl.name] = typechecker.Symbol.Type(decl._type)
+            else
+                symbols[decl.name] = typechecker.Symbol.Value(decl._type, typechecker.Def.Import(module_name, decl.name))
+            end
+            print(string.format("Adding %s to the symbol table", localname .. '.' .. decl.name))
+        end
+        self:add_module_symbol(localname, false, symbols)
     else
         tagged_union.error(tag)
     end

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -358,6 +358,8 @@ function Typechecker:check_type_file(prog_ast)
 
     assert(prog_ast._tag == "ast.TypeFile.TypeFile")
 
+    local modname = prog_ast.modname
+
     -- 1) Add primitive types to the symbol table
     self:add_type_symbol("any",     types.T.Any)
     self:add_type_symbol("boolean", types.T.Boolean)
@@ -370,8 +372,7 @@ function Typechecker:check_type_file(prog_ast)
         local tag = decl._tag
 
         if tag == "ast.TypeFile.Typealias" then
-            local typ = types.T.Alias(decl.name, self:from_ast_type(decl.type))
-            -- self:export_type_symbol(decl.name, typ, decl.loc)
+            local typ = types.T.Alias(modname .. "." .. decl.name, self:from_ast_type(decl.type))
             self:add_type_symbol(decl.name, typ)
             decl._type = typ
 
@@ -387,7 +388,7 @@ function Typechecker:check_type_file(prog_ast)
                 field_types[field_name] = self:from_ast_type(field_decl.type)
             end
 
-            local typ = types.T.Record(decl.name, field_names, field_types, false)
+            local typ = types.T.Record(modname .. '.' .. decl.name, field_names, field_types, false)
             self:add_type_symbol(decl.name, typ)
 
             decl._type = typ

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -275,16 +275,18 @@ function Typechecker:load_required_ast(tl_require)
     local module_name = require_arg.value
 
     local driver = require "pallene.driver"
-    local type_ast, _ = driver.compile_type_file(string.format("%s.d.pln", module_name))
+    local type_ast, err = driver.compile_type_file(string.format("%s.d.pln", module_name))
 
-    -- TODO: Reporting error
     if not type_ast then
-        local msg = string.format("file error:" .. require_arg.loc:format_error( "could not find module '%s'", module_name))
-        table.insert(self.errors, msg)
-        trycatch.error("file-error")
+        local errs = table.concat(err, "\n")
+        util.abort("error: "
+            .. require_arg.loc:format_error("could not load module '%s'", module_name)
+            .. "\n"
+            .. errs
+        )
+    else
+        assert(type_ast._tag == "ast.TypeFile.TypeFile")
     end
-
-    assert(type_ast._tag == "ast.TypeFile.TypeFile")
 
     return type_ast
 end

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -275,7 +275,7 @@ function Typechecker:load_required_ast(tl_require)
     local module_name = require_arg.value
 
     local driver = require "pallene.driver"
-    local type_ast, _ = driver.parse_type_file(string.format("%s.d.pln", module_name))
+    local type_ast, _ = driver.compile_type_file(string.format("%s.d.pln", module_name))
 
     -- TODO: Reporting error
     if not type_ast then

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -711,6 +711,9 @@ function Typechecker:check_stat(stat, is_toplevel)
             func.value = self:check_exp_verify(func.value, func._type, "toplevel function")
         end
 
+    elseif tag == "ast.Toplevel.Require" then
+        -- ok
+        -- TODO: import the module and add its symbols to the symbol table
     else
         tagged_union.error(tag)
     end

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -781,7 +781,11 @@ function Typechecker:check_var(var)
     if     tag == "ast.Var.Name" then
         local sym = self.symbol_table:find_symbol(var.name)
         if not sym then
-            type_error(var.loc, "variable '%s' is not declared", var.name)
+            if var.name == "require" then
+                type_error(var.loc, "calls to require are only allowed in toplevel declarations", var.name)
+            else
+                type_error(var.loc, "variable '%s' is not declared", var.name)
+            end
         end
 
         local stag = sym._tag

--- a/src/pallene/typechecker.lua
+++ b/src/pallene/typechecker.lua
@@ -278,12 +278,10 @@ function Typechecker:load_required_ast(tl_require)
     local type_ast, err = driver.compile_type_file(string.format("%s.d.pln", module_name))
 
     if not type_ast then
-        local errs = table.concat(err, "\n")
-        util.abort("error: "
-            .. require_arg.loc:format_error("could not load module '%s'", module_name)
-            .. "\n"
-            .. errs
-        )
+        local msg = "error: " ..
+            require_arg.loc:format_error("could not load module '%s'", module_name)
+        table.insert(err, 1, msg)
+        trycatch.error("typechecker", table.concat(err, "\n"))
     else
         assert(type_ast._tag == "ast.TypeFile.TypeFile")
     end


### PR DESCRIPTION
This PR adds partial support for the `require` command in the compiler's frontend

Here is a non-exaustive list of changes:

AST (src/pallene/ast.lua)

### Parser and AST

 - Added `ast.Type.QualifiedName` for parsing imported types; [[1]](https://github.com/pallene-lang/pallene/pull/658/changes#:~:text=QualifiedName%20%3D%20%7B%22loc%22%2C%20%22module%22%2C%20%22name%22%7D%2C)
 - Added `ast.Toplevel.Require` for parsing `require()` statements; [[2]](https://github.com/pallene-lang/pallene/pull/658/changes#:~:text=Require%20%3D%20%7B%22loc%22%2C%20%22local%5Fname%5Fdecl%22%2C%20%22module%5Fname%5Fexp%22%7D%2C)
 - Added code identify `require()`s in regular `ast.Decl.Decl`s at the toplevel and convert them to `ast.Toplevel.Require`s; [[3]](https://github.com/pallene-lang/pallene/pull/658/changes#:~:text=local%20function%20is%5Frequire%5Fcall,end,-301)
 - Modified `Parser:SimpleType()` to parse qualified type names; [[4]](https://github.com/pallene-lang/pallene/pull/658/changes#:~:text=local%20name,name,-445)
 - Added constraints to `require()` usage -- they should only happen as a single variable declaration on the toplevel, before any other toplevel node (aside from the module declaration); [[5]](https://github.com/pallene-lang/pallene/pull/658/changes#diff-0a14cd680e1dedb2b17f72aaabcd2941e9d8673b7134039272e9b94ad8e8c424R224-R236) [[6]](https://github.com/pallene-lang/pallene/pull/658/changes#diff-0a14cd680e1dedb2b17f72aaabcd2941e9d8673b7134039272e9b94ad8e8c424R284-R287)

### Typechecker

 - Enabled `typechecker.Def.Import` with module and field fields; [[7]](https://github.com/pallene-lang/pallene/pull/658/changes#:~:text=Import%20%3D%20%7B%20%22module%22%2C%20%22field%22%20%7D%2C%20%2D%2D%20string%2C%20string)
 - Added `Typechecker:import_symbols()` and `Typechecker:load_require_ast` to load and compile  a `.d.pln` file up to typecheck phase and register imported types and values imported from it to the symbol table; [[8]](https://github.com/pallene-lang/pallene/pull/658/changes#:~:text=%2B-,function%20Typechecker,end,-310)
 - Added code to handle the new AST nodes aforementioned;
 - Added code to forbid `require()` usages as ordinary expressions; [[9]](https://github.com/pallene-lang/pallene/pull/658/changes#:~:text=if%20var%2Ename,var%2Ename%29);

### Driver

 - Removed the "compilation aborted" sentinel from `compile_internal_d_pln`'s `abort()` so errors in the type declaration file can be reported by te importing module; [[10]](https://github.com/pallene-lang/pallene/pull/658/changes#diff-dd1c837956bc7f1945fc9d7ffb37900f24edf914ea4c577e196d92d800265d09L210)

### IR

 - Added handlers for `ast.Toplevel.Require` and `typechecker.Def.Import`, although they issue errors as they're not implemented yet. [[11]](https://github.com/pallene-lang/pallene/pull/658/changes#diff-b7e15ec209b4a975b271666c15e5c787433e639a4fd5e953b41172b53baab263R367-R369) [[12]](https://github.com/pallene-lang/pallene/pull/658/changes#diff-b7e15ec209b4a975b271666c15e5c787433e639a4fd5e953b41172b53baab263R1059-R1061)