### PR TITLE
Remove unused to_ir.Var.GlobalVar constructor

### DIFF
--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -28,7 +28,6 @@ define_union("LHS", {
 define_union("Var", {
     LocalVar   = {"id"},
     Upvalue    = {"id"},
-    GlobalVar  = {"id"},
 })
 
 local BlockBuilder = util.Class()
@@ -1063,8 +1062,6 @@ function ToIR:exp_to_value(bb, exp, is_recursive)
                 return ir.Value.LocalVar(var_info.id)
             elseif var_info._tag == "to_ir.Var.Upvalue" then
                 return ir.Value.Upvalue(var_info.id)
-            elseif var_info._tag == "to_ir.Var.GlobalVar" then
-                -- Fallthrough to default
             else
                 tagged_union.error(var_info._tag)
             end
@@ -1311,8 +1308,6 @@ function ToIR:exp_to_assignment(bb, dst, exp)
 
                 if var_info._tag == "to_ir.Var.LocalVar" or var_info._tag == "to_ir.Var.Upvalue" then
                     use_exp_to_value = true
-                elseif var_info._tag == "to_ir.Var.GlobalVar" then
-                    bb:append_cmd(ir.Cmd.GetGlobal(loc, dst, var_info.id))
                 else
                     tagged_union.error(var_info._tag)
                 end


### PR DESCRIPTION
## Summary

Removes the `to_ir.Var.GlobalVar` constructor from the `to_ir.Var` union and the two `elseif var_info._tag == "to_ir.Var.GlobalVar"` arms in `to_ir.lua` that referenced it. Per issue #662 these are residual after the rest of the global-handling rewrite.

## Why this matters

Issue #662 says `to_ir.Var.GlobalVar` is residual code. Confirmed by reading the function that produces `to_ir.Var` values:

`ToIR:resolve_variable` (`src/pallene/to_ir.lua:237`) only ever constructs `to_ir.Var.LocalVar` (line 255) inside its initial loop, then optionally promotes that value to `to_ir.Var.Upvalue` (line 288) when the declaration is captured by an enclosing function. There is no code path that constructs `to_ir.Var.GlobalVar`. The function asserts `var` is set, so it always returns either `LocalVar` or `Upvalue`.

That means the two `elseif var_info._tag == "to_ir.Var.GlobalVar"` arms in `exp_to_value` (line 1066) and `exp_to_assignment` (line 1314) are unreachable. The first arm contains only a `-- Fallthrough to default` comment; the second arm contains `bb:append_cmd(ir.Cmd.GetGlobal(loc, dst, var_info.id))` which can never execute. The `else` branch with `tagged_union.error(var_info._tag)` still catches any future tag the compiler might add.

## Changes

`src/pallene/to_ir.lua`: 5 lines removed across 3 spots.

- Line 31: `GlobalVar = {"id"},` removed from the `define_union("Var", { ... })` block.
- Lines 1066-1067 in `exp_to_value`: drop the `elseif ... GlobalVar` arm whose body is just a comment.
- Lines 1314-1315 in `exp_to_assignment`: drop the `elseif ... GlobalVar` arm whose `bb:append_cmd(ir.Cmd.GetGlobal(...))` body is unreachable.

The two `else` branches that follow each removed `elseif` continue to call `tagged_union.error(var_info._tag)`, so any new variant would still be caught loudly at runtime.

## Testing

After the change, `grep -rn 'GlobalVar' src/pallene/` returns no matches.

I do not have a Lua / busted toolchain in this environment, so I did not run the test suite locally. The change is mechanical removal of dead code; no logic flow is altered.

Closes #662
