### PR TITLE
Lua 5.5.0 initial fixes

### DIFF
--- a/pallene-dev-1.rockspec
+++ b/pallene-dev-1.rockspec
@@ -12,7 +12,7 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "lua == 5.4",
+   "lua >= 5.4, < 5.6",
    "lpeg >= 1.0",
    "argparse >= 0.7.0",
 }

--- a/src/pallene/C.lua
+++ b/src/pallene/C.lua
@@ -144,8 +144,9 @@ end
 function C.reformat(input)
     local out = {}
     local depth = 0
-    for line in input:gmatch("([^\n]*)") do
-        line = line:match("^%s*(.-)%s*$")
+    local line
+    for _line in input:gmatch("([^\n]*)") do
+        line = _line:match("^%s*(.-)%s*$")
 
         local nspaces
         if line:match("^#") then

--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -1369,7 +1369,10 @@ gen_cmd["SetTable"] = function(self, args)
             TValue valv; ${init_valv}
             static int cache = -1;
             TValue *slot = pallene_getstr($field_len, $tab, $key, &cache);
-            luaH_finishset(L, $tab, &keyv, slot, &valv);
+            int hres = luaH_pset($tab, &keyv, &valv);
+            if (hres != HOK)
+                luaH_finishset(L, $tab, s2v(L->top.p - 2),
+                                s2v(L->top.p - 1), hres);
     ]], {
         field_len = tostring(#field_name),
         tab = tab,

--- a/src/pallene/coder.lua
+++ b/src/pallene/coder.lua
@@ -1966,8 +1966,8 @@ function Coder:generate_luaopen_function()
     return (util.render([[
         int ${name}(lua_State *L)
         {
-            #if LUA_VERSION_RELEASE_NUM != 50407
-            #error "Lua version must be exactly 5.4.7"
+            #if LUA_VERSION_RELEASE_NUM != 50500
+            #error "Lua version must be exactly 5.0.0"
             #endif
             luaL_checkcoreversion(L);
 

--- a/src/pallene/pallenelib.lua
+++ b/src/pallene/pallenelib.lua
@@ -626,7 +626,13 @@ static TString *pallene_tostring(lua_State *L, const char* file, int line, TValu
             if (ttisinteger(&v)) {
                 len = lua_integer2str(buff, MAXNUMBER2STR, ivalue(&v));
             } else {
-                len = lua_number2str(buff, MAXNUMBER2STR, fltvalue(&v));
+                len = lua_number2strx(
+                        L,
+                        buff,
+                        MAXNUMBER2STR,
+                        "%" LUA_NUMBER_FRMLEN "a",
+                        fltvalue(&v))
+                    ;
                 if (buff[strspn(buff, "-0123456789")] == '\0') {  /* looks like an int? */
                   buff[len++] = lua_getlocaledecpoint();
                   buff[len++] = '0';  /* adds '.0' to result */

--- a/src/pallene/pallenelib.lua
+++ b/src/pallene/pallenelib.lua
@@ -464,7 +464,8 @@ static TValue *pallene_getstr(size_t len, Table *t, TString *key, int *cache)
     if (len <= LUAI_MAXSHORTLEN) {
         return pallene_getshortstr(t, key, cache);
     } else {
-        return cast(TValue *, luaH_getstr(t, key));
+        TValue idx;
+        return cast(TValue *, luaH_getstr(t, key, &idx));
     }
 }
 

--- a/src/pallene/pallenelib.lua
+++ b/src/pallene/pallenelib.lua
@@ -421,7 +421,7 @@ static void pallene_renormalize_array(
     const char* file,int line
 ){
     lua_Unsigned ui = (lua_Unsigned) i - 1;
-    if (l_unlikely(ui >= arr->alimit)) {
+    if (l_unlikely(ui >= arr->asize)) {
         pallene_grow_array(L, file, line, arr, ui);
     }
 }


### PR DESCRIPTION
Trivial test, i.e. by far **not** complete: 

```
$ pallenec --emit-lua examples/arithmetic/arithmetic.pln
$ $ cat examples/arithmetic/arithmetic.lua
-- Copyright (c) 2020, The Pallene Developers
-- Pallene is licensed under the MIT license.
-- Please refer to the LICENSE and AUTHORS files for details
-- SPDX-License-Identifier: MIT

local m = {}

function m.add(a, b)
    return (a) + (b)
end

function m.subtract(a, b)
    return (a) - (b)
end

return m
```