### PR TITLE
Remove unused GlobalVar handling from to_ir

### DIFF
--- a/src/pallene/to_ir.lua
+++ b/src/pallene/to_ir.lua
@@ -28,7 +28,6 @@ define_union("LHS", {
 define_union("Var", {
     LocalVar   = {"id"},
     Upvalue    = {"id"},
-    GlobalVar  = {"id"},
 })
 
 local BlockBuilder = util.Class()
@@ -1068,8 +1067,6 @@ function ToIR:exp_to_value(bb, exp, is_recursive)
                 return ir.Value.LocalVar(var_info.id)
             elseif var_info._tag == "to_ir.Var.Upvalue" then
                 return ir.Value.Upvalue(var_info.id)
-            elseif var_info._tag == "to_ir.Var.GlobalVar" then
-                -- Fallthrough to default
             else
                 tagged_union.error(var_info._tag)
             end
@@ -1316,8 +1313,6 @@ function ToIR:exp_to_assignment(bb, dst, exp)
 
                 if var_info._tag == "to_ir.Var.LocalVar" or var_info._tag == "to_ir.Var.Upvalue" then
                     use_exp_to_value = true
-                elseif var_info._tag == "to_ir.Var.GlobalVar" then
-                    bb:append_cmd(ir.Cmd.GetGlobal(loc, dst, var_info.id))
                 else
                     tagged_union.error(var_info._tag)
                 end


### PR DESCRIPTION
This PR , removes the unused GlobalVar handling from src/pallene/to_ir.lua
The changes I have done here are :
Removing the unused GlobVar variant from Var union then removing the two unreachable to_ir.Var.GlobalVar branches and
removing the associated 'GetGlobal' emission path.

From what I understood, these code paths are no longer referenced anywhere , so this change is basically a cleanup which doesn't affect the compiler behaviour.
This PR closes the issue #662.
I'd be happy to get a feedback or make any further changes if needed.
Thanks for your time.
