### PR TITLE
Handing uninit var during declare

### DIFF
--- a/spec/uninitialized_spec.lua
+++ b/spec/uninitialized_spec.lua
@@ -161,4 +161,32 @@ describe("Uninitialized variable analysis: ", function()
             return m
         ]], "variable 'x' is used before being initialized")
     end)
+
+    it("catches use of uninitialized variable in its own initialization", function()
+        assert_error([[
+            local m: module = {}
+            function m.foo(): integer
+                local x: integer
+                x = x + 1
+                return x
+            end
+            return m
+        ]], "variable 'x' is used before being initialized")
+    end)
+
+    it("catches use of uninitialized variable when assigned to an upvalue box", function()
+        assert_error([[
+            local m: module = {}
+            function m.foo(): integer
+                local x: integer
+                local function g()
+                    x = 1
+                end
+                local y: integer
+                x = y
+                return x
+            end
+            return m
+        ]], "variable 'y' is used before being initialized")
+    end)
 end)

--- a/src/pallene/uninitialized.lua
+++ b/src/pallene/uninitialized.lua
@@ -39,7 +39,7 @@ function uninitialized.verify_variables(module)
                     -- `SetField` instructions can count as initializers when the target is an
                     -- upvalue box. This is because upvalue boxes are allocated, but not initialized
                     -- upon declaration.
-                    if cmd._tag == "ir.Cmd.SetField" and cmd.rec_typ.is_upvalue_box then
+                    if cmd._tag == "ir.Cmd.SetField" and cmd.rec_typ.is_upvalue_box and src == cmd.src_rec then
                         flow.kill_value(gk, src.id)
                     end
                 end
@@ -63,18 +63,23 @@ function uninitialized.verify_variables(module)
             local uninit = sets_list[block_i]
             for cmd_i, cmd in ipairs(block.cmds) do
                 local loc = cmd.loc
-                flow.update_set(uninit, flow_info, block_i, cmd_i)
                 for _, src in ipairs(ir.get_srcs(cmd)) do
                     local v = src.id
                     if src._tag == "ir.Value.LocalVar" and uninit[v] then
-                        if not reported_variables[v] then
-                            reported_variables[v] = true
-                            local name = assert(func.vars[v].name)
-                            table.insert(errors, loc:format_error(
-                                "error: variable '%s' is used before being initialized", name))
+                        local is_upvalue_init = (cmd._tag == "ir.Cmd.SetField" and
+                                                 cmd.rec_typ.is_upvalue_box and
+                                                 src == cmd.src_rec)
+                        if not is_upvalue_init then
+                            if not reported_variables[v] then
+                                reported_variables[v] = true
+                                local name = assert(func.vars[v].name)
+                                table.insert(errors, loc:format_error(
+                                    "error: variable '%s' is used before being initialized", name))
+                            end
                         end
                     end
                 end
+                flow.update_set(uninit, flow_info, block_i, cmd_i)
             end
         end
 


### PR DESCRIPTION
# Fix undetected uninitialized variables in self-assignments and upvalues

Fixes #650

### Description
This PR addresses an issue where the Pallene compiler fails to detect when an uninitialized variable is used if the usage occurs within the same command that initializes it (e.g., `a = a + 1`). It also fixes a secondary bug where assigning an uninitialized variable to an upvalue box erroneously marks the *source* variable as initialized.

### Changes Made
- **[src/pallene/uninitialized.lua](cci:7://file:///home/suryansh/dev/GSOC/pallene/src/pallene/uninitialized.lua:0:0-0:0)**: 
  - Moved the `flow.update_set` call in `verify_variables` to occur *after* the command's sources are checked for being uninitialized. This ensures that a command's side effects (like initializing a variable) do not mask its own errors.
  - Updated the logic for `SetField` instructions when the target is an upvalue box. It now correctly ensures that only the record base (the upvalue box itself) is initialized, rather than suppressing errors for all source variables.
- **[spec/uninitialized_spec.lua](cci:7://file:///home/suryansh/dev/GSOC/pallene/spec/uninitialized_spec.lua:0:0-0:0)**: Added two new regression tests to verify that these specific uninitialized variable cases are correctly caught by the compiler.

### Test change
Run the command
```bash
export LUA_PATH="src/?.lua;;"
  lua5.4 repro_check.lua
```
<details>
<summary>repro_check.lua</summary>

```lua
local ir = require "pallene.ir"
local uninitialized = require "pallene.uninitialized"

-- Mock Location
local loc = {
    format_error = function(self, fmt, ...)
        return string.format(fmt, ...)
    end
}

-- Mock Type
local dummy_typ = { arg_types = {}, ret_types = { { _tag = "types.T.Integer" } } }

-- Create function f
local func = ir.Function(loc, "f", dummy_typ)
local a_id = ir.add_local(func, "a", { _tag = "types.T.Integer" })
func.ret_vars = { a_id }

-- Block 1: a = a + 1
local block = ir.BasicBlock()
table.insert(block.cmds, ir.Cmd.Binop(loc, a_id, "+", ir.Value.LocalVar(a_id), ir.Value.Integer(1)))
table.insert(func.blocks, block)

local module = ir.Module()
table.insert(module.functions, func)

print("Running uninitialized analysis on 'a = a + 1'...")
local ok, errs = uninitialized.verify_variables(module)

if ok then
    print("BUG: Analysis passed (should have failed)")
else
    print("SUCCESS: Analysis failed as expected:")
    for _, err in ipairs(errs) do
        print("  " .. err)
    end
end

-- Test case 3: Secondary bug - does assigning to upvalue box incorrectly initialize the source?
print("\nRunning uninitialized analysis on SetField(box, 'value', y) where y is uninit...")
local func3 = ir.Function(loc, "h", { arg_types = {}, ret_types = {} })
local x_box_id = ir.add_local(func3, "x_box", { is_upvalue_box = true })
local y_id = ir.add_local(func3, "y", { _tag = "types.T.Integer" })

local block3 = ir.BasicBlock()
-- x_box = NewRecord(...)
table.insert(block3.cmds, ir.Cmd.NewRecord(loc, { is_upvalue_box = true }, x_box_id))
-- SetField(x_box, "value", y)
table.insert(block3.cmds, ir.Cmd.SetField(loc, { is_upvalue_box = true }, ir.Value.LocalVar(x_box_id), "value", ir.Value.LocalVar(y_id)))
-- return y
table.insert(block3.cmds, ir.Cmd.Move(loc, ir.add_local(func3, "ret", { _tag = "types.T.Integer" }), ir.Value.LocalVar(y_id)))
table.insert(func3.blocks, block3)

local module3 = ir.Module()
table.insert(module3.functions, func3)

local ok3, errs3 = uninitialized.verify_variables(module3)
-- We expect an error for y used in SetField, and another error for y used in Move (return y).
-- BUT if the bug exists, y might be marked as initialized after SetField, and the second error won't show up.
-- Actually, the current code reports errors at EACH use if it's uninit.
-- Wait, reported_variables[v] = true prevents multiple reports.
-- So we should check if y is in the uninit set AFTER SetField.

-- Let's just see how many errors we get.
local found_y_error = false
if not ok3 then
    for _, err in ipairs(errs3) do
        if err:match("variable 'y'") then found_y_error = true end
        print("  " .. err)
    end
end

if not found_y_error then
    print("BUG: Variable 'y' was used uninitialized but no error was reported!")
else
    print("Variable 'y' correctly reported as uninitialized.")
end

-- Test case 2: Captured variable initialization (should NOT fail)
print("\nRunning uninitialized analysis on upvalue box initialization...")
local func2 = ir.Function(loc, "g", { arg_types = {}, ret_types = {} })
local x_box_id = ir.add_local(func2, "x_box", { is_upvalue_box = true })

local block2 = ir.BasicBlock()
-- x_box = NewRecord(...)
table.insert(block2.cmds, ir.Cmd.NewRecord(loc, { is_upvalue_box = true }, x_box_id))
-- SetField(x_box, "value", 10)
table.insert(block2.cmds, ir.Cmd.SetField(loc, { is_upvalue_box = true }, ir.Value.LocalVar(x_box_id), "value", ir.Value.Integer(10)))
table.insert(func2.blocks, block2)

local module2 = ir.Module()
table.insert(module2.functions, func2)

local ok2, errs2 = uninitialized.verify_variables(module2)
if ok2 then
    print("SUCCESS: Upvalue box initialization passed")
else
    print("FAILURE: Upvalue box initialization failed (false positive):")
    for _, err in ipairs(errs2) do
        print("  " .. err)
    end
end
```
</details>